### PR TITLE
Fix plugin forwards and backwards compatibility

### DIFF
--- a/packages/core/core/src/loadAtlaspackPlugin.js
+++ b/packages/core/core/src/loadAtlaspackPlugin.js
@@ -24,7 +24,7 @@ import {type ProjectPath, toProjectPath} from './projectPath';
 import {version as ATLASPACK_VERSION} from '../package.json';
 
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
-const CONFIG = Symbol.for('atlaspack-plugin-config');
+const CONFIG = Symbol.for('parcel-plugin-config');
 
 export default async function loadPlugin<T>(
   pluginName: PackageName,

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -6386,7 +6386,7 @@ describe.v2('cache', function () {
           import {Bundler} from '@atlaspack/plugin'
           import DefaultBundler from '@atlaspack/bundler-default'
 
-          const CONFIG = Symbol.for('atlaspack-plugin-config');
+          const CONFIG = Symbol.for('parcel-plugin-config');
 
           export default new Bundler({
             loadConfig({config, options}) {

--- a/packages/core/integration-tests/test/incremental-bundling.js
+++ b/packages/core/integration-tests/test/incremental-bundling.js
@@ -16,7 +16,7 @@ import {NodePackageManager} from '@atlaspack/package-manager';
 
 import {type Asset} from '@atlaspack/types';
 
-const CONFIG = Symbol.for('atlaspack-plugin-config');
+const CONFIG = Symbol.for('parcel-plugin-config');
 let packageManager = new NodePackageManager(inputFS, '/');
 
 describe.v2('incremental bundling', function () {

--- a/packages/core/integration-tests/test/integration/incremental-bundling/node_modules/atlaspack-bundler-test/index.js
+++ b/packages/core/integration-tests/test/integration/incremental-bundling/node_modules/atlaspack-bundler-test/index.js
@@ -1,5 +1,5 @@
 // Spying on the Bundler, it did not like the imports
-let CONFIG = Symbol.for('atlaspack-plugin-config');
+let CONFIG = Symbol.for('parcel-plugin-config');
 
 class Bundler {
   constructor(opts) {

--- a/packages/core/plugin/src/PluginAPI.js
+++ b/packages/core/plugin/src/PluginAPI.js
@@ -13,6 +13,8 @@ import type {
   Validator as ValidatorOpts,
 } from '@atlaspack/types';
 
+// This uses the `parcel-plugin-config` symbol so it's backwards compatible with
+// parcel plugins.
 const CONFIG = Symbol.for('parcel-plugin-config');
 
 export class Transformer {

--- a/packages/core/plugin/src/PluginAPI.js
+++ b/packages/core/plugin/src/PluginAPI.js
@@ -13,7 +13,7 @@ import type {
   Validator as ValidatorOpts,
 } from '@atlaspack/types';
 
-const CONFIG = Symbol.for('atlaspack-plugin-config');
+const CONFIG = Symbol.for('parcel-plugin-config');
 
 export class Transformer {
   constructor<T>(opts: TransformerOpts<T>) {


### PR DESCRIPTION
Use the parcel plugin config symbol. This lets parcel plugins work with this tool and will allow all plugins from this tool to work with parcel.

In the future the atlaspack plugins can skip this symbol and just pass around objects that implement an interface. Adding the symbol into the plugin would be a compatibility layer.

## Motivation

Fix parcel plugin compatibility

* It'd be possible to handle both atlaspack and parcel symbols here, but that will mean plugins declared with `@atlaspack/plugin` will not work with parcel