### PR TITLE
Use yarn registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,7 +222,8 @@ jobs:
           path: debug-symbols/**
       - name: Debug
         run: ls -l packages/*/*/*.node
-      - run: echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Npm
+        run: |
+          npm config set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
+          npm config set registry https://registry.npmjs.org/
       - run: ${{ inputs.release-command }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.yarnpkg.com


### PR DESCRIPTION
## Motivation

It is quite common for the Atlassian registry to be committed into the yarn lockfile instead of the yarn registry. This will result in failing installs for anyone outside of Atlassian.

## Changes

Add an `.npmrc` file that specifies the yarn registry so it is always used. Once yarn is upgraded to v2+, we can replace `.npmrc` with a `yarnrc.yml` config file.

## Checklist

- [x] Existing or new tests cover this change
