### PR TITLE
Add atlaspack migration package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ yarn-debug.log*
 yarn-error.log*
 *.log
 *.min.js
+*.tsbuildinfo

--- a/packages/migrations/parcel-to-atlaspack/README.md
+++ b/packages/migrations/parcel-to-atlaspack/README.md
@@ -1,0 +1,34 @@
+# @atlaspack/parcel-to-atlaspack
+
+This package exposes a CLI that can be used to migrate a Parcel application to Atlaspack
+
+## Installation
+
+```sh
+npm install -g @atlaspack/parcel-to-atlaspack
+```
+
+## Usage
+
+```sh
+parcel-to-atlaspack
+parcel-to-atlaspack --dry-run
+parcel-to-atlaspack --help
+```
+
+## Features
+
+This CLI supports the following features:
+
+- Replace parcel dependencies with atlaspack in `package.json`
+- Rename `.parcelrc` files to `.atlaspackrc`
+- Update `@parcel/` plugin references to `@atlaspack` in both `.atlaspackrc` and `package.json`
+- Update `package.json#engines` to reference atlaspack instead of parcel
+
+## Development Workflow
+
+```sh
+yarn workspace @atlaspack/parcel-to-atlaspack start
+yarn workspace @atlaspack/parcel-to-atlaspack start --dry-run
+yarn workspace @atlaspack/parcel-to-atlaspack start --help
+```

