### PR TITLE
Prevent watcher from crashing on first run

### DIFF
--- a/packages/utils/atlaspack-watcher-watchman-js/src/wrapper.js
+++ b/packages/utils/atlaspack-watcher-watchman-js/src/wrapper.js
@@ -100,6 +100,7 @@ export class AtlaspackWatcherWatchmanJS implements Watcher {
     await this.init(dir);
 
     const response = await this.commandAsync(['clock', dir]);
+    fs.mkdirSync(path.dirname(snapshot), {recursive: true});
     fs.writeFileSync(snapshot, response.clock, {
       encoding: 'utf-8',
     });


### PR DESCRIPTION
It's possible that the node.js watcher runs before the cache directory has been created.

Because of this we should create the cache directory before writing the snapshot file.
