### PR TITLE
Retain .parcelrc suffix in migration cli

### DIFF
--- a/packages/migrations/parcel-to-atlaspack/src/migrations/migrate-parcelrc.ts
+++ b/packages/migrations/parcel-to-atlaspack/src/migrations/migrate-parcelrc.ts
@@ -44,7 +44,11 @@ export async function migrateParcelRc({cwd, dryRun}: MigrateParcelRcOptions) {
         }
       }
 
-      const atlaspackrcPath = join(dirname(parcelrcPath), '.atlaspackrc');
+      const atlaspackrcPath = join(
+        dirname(parcelrcPath),
+        basename(parcelrcPath).replace('.parcelrc', '.atlaspackrc'),
+      );
+
       if (dryRun) {
         console.log(
           chalk.blue('[INFO]'),


### PR DESCRIPTION
## Motivation

Currently the migration cli will rename all files that start with `.parcelrc` to `.atlaspackrc` which will cause many files to be overwritten. For example, two files named `.parcelrc` and `.parcelrc-customsuffix` will both be renamed as `.atlaspackrc`.

## Changes

Retain the suffix when renaming `.parcelrc` files


