### PR TITLE
[V3] Registering transformer plugins

### DIFF
--- a/crates/atlaspack/src/test_utils.rs
+++ b/crates/atlaspack/src/test_utils.rs
@@ -32,7 +32,7 @@ pub(crate) fn make_test_plugin_context() -> PluginContext {
 pub(crate) fn config_plugins(ctx: PluginContext) -> PluginsRef {
   let fixture = default_config(Arc::new(PathBuf::default()));
 
-  Arc::new(ConfigPlugins::new(fixture.atlaspack_config, ctx))
+  Arc::new(ConfigPlugins::new(None, fixture.atlaspack_config, ctx))
 }
 
 pub struct RequestTrackerTestOptions {

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
@@ -38,7 +38,7 @@ impl RpcWorker for NodejsWorker {
     Ok(())
   }
 
-  fn transformer_register(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
+  fn register_transformer(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
     self
       .transformer_register_fn
       .call_with_return(

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
@@ -1,3 +1,6 @@
+use std::path::Path;
+
+use anyhow::Context;
 use atlaspack_napi_helpers::anyhow_from_napi;
 use atlaspack_napi_helpers::js_callable::JsCallable;
 use napi::{JsObject, JsUnknown};
@@ -8,12 +11,17 @@ use crate::RpcWorker;
 /// single Nodejs worker thread
 pub struct NodejsWorker {
   ping_fn: JsCallable,
+  transformer_register_fn: JsCallable,
 }
 
 impl NodejsWorker {
   pub fn new(delegate: JsObject) -> napi::Result<Self> {
     Ok(Self {
       ping_fn: JsCallable::new_from_object_prop_bound("ping", &delegate)?,
+      transformer_register_fn: JsCallable::new_from_object_prop_bound(
+        "transformerRegister",
+        &delegate,
+      )?,
     })
   }
 }
@@ -24,6 +32,26 @@ impl RpcWorker for NodejsWorker {
       .ping_fn
       .call_with_return(
         |_env| Ok(Vec::<JsUnknown>::new()),
+        |_env, _| Ok(Vec::<()>::new()),
+      )
+      .map_err(anyhow_from_napi)?;
+    Ok(())
+  }
+
+  fn transformer_register(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
+    self
+      .transformer_register_fn
+      .call_with_return(
+        {
+          let specifier = specifier.to_string();
+          let resolve_from = resolve_from.to_str().context("")?.to_string();
+          move |env| {
+            Ok(vec![
+              env.create_string(&resolve_from)?.into_unknown(),
+              env.create_string(&specifier)?.into_unknown(),
+            ])
+          }
+        },
         |_env, _| Ok(Vec::<()>::new()),
       )
       .map_err(anyhow_from_napi)?;

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use parking_lot::Mutex;
 
 use super::NodejsWorker;
@@ -8,21 +10,21 @@ use crate::RpcWorker;
 /// Implements round robin messaging
 pub struct NodejsWorkerFarm {
   current_index: Mutex<usize>, // TODO use AtomicUsize
-  conns: Vec<NodejsWorker>,
+  workers: Vec<NodejsWorker>,
 }
 
 impl NodejsWorkerFarm {
   pub fn new(conns: Vec<NodejsWorker>) -> Self {
     Self {
       current_index: Default::default(),
-      conns,
+      workers: conns,
     }
   }
 
   #[allow(unused)]
   fn next_index(&self) -> usize {
     let mut current_index = self.current_index.lock();
-    if *current_index >= self.conns.len() - 1 {
+    if *current_index >= self.workers.len() - 1 {
       *current_index = 0;
     } else {
       *current_index = *current_index + 1;
@@ -33,8 +35,15 @@ impl NodejsWorkerFarm {
 
 impl RpcWorker for NodejsWorkerFarm {
   fn ping(&self) -> anyhow::Result<()> {
-    for conn in &self.conns {
-      conn.ping()?;
+    for worker in &self.workers {
+      worker.ping()?;
+    }
+    Ok(())
+  }
+
+  fn transformer_register(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
+    for worker in &self.workers {
+      worker.transformer_register(resolve_from, specifier)?;
     }
     Ok(())
   }

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
@@ -17,7 +17,7 @@ impl NodejsWorkerFarm {
   pub fn new(conns: Vec<NodejsWorker>) -> Self {
     Self {
       current_index: Default::default(),
-      workers: conns,
+      workers,
     }
   }
 

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
@@ -14,7 +14,7 @@ pub struct NodejsWorkerFarm {
 }
 
 impl NodejsWorkerFarm {
-  pub fn new(conns: Vec<NodejsWorker>) -> Self {
+  pub fn new(workers: Vec<NodejsWorker>) -> Self {
     Self {
       current_index: Default::default(),
       workers,
@@ -41,9 +41,9 @@ impl RpcWorker for NodejsWorkerFarm {
     Ok(())
   }
 
-  fn transformer_register(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
+  fn register_transformer(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
     for worker in &self.workers {
-      worker.transformer_register(resolve_from, specifier)?;
+      worker.register_transformer(resolve_from, specifier)?;
     }
     Ok(())
   }

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -9,26 +9,40 @@ use atlaspack_core::plugin::TransformResult;
 use atlaspack_core::plugin::TransformerPlugin;
 use atlaspack_core::types::Asset;
 
+use crate::RpcWorkerRef;
+
 pub struct RpcTransformerPlugin {
-  _name: String,
+  _rpc_worker: RpcWorkerRef,
+  name: String,
 }
 
 impl Debug for RpcTransformerPlugin {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "RpcTransformerPlugin")
+    write!(f, "RpcTransformerPlugin({})", self.name)
   }
 }
 
 impl RpcTransformerPlugin {
-  pub fn new(_ctx: &PluginContext, plugin: &PluginNode) -> Result<Self, anyhow::Error> {
+  pub fn new(
+    rpc_worker: RpcWorkerRef,
+    _ctx: &PluginContext,
+    plugin: &PluginNode,
+  ) -> Result<Self, anyhow::Error> {
+    rpc_worker.transformer_register(&plugin.resolve_from, &plugin.package_name)?;
+
     Ok(RpcTransformerPlugin {
-      _name: plugin.package_name.clone(),
+      _rpc_worker: rpc_worker,
+      name: plugin.package_name.clone(),
     })
   }
 }
 
 impl TransformerPlugin for RpcTransformerPlugin {
-  fn transform(&mut self, _asset: Asset) -> Result<TransformResult, Error> {
-    todo!()
+  fn transform(&mut self, asset: Asset) -> Result<TransformResult, Error> {
+    Ok(TransformResult {
+      asset,
+      dependencies: vec![],
+      invalidate_on_file_change: vec![],
+    })
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -28,7 +28,7 @@ impl RpcTransformerPlugin {
     _ctx: &PluginContext,
     plugin: &PluginNode,
   ) -> Result<Self, anyhow::Error> {
-    rpc_worker.transformer_register(&plugin.resolve_from, &plugin.package_name)?;
+    rpc_worker.register_transformer(&plugin.resolve_from, &plugin.package_name)?;
 
     Ok(RpcTransformerPlugin {
       _rpc_worker: rpc_worker,

--- a/crates/atlaspack_plugin_rpc/src/rpc_host.rs
+++ b/crates/atlaspack_plugin_rpc/src/rpc_host.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::sync::Arc;
 
 pub type RpcHostRef = Arc<dyn RpcHost>;
@@ -9,4 +10,5 @@ pub trait RpcHost: Send + Sync {
 
 pub trait RpcWorker: Send + Sync {
   fn ping(&self) -> anyhow::Result<()>;
+  fn transformer_register(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()>;
 }

--- a/crates/atlaspack_plugin_rpc/src/rpc_host.rs
+++ b/crates/atlaspack_plugin_rpc/src/rpc_host.rs
@@ -10,5 +10,5 @@ pub trait RpcHost: Send + Sync {
 
 pub trait RpcWorker: Send + Sync {
   fn ping(&self) -> anyhow::Result<()>;
-  fn transformer_register(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()>;
+  fn register_transformer(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()>;
 }

--- a/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
+++ b/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
@@ -33,17 +33,6 @@ export class AtlaspackV3 {
     });
   }
 
-  async build(): Promise<any> {
-    const [workers, registerWorker] = this.#createWorkers();
-
-    let result = await this._internal.build({
-      registerWorker,
-    });
-
-    for (const worker of workers) worker.terminate();
-    return result;
-  }
-
   async buildAssetGraph(): Promise<any> {
     const [workers, registerWorker] = this.#createWorkers();
 

--- a/packages/core/core/src/atlaspack-v3/plugins/Resolver.js
+++ b/packages/core/core/src/atlaspack-v3/plugins/Resolver.js
@@ -1,9 +1,0 @@
-// @flow
-
-export class ResolverNapi {
-  constructor() {}
-
-  loadConfig() {}
-
-  resolve() {}
-}

--- a/packages/core/core/src/atlaspack-v3/plugins/index.js
+++ b/packages/core/core/src/atlaspack-v3/plugins/index.js
@@ -1,3 +1,0 @@
-// @flow
-
-export * from './Resolver';

--- a/packages/core/core/src/atlaspack-v3/worker/worker.js
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.js
@@ -1,13 +1,26 @@
 // @flow
 import * as napi from '@atlaspack/rust';
+import type {Transformer} from '@atlaspack/types';
 import {workerData} from 'worker_threads';
-import type {ResolverNapi} from '../plugins/Resolver';
+import * as module from 'module';
 
 export class AtlaspackWorker {
-  #resolvers: Map<string, ResolverNapi>;
+  #transformers: Map<string, Transformer<any>>;
+
+  constructor() {
+    this.#transformers = new Map();
+  }
 
   ping() {
     // console.log('Hi');
+  }
+
+  async transformerRegister(resolve_from: string, specifier: string) {
+    let customRequire = module.createRequire(resolve_from);
+    let resolvedPath = customRequire.resolve(specifier);
+    // $FlowFixMe
+    let transformer = await import(resolvedPath);
+    this.#transformers.set(`${resolve_from}:${specifier}`, transformer);
   }
 }
 

--- a/packages/core/integration-tests/test/atlaspack-v3.js
+++ b/packages/core/integration-tests/test/atlaspack-v3.js
@@ -37,6 +37,6 @@ describe('AtlaspackV3', function () {
       packageManager: new NodePackageManager(inputFS, __dirname),
     });
 
-    await atlaspack.build();
+    await atlaspack.buildAssetGraph();
   });
 });


### PR DESCRIPTION
This PR adds the ability for the Nodejs context to initialize Transformer plugins. They currently don't do anything other than resolve, initialize & store the target transformer plugin 

- removed `AtlaspackV3.build()` because it's currently unused
- expanded `NodejsWorker` to include `transformerRegister()` method
  - Used to resolve and register a transformer plugin within the nodejs context
- injecting `RpcWorker` into `RpcTransformerPlugin`
- calling `transformerRegister` when `RpcTransformerPlugin` is initialized