### PR TITLE
[V3] Fix non-deterministic dependency order

### DIFF
--- a/crates/atlaspack/Cargo.toml
+++ b/crates/atlaspack/Cargo.toml
@@ -19,6 +19,7 @@ atlaspack-resolver = { path = "../../packages/utils/node-resolver-rs" }
 
 anyhow = "1.0.82"
 dyn-hash = "0.x"
+indexmap = "2.2.6"
 num_cpus = "1.16.0"
 pathdiff = "0.2.1"
 petgraph = "0.x"

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -1,3 +1,4 @@
+use indexmap::IndexMap;
 use std::collections::{HashMap, HashSet};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::Arc;
@@ -247,7 +248,7 @@ impl AssetGraphBuilder {
       .insert(request_id, asset_node_index);
 
     // Connect dependencies of the Asset
-    let mut unique_deps: HashMap<u64, Dependency> = HashMap::new();
+    let mut unique_deps: IndexMap<u64, Dependency> = IndexMap::new();
 
     for mut dependency in dependencies {
       unique_deps


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Since merging #31, some of the integration tests have been flaky. This was due to dependency insertion order not being respected when they are de-duplicated. 

## Changes

Instead of a HashMap, use an IndexMap for deduping as that respects the insertion order of the dependencies. 

## Checklist

- [x] Existing or new tests cover this change
