### PR TITLE
Enable canary releases

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   build-and-release:
     name: Build and release canary
-    if: false
     uses: ./.github/workflows/release.yml
     secrets: inherit
     with:


### PR DESCRIPTION
## Motivation

The canary release workflow was disabled when initially creating this repository. Now that we are public, we can proceed with testing the workflow.

## Changes

Enabled the canary release workflow

## Checklist

- [x] Existing or new tests cover this change