--- a/packages/migrations/parcel-to-atlaspack/package.json
+++ b/packages/migrations/parcel-to-atlaspack/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@atlaspack/parcel-to-atlaspack",
+  "version": "2.12.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/atlaspack.git"
+  },
+  "license": "MIT",
+  "main": "dist/cli.js",
+  "bin": {
+    "parcel-to-atlaspack": "dist/bin.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "prepack": "tsc --project src/tsconfig.json && chmod +x dist/bin.js",
+    "start": "ts-node src/bin.ts"
+  },
+  "dependencies": {
+    "chalk": "^5.3.0",
+    "commander": "^7.0.0",
+    "fdir": "^6.2.0",
+    "jest-diff": "^29.7.0",
+    "semver": "^7.6.3"
+  },
+  "devDependencies": {
+    "ts-node": "^10.9.2",
+    "typescript": "^5.5.4"
+  },
+  "engines": {
+    "node": ">= 16.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/migrations/parcel-to-atlaspack/src/bin.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/bin.ts
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+import {run} from './cli';
+
+run().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/packages/migrations/parcel-to-atlaspack/src/cli.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/cli.ts
@@ -1,0 +1,58 @@
+import {Command} from 'commander';
+
+import packageJson from '../package.json';
+
+import {migratePackageJson} from './migrations/migrate-package-json';
+import {migrateParcelRc} from './migrations/migrate-parcelrc';
+
+export async function run() {
+  const program = new Command();
+
+  program
+    .name(packageJson.name)
+    .description('Migrate from Parcel to Atlaspack')
+    .option(
+      '--cwd <cwd>',
+      'The current working directory that the script will run the migration on',
+      process.cwd(),
+    )
+    .option(
+      '--dry-run',
+      'Report the changes that will be made instead of making them',
+    )
+    .option(
+      '--skip-dependencies',
+      'Skip migrating the parcel dependencies to atlaspack',
+    )
+    .option(
+      '--skip-engines',
+      'Skip migrating the parcel key in package.json#engines',
+    )
+    .option(
+      '--skip-parcelrc',
+      'Skip migrating the .parcelrc file to .atlaspackrc',
+    )
+    .option(
+      '--tag <tag>',
+      'The tag used to search the npm registry for Atlaspack packages',
+      'canary',
+    )
+    .version(packageJson.version);
+
+  program.parse();
+
+  const {
+    cwd,
+    dryRun,
+    skipDependencies,
+    skipEngines,
+    skipParcelrc: skipParcelRc,
+    tag,
+  } = program.opts();
+
+  // TODO Node API / types, parcel exe in scripts, etc
+  await Promise.all([
+    migratePackageJson({cwd, dryRun, skipDependencies, skipEngines, tag}),
+    !skipParcelRc && migrateParcelRc({cwd, dryRun}),
+  ]);
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/diff.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/diff.ts
@@ -1,0 +1,16 @@
+import {diff as jestDiff} from 'jest-diff';
+
+export function diff(
+  chalk: any,
+  original: string,
+  modified: string,
+): ReturnType<typeof jestDiff> {
+  return jestDiff(original, modified, {
+    aAnnotation: 'Original',
+    aColor: chalk.red,
+    bAnnotation: 'Modified',
+    bColor: chalk.green,
+    expand: false,
+    omitAnnotationLines: true,
+  });
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/migrate-package-json.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/migrate-package-json.ts
@@ -1,0 +1,86 @@
+import {readFile, writeFile} from 'node:fs/promises';
+import {basename, relative} from 'node:path';
+
+import {fdir} from 'fdir';
+
+import {diff} from './diff';
+import {migrateConfigFields} from './package-json/migrate-config-fields';
+import {migrateDependencies} from './package-json/migrate-dependencies';
+import {migrateEnginesField} from './package-json/migrate-engines-field';
+
+export type MigratePackageJsonOptions = {
+  cwd: string;
+  dryRun: string;
+  skipDependencies: boolean;
+  skipEngines: boolean;
+  tag: string;
+};
+
+// TODO Update dependencies
+export async function migratePackageJson({
+  cwd,
+  dryRun,
+  skipDependencies,
+  skipEngines,
+  tag,
+}: MigratePackageJsonOptions) {
+  const {default: chalk} = await import('chalk');
+
+  console.log(chalk.blue('[INFO]'), 'Searching for package.json files');
+
+  const packageJsonPaths = await new fdir()
+    .withFullPaths()
+    .exclude(dir => dir.startsWith('node_modules'))
+    .filter((path: string) => basename(path) === 'package.json')
+    .crawl(cwd)
+    .withPromise();
+
+  const modifiedFiles = [];
+
+  await Promise.all(
+    packageJsonPaths.map(async packageJsonPath => {
+      const rawPackageJson = await readFile(packageJsonPath, 'utf8');
+      if (!rawPackageJson.includes('parcel')) {
+        return;
+      }
+
+      const packageJson = JSON.parse(rawPackageJson);
+
+      const didChange = [
+        !skipEngines && migrateEnginesField(packageJson),
+        migrateConfigFields(packageJson),
+        !skipDependencies && migrateDependencies(packageJson, tag),
+      ].includes(true);
+
+      if (!didChange) {
+        return;
+      }
+
+      const {space = 2} =
+        rawPackageJson.match(/^\s*{.*\n(?<space>\s*)"/)?.groups ?? {};
+
+      const migratedPackageJson =
+        JSON.stringify(packageJson, null, space) + '\n';
+
+      if (dryRun) {
+        console.log(
+          chalk.blue('[INFO]'),
+          `Updated ${relative(cwd, packageJsonPath)}\n${diff(
+            chalk,
+            rawPackageJson,
+            migratedPackageJson,
+          )}`,
+        );
+      } else {
+        await writeFile(packageJsonPath, migratedPackageJson);
+      }
+
+      modifiedFiles.push(packageJsonPath);
+    }),
+  );
+
+  console.log(
+    chalk.blue('[INFO]'),
+    `Migrated ${modifiedFiles.length} package.json files`,
+  );
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/migrate-parcelrc.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/migrate-parcelrc.ts
@@ -1,0 +1,65 @@
+import {readFile, rename, writeFile} from 'node:fs/promises';
+import {basename, dirname, join, relative} from 'node:path';
+
+import {fdir} from 'fdir';
+
+import {diff} from './diff';
+
+export type MigrateParcelRcOptions = {
+  cwd: string;
+  dryRun: string;
+};
+
+// TODO: Support extended config defined in index.json?
+export async function migrateParcelRc({cwd, dryRun}: MigrateParcelRcOptions) {
+  const {default: chalk} = await import('chalk');
+
+  console.log(chalk.blue('[INFO]'), 'Searching for .parcelrc files');
+
+  const parcelrcPaths = await new fdir()
+    .withFullPaths()
+    .exclude(dir => dir.startsWith('node_modules'))
+    .filter((path: string) => basename(path).startsWith('.parcelrc'))
+    .crawl(cwd)
+    .withPromise();
+
+  const modifiedFiles = [];
+
+  await Promise.all(
+    parcelrcPaths.map(async parcelrcPath => {
+      const parcelrc = await readFile(parcelrcPath, 'utf8');
+      const atlaspckrc = parcelrc.replace(/@parcel\//g, '@atlaspack/');
+      if (atlaspckrc !== parcelrc) {
+        if (dryRun) {
+          console.log(
+            chalk.blue('[INFO]'),
+            `Updated ${relative(cwd, parcelrcPath)}\n${diff(
+              chalk,
+              parcelrc,
+              atlaspckrc,
+            )}`,
+          );
+        } else {
+          await writeFile(parcelrcPath, atlaspckrc);
+        }
+      }
+
+      const atlaspackrcPath = join(dirname(parcelrcPath), '.atlaspackrc');
+      if (dryRun) {
+        console.log(
+          chalk.blue('[INFO]'),
+          `Renamed ${relative(cwd, parcelrcPath)}`,
+        );
+      } else {
+        await rename(parcelrcPath, atlaspackrcPath);
+      }
+
+      modifiedFiles.push(parcelrcPath);
+    }),
+  );
+
+  console.log(
+    chalk.blue('[INFO]'),
+    `Migrated ${modifiedFiles.length} .parcelrc files`,
+  );
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/migrate-config-fields.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/migrate-config-fields.ts
@@ -1,0 +1,15 @@
+// TODO Preserve order?
+export function migrateConfigFields(packageJson: any): boolean {
+  let didConfigChange = false;
+
+  for (const field of Object.keys(packageJson).filter(key =>
+    key.startsWith('@parcel/'),
+  )) {
+    packageJson[`@atlaspack/${field.replace('@parcel/', '')}`] =
+      packageJson[field];
+    delete packageJson[field];
+    didConfigChange = true;
+  }
+
+  return didConfigChange;
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/migrate-dependencies.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/migrate-dependencies.ts
@@ -1,0 +1,96 @@
+import {spawnSync as spawn} from 'child_process';
+
+import {minVersion} from 'semver';
+
+import {sortPackageJsonField} from './sort-package-json-field';
+
+const versions = new Map<string, string>();
+
+function isValidRange(range: string): boolean {
+  try {
+    return !!minVersion(range);
+  } catch (err) {
+    return false;
+  }
+}
+
+function getAtlaspackPackageName(parcelPackageName: string): string {
+  switch (parcelPackageName) {
+    case 'parcel':
+      return '@atlaspack/cli';
+    default:
+      return `@atlaspack/${parcelPackageName.replace('@parcel/', '')}`;
+  }
+}
+
+function getVersion(name: string, range: string, tag: string): string {
+  let version = versions.get(name);
+  if (version) {
+    return version;
+  }
+
+  // If the range is invalid, then just use it as is
+  if (!isValidRange(range)) {
+    return range;
+  }
+
+  const {status, stdout} = spawn(
+    'npm',
+    ['show', '--loglevel', 'error', `${name}@${tag}`, 'version'],
+    {
+      stdio: ['pipe', 'pipe', 'inherit'],
+    },
+  );
+
+  if (status) {
+    throw new Error(`Failed to retrieve canary version for ${name}`);
+  }
+
+  version = `^${stdout.toString().trim()}`;
+  versions.set(name, version);
+  return version;
+}
+
+export function migrateDependencies(packageJson: any, tag: string): boolean {
+  let didDependenciesChange = false;
+  const skipPackages = new Set([
+    '@parcel/hash',
+    '@parcel/source-map',
+    '@parcel/watcher',
+  ]);
+
+  for (const field of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'resolutions',
+  ]) {
+    if (!packageJson[field]) {
+      continue;
+    }
+
+    let didDependencyFieldChange = false;
+    for (const key of Object.keys(packageJson[field])) {
+      const isParcelPackage = key === 'parcel' || key.startsWith('@parcel/');
+      if (!isParcelPackage || skipPackages.has(key)) {
+        continue;
+      }
+
+      const packageName = getAtlaspackPackageName(key);
+      const version = packageJson[field][key];
+      const nextVersion = getVersion(packageName, version, tag);
+      if (version !== nextVersion) {
+        packageJson[field][packageName] = nextVersion;
+        delete packageJson[field][key];
+        didDependencyFieldChange = true;
+      }
+    }
+
+    if (didDependencyFieldChange) {
+      sortPackageJsonField(packageJson, field);
+      didDependenciesChange = true;
+    }
+  }
+
+  return didDependenciesChange;
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/migrate-engines-field.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/migrate-engines-field.ts
@@ -1,0 +1,14 @@
+import {sortPackageJsonField} from './sort-package-json-field';
+
+export function migrateEnginesField(packageJson: any): boolean {
+  if (!packageJson.engines?.parcel) {
+    return false;
+  }
+
+  const version = packageJson.engines.parcel;
+  delete packageJson.engines.parcel;
+  packageJson.engines.atlaspack = version;
+
+  sortPackageJsonField(packageJson, 'engines');
+  return true;
+}

--- a/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/sort-package-json-field.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/package-json/sort-package-json-field.ts
@@ -1,0 +1,7 @@
+export function sortPackageJsonField(packageJson: any, field: string) {
+  const value = {...packageJson[field]};
+  packageJson[field] = {};
+  for (const key of Object.keys(value).sort()) {
+    packageJson[field][key] = value[key];
+  }
+}

--- a/packages/migrations/parcel-to-atlaspack/src/tsconfig.json
+++ b/packages/migrations/parcel-to-atlaspack/src/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "NodeNext",
+    "outDir": "../dist",
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "es2020"
+  },
+  "references": [{"path": "../"}]
+}

--- a/packages/migrations/parcel-to-atlaspack/tsconfig.json
+++ b/packages/migrations/parcel-to-atlaspack/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "composite": true
+  },
+  "files": ["package.json"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1322,6 +1322,13 @@
     style-mod "^4.0.0"
     w3c-keyname "^2.2.4"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@esbuild/aix-ppc64@0.23.1":
   version "0.23.1"
   resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz#51299374de171dbd80bb7d838e1cfce9af36f353"
@@ -1525,7 +1532,7 @@
   resolved "https://registry.yarnpkg.com/@isaacs/string-locale-compare/-/string-locale-compare-1.1.0.tgz#291c227e93fd407a96ecd59879a35809120e432b"
   integrity sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ==
 
-"@jest/schemas@^29.4.3":
+"@jest/schemas@^29.4.3", "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
   integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
@@ -1554,6 +1561,11 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
+
 "@jridgewell/set-array@^1.0.1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/set-array/-/set-array-1.1.2.tgz#7c6cf998d6d20b914c0a55a91ae928ff25965e72"
@@ -1571,6 +1583,14 @@
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.17", "@jridgewell/trace-mapping@^0.3.9":
   version "0.3.17"
@@ -2642,6 +2662,26 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+
 "@tufjs/canonical-json@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@tufjs/canonical-json/-/canonical-json-1.0.0.tgz#eade9fd1f537993bc1f0949f3aea276ecc4fab31"
@@ -3089,10 +3129,22 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.3.tgz#9caeac29eefaa0c41e3d4c65137de4d6f34df43e"
+  integrity sha512-MxXdReSRhGO7VlFe1bRG/oI7/mdLV9B9JJT0N8vZOhF7gFRR5l3M8W9G8JxmKV+JC5mGqJ0QvqfSOLsCPa4nUw==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^7.0.0, acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.11.0, acorn@^8.4.1:
+  version "8.12.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
+  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
 
 acorn@^8.5.0, acorn@^8.8.0:
   version "8.8.2"
@@ -3282,6 +3334,11 @@ are-we-there-yet@^4.0.0:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/are-we-there-yet/-/are-we-there-yet-4.0.2.tgz#aed25dd0eae514660d49ac2b2366b175c614785a"
   integrity sha512-ncSWAawFhKMJDTdoAeOV+jyW1VCMj5QIAwULIBV0SSR7B/RLPPEQiknKcg/RIIZlUQrxELpsxMiTUoAQ4sIUyg==
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.1:
   version "5.0.1"
@@ -4217,6 +4274,11 @@ chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
+  integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
+
 character-entities-legacy@^1.0.0:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz#3c729991d9293da0ede6dddcaf1f2ce1009ee8b4"
@@ -4916,6 +4978,11 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 crelt@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
@@ -5413,6 +5480,11 @@ didyoumean@^1.2.1, didyoumean@^1.2.2:
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -5422,6 +5494,11 @@ diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -6503,6 +6580,11 @@ fd-slicer@~1.1.0:
   integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
   dependencies:
     pend "~1.2.0"
+
+fdir@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.2.0.tgz#9120f438d566ef3e808ca37864d9dd18e1a4f9b5"
+  integrity sha512-9XaWcDl0riOX5j2kYfy0kKdg7skw3IY6kA4LFT8Tk2yF9UdrADUy8D6AJuBLtf7ISm/MksumwAHE3WVbMRyCLw==
 
 figures@3.2.0, figures@^3.0.0, figures@^3.2.0:
   version "3.2.0"
@@ -8598,6 +8680,21 @@ jake@^10.8.5:
     filelist "^1.0.4"
     minimatch "^3.1.2"
 
+jest-diff@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
+jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
+
 js-cookie@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
@@ -9426,6 +9523,11 @@ make-dir@^2.0.0, make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
 make-fetch-happen@^10.0.3, make-fetch-happen@^10.0.6:
   version "10.2.1"
@@ -11745,6 +11847,15 @@ pretty-format@29.4.3:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 pretty-hrtime@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz#b7e3ea42435a4c9b2759d99e0f201eb195802ee1"
@@ -12827,6 +12938,11 @@ semver@^7.0.0, semver@^7.1.1, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semve
   integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
   dependencies:
     lru-cache "^6.0.0"
+
+semver@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 serialize-javascript@5.0.1:
   version "5.0.1"
@@ -14021,6 +14137,25 @@ ts-easing@^0.2.0:
   resolved "https://registry.yarnpkg.com/ts-easing/-/ts-easing-0.2.0.tgz#c8a8a35025105566588d87dbda05dd7fbfa5a4ec"
   integrity sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.14.2:
   version "3.14.2"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz#6e32f1f79412decd261f92d633a9dc1cfa99f088"
@@ -14208,6 +14343,11 @@ typescript@>=3.0.0:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typescript@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -14559,6 +14699,11 @@ uuid@8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@2.3.0, v8-compile-cache@^2.0.0:
   version "2.3.0"
@@ -15219,6 +15364,11 @@ yazl@^2.2.2:
   integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
   dependencies:
     buffer-crc32 "~0.2.3"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
## Motivation

It is currently tedious to migrate from Parcel to Atlaspack, as there are several parts of a codebase that need to change. This change introduces a CLI to automate some of the migration process.

## Changes

Add a `@atlaspack/parcel-to-atlaspack` package to expose a global `parcel-to-atlaspack` command that makes these changes:

**.parcelrc**
  * Rename to `.atlaspackrc`
  * Update any `@parcel/` plugin references to `@atlaspack/`

**package.json**
  * Update `engines.parcel` to `engines.atlaspack`
  * Update `@parcel/` plugin configurations to `@atlaspack/`
  * Update `parcel` and `@parcel/` dependencies to `@atlaspack`
