### PR TITLE
Add faster packager feature-flag

### DIFF
--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -10,6 +10,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   atlaspackV3: false,
   useWatchmanWatcher: false,
   importRetry: false,
+  fastNeedsDefaultInterop: false,
   ownedResolverStructures: false,
 };
 

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -16,6 +16,12 @@ export type FeatureFlags = {|
    */
   importRetry: boolean,
   /**
+   * Enable fast path for needsDefaultInterop.
+   *
+   * This improves bundling performance of large applications very significantly.
+   */
+  fastNeedsDefaultInterop: boolean,
+  /**
    * Enable resolver refactor into owned data structures.
    */
   ownedResolverStructures: boolean,

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -23,6 +23,7 @@ import ThrowableDiagnostic, {
 } from '@atlaspack/diagnostic';
 import globals from 'globals';
 import path from 'path';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
@@ -1430,6 +1431,10 @@ ${code}
       asset.symbols.hasExportSymbol('*') &&
       !asset.symbols.hasExportSymbol('default')
     ) {
+      if (getFeatureFlag('fastNeedsDefaultInterop')) {
+        return true;
+      }
+
       let deps = this.bundleGraph.getIncomingDependencies(asset);
       return deps.some(
         dep =>


### PR DESCRIPTION
This change adds a fast-path to `ScopeHoistingPackager::needsDefaultInterop`.

We have found that up to 50% of the build time can be spent on this function. If we force the default interop to be true, we can skip this function entirely.

The impact on production bundles from real applications seems minimal and the build time improvement is very significant.