### PR TITLE
Remove package name validation

### DIFF
--- a/packages/core/core/src/AtlaspackConfig.schema.js
+++ b/packages/core/core/src/AtlaspackConfig.schema.js
@@ -1,47 +1,24 @@
 // @flow strict-local
 import type {PackageName} from '@atlaspack/types';
 import type {SchemaEntity} from '@atlaspack/utils';
-import assert from 'assert';
 
-// Reasoning behind this validation:
-// https://github.com/parcel-bundler/parcel/issues/3397#issuecomment-521353931
+// Parcel validates plugin package names due to:
+//
+// * https://github.com/parcel-bundler/parcel/issues/3397#issuecomment-521353931
+//
+// Ultimately:
+//
+// * We do not care about package names
+// * Validation makes interop between parcel/atlaspack confusing.
+//
 export function validatePackageName(
+  // eslint-disable-next-line no-unused-vars
   pkg: ?PackageName,
+  // eslint-disable-next-line no-unused-vars
   pluginType: string,
+  // eslint-disable-next-line no-unused-vars
   key: string,
-) {
-  // $FlowFixMe
-  if (!pkg) {
-    return;
-  }
-
-  assert(typeof pkg === 'string', `"${key}" must be a string`);
-
-  // Probably all of these need to be removed
-  if (pkg.startsWith('@atlaspack') || pkg.startsWith('@parcel')) {
-    assert(
-      pkg.replace(/^@(atlaspack|parcel)\//, '').startsWith(`${pluginType}-`),
-      `Official atlaspack ${pluginType} packages must be named according to "@atlaspack/${pluginType}-{name}"`,
-    );
-  } else if (pkg.startsWith('@')) {
-    // Disabling this validation to allow for migration to parcel
-    // let [scope, name] = pkg.split('/');
-    // assert(
-    //   name.startsWith(`parcel-${pluginType}-`) ||
-    //     name === `parcel-${pluginType}` ||
-    //     name.startsWith(`parcel-${pluginType}-`) ||
-    //     name === `parcel-${pluginType}`,
-    //   `Scoped parcel ${pluginType} packages must be named according to "${scope}/parcel-${pluginType}[-{name}]"`,
-    // );
-  } else if (!pkg.startsWith('.')) {
-    assert(
-      pkg.startsWith(`parcel-${pluginType}-`) ||
-        pkg.startsWith(`atlaspack-${pluginType}`),
-      // let the error message be wrong for now
-      `Atlaspack ${pluginType} packages must be named according to "parcel-${pluginType}-{name}"`,
-    );
-  }
-}
+) {}
 
 const validatePluginName = (pluginType: string, key: string) => {
   return (val: string) => {

--- a/packages/core/core/test/AtlaspackConfigRequest.test.js
+++ b/packages/core/core/test/AtlaspackConfigRequest.test.js
@@ -13,107 +13,11 @@ import {
   resolveAtlaspackConfig,
   processConfig,
 } from '../src/requests/AtlaspackConfigRequest';
-import {validatePackageName} from '../src/AtlaspackConfig.schema';
 import {DEFAULT_OPTIONS, relative} from './test-utils';
 import {toProjectPath} from '../src/projectPath';
 
 describe('AtlaspackConfigRequest', () => {
-  describe('validatePackageName', () => {
-    it('should error on an invalid official package', () => {
-      assert.throws(() => {
-        validatePackageName('@atlaspack/foo-bar', 'transform', 'transformers');
-      }, /Official atlaspack transform packages must be named according to "@atlaspack\/transform-{name}"/);
-
-      assert.throws(() => {
-        validatePackageName(
-          '@atlaspack/transformer',
-          'transform',
-          'transformers',
-        );
-      }, /Official atlaspack transform packages must be named according to "@atlaspack\/transform-{name}"/);
-    });
-
-    it('should succeed on a valid official package', () => {
-      validatePackageName(
-        '@atlaspack/transform-bar',
-        'transform',
-        'transformers',
-      );
-    });
-
-    it('should error on an invalid community package', () => {
-      assert.throws(() => {
-        validatePackageName('foo-bar', 'transform', 'transformers');
-      }, /Atlaspack transform packages must be named according to "parcel-transform-{name}"/);
-
-      assert.throws(() => {
-        validatePackageName('parcel-foo-bar', 'transform', 'transformers');
-      }, /Atlaspack transform packages must be named according to "parcel-transform-{name}"/);
-
-      assert.throws(() => {
-        validatePackageName('parcel-transform', 'transform', 'transformers');
-      }, /Atlaspack transform packages must be named according to "parcel-transform-{name}"/);
-    });
-
-    it('should succeed on a valid community package', () => {
-      validatePackageName('parcel-transform-bar', 'transform', 'transformers');
-    });
-
-    // Skipping this while the migration to parcel occurs
-    it.skip('should error on an invalid scoped package', () => {
-      assert.throws(() => {
-        validatePackageName('@test/foo-bar', 'transform', 'transformers');
-      }, /Scoped atlaspack transform packages must be named according to "@test\/parcel-transform\[-{name}\]"/);
-
-      assert.throws(() => {
-        validatePackageName(
-          '@test/atlaspack-foo-bar',
-          'transform',
-          'transformers',
-        );
-      }, /Scoped atlaspack transform packages must be named according to "@test\/parcel-transform\[-{name}\]"/);
-    });
-
-    it('should succeed on a valid scoped package', () => {
-      validatePackageName(
-        '@test/atlaspack-transform-bar',
-        'transform',
-        'transformers',
-      );
-
-      validatePackageName(
-        '@test/atlaspack-transform',
-        'transform',
-        'transformers',
-      );
-    });
-
-    it('should succeed on a local package', () => {
-      validatePackageName(
-        './atlaspack-transform-bar',
-        'transform',
-        'transformers',
-      );
-      validatePackageName('./bar', 'transform', 'transformers');
-    });
-  });
-
   describe('validateConfigFile', () => {
-    it('should throw on invalid config', () => {
-      assert.throws(() => {
-        validateConfigFile(
-          {
-            filePath: '.parcelrc',
-            extends: 'parcel-config-foo',
-            transformers: {
-              '*.js': ['parcel-invalid-plugin'],
-            },
-          },
-          '.parcelrc',
-        );
-      });
-    });
-
     it('should require pipeline to be an array', () => {
       assert.throws(() => {
         validateConfigFile(
@@ -134,18 +38,6 @@ describe('AtlaspackConfigRequest', () => {
             filePath: '.parcelrc',
             // $FlowExpectedError[incompatible-call]
             resolvers: [1, '123', 5],
-          },
-          '.parcelrc',
-        );
-      });
-    });
-
-    it('should require package names to be valid', () => {
-      assert.throws(() => {
-        validateConfigFile(
-          {
-            filePath: '.parcelrc',
-            resolvers: ['parcel-foo-bar'],
           },
           '.parcelrc',
         );
@@ -179,21 +71,6 @@ describe('AtlaspackConfigRequest', () => {
             filePath: '.parcelrc',
             // $FlowExpectedError[incompatible-call]
             transformers: ['parcel-transformer-test', '...'],
-          },
-          '.parcelrc',
-        );
-      });
-    });
-
-    it('should trigger the validator function for each key', () => {
-      assert.throws(() => {
-        validateConfigFile(
-          {
-            filePath: '.parcelrc',
-            transformers: {
-              'types:*.{ts,tsx}': ['@atlaspack/transformer-typescript-types'],
-              'bundle-text:*': ['-inline-string', '...'],
-            },
           },
           '.parcelrc',
         );
@@ -237,44 +114,6 @@ describe('AtlaspackConfigRequest', () => {
         {
           filePath: '.parcelrc',
           extends: ['./foo', './bar'],
-        },
-        '.parcelrc',
-      );
-    });
-
-    it('should validate package names', () => {
-      assert.throws(() => {
-        validateConfigFile(
-          {
-            filePath: '.parcelrc',
-            extends: 'foo',
-          },
-          '.parcelrc',
-        );
-      });
-
-      assert.throws(() => {
-        validateConfigFile(
-          {
-            filePath: '.parcelrc',
-            extends: ['foo', 'bar'],
-          },
-          '.parcelrc',
-        );
-      });
-
-      validateConfigFile(
-        {
-          filePath: '.parcelrc',
-          extends: 'parcel-config-foo',
-        },
-        '.parcelrc',
-      );
-
-      validateConfigFile(
-        {
-          filePath: '.parcelrc',
-          extends: ['parcel-config-foo', 'parcel-config-bar'],
         },
         '.parcelrc',
       );


### PR DESCRIPTION
Reasoning for there being validation is on https://github.com/parcel-bundler/parcel/issues/3397#issuecomment-521353931

Ultimately, we do not care about package names on NPM or whether there are published packages for plug-ins. Furthermore validation means incompatibility between parcel/atlaspack or adding code on both sides to support the renamed packages.