### PR TITLE
Fix default target merging and add env id

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -200,24 +200,21 @@ describe('javascript', function () {
     assert.equal(output(), 7);
   });
 
-  it.v2(
-    'should preserve hashbangs in bundles and preserve executable file mode',
-    async () => {
-      let fixturePath = path.join(__dirname, '/integration/node_hashbang');
-      await bundle(path.join(fixturePath, 'main.js'));
+  it('should preserve hashbangs in bundles and preserve executable file mode', async () => {
+    let fixturePath = path.join(__dirname, '/integration/node_hashbang');
+    await bundle(path.join(fixturePath, 'main.js'));
 
-      let mainPath = path.join(fixturePath, 'dist', 'node', 'main.js');
-      let main = await outputFS.readFile(mainPath, 'utf8');
-      assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
-      assert.equal(
-        (await outputFS.stat(mainPath)).mode,
-        (await inputFS.stat(path.join(fixturePath, 'main.js'))).mode,
-      );
-      await outputFS.rimraf(path.join(fixturePath, 'dist'));
-    },
-  );
+    let mainPath = path.join(fixturePath, 'dist', 'node', 'main.js');
+    let main = await outputFS.readFile(mainPath, 'utf8');
+    assert.equal(main.lastIndexOf('#!/usr/bin/env node\n'), 0);
+    assert.equal(
+      (await outputFS.stat(mainPath)).mode,
+      (await inputFS.stat(path.join(fixturePath, 'main.js'))).mode,
+    );
+    await outputFS.rimraf(path.join(fixturePath, 'dist'));
+  });
 
-  it.v2('should not preserve hashbangs in browser bundles', async () => {
+  it('should not preserve hashbangs in browser bundles', async () => {
     let fixturePath = path.join(__dirname, '/integration/node_hashbang');
     await bundle(path.join(fixturePath, 'main.js'));
 
@@ -229,7 +226,7 @@ describe('javascript', function () {
     await outputFS.rimraf(path.join(fixturePath, 'dist'));
   });
 
-  it.v2('should preserve hashbangs in scopehoisted bundles', async () => {
+  it('should preserve hashbangs in scopehoisted bundles', async () => {
     let fixturePath = path.join(__dirname, '/integration/node_hashbang');
     await bundle(path.join(__dirname, '/integration/node_hashbang/main.js'), {
       defaultTargetOptions: {

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -133,6 +133,7 @@ export type ResolvedParcelConfigFile = ResolvedAtlaspackConfigFile;
 
 /** Corresponds to <code>pkg#engines</code> */
 export type Engines = {
+  +atlaspack?: SemverRange,
   +browsers?: string | Array<string>,
   +electron?: SemverRange,
   +node?: SemverRange,


### PR DESCRIPTION
## Motivation

When multiple targets are specified, v3 does not correctly insert enough asset groups. This occurs as the id generated in `nodeFromAssetGroup` includes an environment id, which was previously missing. When `addNodeByContentKeyIfNeeded` was called shortly thereafter, the id would be considered the same for all targets due to the missing environment id. In addition to this, the default values for builtin targets were not preserved.

## Changes

* Add environment id on the JavaScript side, as it is not currently needed on the Rust side and would involve changing several structures to omit default values
* Merge default builtin target values when parts of a builtin config are specified to match v2 behaviour and add corresponding unit tests

## Checklist

- [x] Existing or new tests cover this change
