### PR TITLE
[V3] Ensure Dependency.symbols when scope hoisting is enabled

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3324,49 +3324,44 @@ describe('javascript', function () {
     assert.deepEqual(await (await run(b)).default, [42, 42, 42]);
   });
 
-  // V3 fails this test intermitantly, might be a race condition or some
-  // missing logic in the asset_graph_request
-  it.v2(
-    'async dependency can be resolved internally and externally from two different bundles',
-    async () => {
-      let b = await bundle(
-        ['entry1.js', 'entry2.js'].map(entry =>
-          path.join(
-            __dirname,
-            '/integration/async-dep-internal-external/',
-            entry,
-          ),
+  it('async dependency can be resolved internally and externally from two different bundles', async () => {
+    let b = await bundle(
+      ['entry1.js', 'entry2.js'].map(entry =>
+        path.join(
+          __dirname,
+          '/integration/async-dep-internal-external/',
+          entry,
         ),
-        {
-          mode: 'production',
-          defaultTargetOptions: {
-            shouldScopeHoist: true,
-          },
+      ),
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
         },
-      );
+      },
+    );
 
-      assertBundles(b, [
-        {
-          assets: ['async.js'],
-        },
-        {
-          name: 'entry1.js',
-          assets: ['child.js', 'entry1.js', 'async.js'],
-        },
-        {
-          name: 'entry2.js',
-          assets: [
-            'bundle-manifest.js',
-            'bundle-url.js',
-            'cacheLoader.js',
-            'child.js',
-            'entry2.js',
-            'js-loader.js',
-          ],
-        },
-      ]);
-    },
-  );
+    assertBundles(b, [
+      {
+        assets: ['async.js'],
+      },
+      {
+        name: 'entry1.js',
+        assets: ['child.js', 'entry1.js', 'async.js'],
+      },
+      {
+        name: 'entry2.js',
+        assets: [
+          'bundle-manifest.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'child.js',
+          'entry2.js',
+          'js-loader.js',
+        ],
+      },
+    ]);
+  });
 
   it('can static import and dynamic import in the same bundle ancestry without creating a new bundle', async () => {
     let b = await bundle(


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

For some reason, `Dependency.symbols` is expected to always be a Map (even if empty) but only when scope hoisting is enabled. We should definitely address this and make things more consistent between the two modes (or unify them completely) when we revisit packaging, however I think we should just keep consistent with V2 for now. 

## Changes

- Ensure `Dependency.symbols` is always a Map when scope hoisting is enabled
- Enable another test for V3
- Change symbols and loc to make them more consistent with V2 for easier diffing 

## Checklist

- [x] Existing or new tests cover this change
