### PR TITLE
Update with LMDB lite cache implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,8 +198,8 @@ version = "0.1.0"
 dependencies = [
  "crossbeam-channel",
  "indexmap 1.9.3",
- "napi 2.16.6",
- "napi-derive 2.16.5",
+ "napi",
+ "napi-derive",
  "serde",
  "swc_core",
 ]
@@ -227,13 +227,14 @@ dependencies = [
  "indexmap 1.9.3",
  "jemallocator",
  "libc",
+ "lmdb-js-lite",
  "log",
  "mimalloc",
  "mockall",
  "mozjpeg-sys",
- "napi 2.16.6",
+ "napi",
  "napi-build",
- "napi-derive 2.16.5",
+ "napi-derive",
  "num_cpus",
  "once_cell",
  "oxipng",
@@ -374,7 +375,7 @@ name = "atlaspack_napi_helpers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "napi 2.16.6",
+ "napi",
  "napi-build",
  "once_cell",
  "serde",
@@ -409,7 +410,7 @@ dependencies = [
  "atlaspack_config",
  "atlaspack_core",
  "atlaspack_napi_helpers",
- "napi 2.16.6",
+ "napi",
  "once_cell",
  "parking_lot",
  "serde",
@@ -1886,9 +1887,9 @@ dependencies = [
  "heed",
  "lazy_static",
  "lz4_flex",
- "napi 3.0.0-alpha.8",
+ "napi",
  "napi-build",
- "napi-derive 3.0.0-alpha.7",
+ "napi-derive",
  "rand 0.9.0-alpha.2",
  "rayon",
  "thiserror",
@@ -2134,25 +2135,11 @@ checksum = "dfc300228808a0e6aea5a58115c82889240bcf8dab16fc25ad675b33e454b368"
 dependencies = [
  "bitflags 2.6.0",
  "ctor",
- "napi-derive 2.16.5",
+ "napi-derive",
  "napi-sys",
  "once_cell",
  "serde",
  "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "napi"
-version = "3.0.0-alpha.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743b5a7769f54c95e20a26d9e66d1b43d5622b7dc8ec8f97b51ed8c58633841f"
-dependencies = [
- "bitflags 2.6.0",
- "ctor",
- "napi-build",
- "napi-sys",
- "once_cell",
  "tokio",
 ]
 
@@ -2170,21 +2157,7 @@ checksum = "e0e034ddf6155192cf83f267ede763fe6c164dfa9971585436b16173718d94c4"
 dependencies = [
  "cfg-if",
  "convert_case",
- "napi-derive-backend 1.0.67",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "napi-derive"
-version = "3.0.0-alpha.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7619cfcc3985e1ed73d147d6950caabaedabcf5c98133502f9d18c3d0061320"
-dependencies = [
- "cfg-if",
- "convert_case",
- "napi-derive-backend 2.0.0-alpha.7",
+ "napi-derive-backend",
  "proc-macro2",
  "quote",
  "syn",
@@ -2195,21 +2168,6 @@ name = "napi-derive-backend"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bff2c00437f3b3266391eb5e6aa25d0029187daf5caf05b8e3271468fb5ae73e"
-dependencies = [
- "convert_case",
- "once_cell",
- "proc-macro2",
- "quote",
- "regex",
- "semver 1.0.23",
- "syn",
-]
-
-[[package]]
-name = "napi-derive-backend"
-version = "2.0.0-alpha.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584f6a91c05e8c6bf80622fcc2675c7d27934754d4f1141cfd422d531a3f51fb"
 dependencies = [
  "convert_case",
  "once_cell",

--- a/crates/lmdb-js-lite/Cargo.toml
+++ b/crates/lmdb-js-lite/Cargo.toml
@@ -16,8 +16,8 @@ anyhow = "1.0.86"
 crossbeam = "0.8.4"
 heed = "0.20.3"
 lazy_static = "1.5.0"
-napi = { version = "3.0.0-alpha.8", default-features = false, features = ["napi4", "tokio"] }
-napi-derive = "3.0.0-alpha.7"
+napi = { version = "2.16.4", features = ["async", "napi4", "napi5", "serde-json"] }
+napi-derive = "2.16.3"
 rayon = "1.10.0"
 thiserror = "1.0.63"
 tracing = "0.1.40"

--- a/crates/lmdb-js-lite/Cargo.toml
+++ b/crates/lmdb-js-lite/Cargo.toml
@@ -9,7 +9,7 @@ name = "lmdb_js_safe_benchmark"
 harness = false
 
 [lib]
-crate-type = ["cdylib", "lib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1.0.86"

--- a/crates/lmdb-js-lite/src/lib.rs
+++ b/crates/lmdb-js-lite/src/lib.rs
@@ -47,7 +47,7 @@ use napi::JsUnknown;
 use napi_derive::napi;
 use tracing::Level;
 
-use crate::writer::LMDBOptions;
+pub use crate::writer::LMDBOptions;
 use crate::writer::{
   start_make_database_writer, DatabaseWriter, DatabaseWriterError, DatabaseWriterHandle,
   DatabaseWriterMessage,

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -20,6 +20,7 @@ atlaspack-resolver-old = { path = "../../packages/utils/node-resolver-rs-old" }
 atlaspack_package_manager = { path = "../atlaspack_package_manager" }
 atlaspack_plugin_transformer_js = { path = "../atlaspack_plugin_transformer_js" }
 atlaspack_napi_helpers = { path = "../atlaspack_napi_helpers" }
+lmdb-js-lite = { path = "../lmdb-js-lite" }
 
 anyhow = "1.0.82"
 glob = "0.3.1"

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -25,7 +25,7 @@ mod image;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod atlaspack;
-mod lmdb;
+pub mod lmdb;
 mod resolver;
 mod resolver_old;
 mod transformer;

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -25,6 +25,7 @@ mod image;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod atlaspack;
+mod lmdb;
 mod resolver;
 mod resolver_old;
 mod transformer;

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -25,6 +25,7 @@ mod image;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod atlaspack;
+#[cfg(not(test))]
 pub mod lmdb;
 mod resolver;
 mod resolver_old;

--- a/crates/node-bindings/src/lmdb.rs
+++ b/crates/node-bindings/src/lmdb.rs
@@ -1,2 +1,77 @@
-#[cfg(not(test))]
-pub use lmdb_js_lite::*;
+use napi::bindgen_prelude::Buffer;
+use napi::bindgen_prelude::Env;
+use napi::JsUnknown;
+use napi_derive::napi;
+#[napi]
+pub struct LMDB {
+  inner: lmdb_js_lite::LMDB,
+}
+
+#[napi]
+impl LMDB {
+  #[napi(constructor)]
+  pub fn new(options: lmdb_js_lite::LMDBOptions) -> napi::Result<Self> {
+    Ok(Self {
+      inner: lmdb_js_lite::LMDB::new(options)?,
+    })
+  }
+
+  #[napi(ts_return_type = "Promise<Buffer | null | undefined>")]
+  pub fn get(&self, env: Env, key: String) -> napi::Result<napi::JsObject> {
+    self.inner.get(env, key)
+  }
+
+  #[napi(ts_return_type = "Buffer | null")]
+  pub fn get_sync(&self, env: Env, key: String) -> napi::Result<JsUnknown> {
+    self.inner.get_sync(env, key)
+  }
+
+  #[napi]
+  pub fn get_many_sync(&self, keys: Vec<String>) -> napi::Result<Vec<Option<Buffer>>> {
+    self.inner.get_many_sync(keys)
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn put_many(
+    &self,
+    env: Env,
+    entries: Vec<lmdb_js_lite::Entry>,
+  ) -> napi::Result<napi::JsObject> {
+    self.inner.put_many(env, entries)
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn put(&self, env: Env, key: String, data: Buffer) -> napi::Result<napi::JsObject> {
+    self.inner.put(env, key, data)
+  }
+
+  #[napi]
+  pub fn put_no_confirm(&self, key: String, data: Buffer) -> napi::Result<()> {
+    self.inner.put_no_confirm(key, data)
+  }
+
+  #[napi]
+  pub fn start_read_transaction(&mut self) -> napi::Result<()> {
+    self.inner.start_read_transaction()
+  }
+
+  #[napi]
+  pub fn commit_read_transaction(&mut self) -> napi::Result<()> {
+    self.inner.commit_read_transaction()
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn start_write_transaction(&self, env: Env) -> napi::Result<napi::JsObject> {
+    self.inner.start_write_transaction(env)
+  }
+
+  #[napi(ts_return_type = "Promise<void>")]
+  pub fn commit_write_transaction(&self, env: Env) -> napi::Result<napi::JsObject> {
+    self.inner.commit_write_transaction(env)
+  }
+
+  #[napi]
+  pub fn close(&mut self) {
+    self.inner.close()
+  }
+}

--- a/crates/node-bindings/src/lmdb.rs
+++ b/crates/node-bindings/src/lmdb.rs
@@ -1,1 +1,2 @@
+#[cfg(not(test))]
 pub use lmdb_js_lite::*;

--- a/crates/node-bindings/src/lmdb.rs
+++ b/crates/node-bindings/src/lmdb.rs
@@ -1,0 +1,1 @@
+pub use lmdb_js_lite::*;

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -17,12 +17,14 @@
     "node": ">= 16.0.0"
   },
   "scripts": {
+    "test": "mocha",
     "build-ts": "mkdir -p lib && flow-to-ts src/types.js > lib/types.d.ts",
     "check-ts": "tsc --noEmit index.d.ts"
   },
   "dependencies": {
     "@atlaspack/fs": "2.12.0",
     "@atlaspack/logger": "2.12.0",
+    "@atlaspack/rust": "2.12.0",
     "@atlaspack/utils": "2.12.0",
     "lmdb": "2.8.5"
   },

--- a/packages/core/cache/src/LMDBLiteCache.js
+++ b/packages/core/cache/src/LMDBLiteCache.js
@@ -1,0 +1,196 @@
+// @flow strict-local
+
+import {Lmdb} from '@atlaspack/rust';
+import type {FilePath} from '@atlaspack/types';
+import type {Cache} from './types';
+import type {Readable, Writable} from 'stream';
+
+import stream from 'stream';
+import path from 'path';
+import {promisify} from 'util';
+import {
+  serialize,
+  deserialize,
+  registerSerializableClass,
+} from '@atlaspack/core';
+import {NodeFS} from '@atlaspack/fs';
+// $FlowFixMe
+import packageJson from '../package.json';
+
+import {FSCache} from './FSCache';
+
+interface DBOpenOptions {
+  name: string;
+  // unused
+  encoding: string;
+  // unused
+  compression: boolean;
+}
+
+export class LmdbWrapper {
+  lmdb: Lmdb;
+
+  constructor(lmdb: Lmdb) {
+    this.lmdb = lmdb;
+
+    // $FlowFixMe
+    this[Symbol.dispose] = () => {
+      this.lmdb.close();
+    };
+  }
+
+  get(key: string): Buffer | null {
+    return this.lmdb.getSync(key);
+  }
+
+  async put(key: string, value: Buffer | string): Promise<void> {
+    const buffer: Buffer =
+      typeof value === 'string' ? Buffer.from(value) : value;
+    await this.lmdb.put(key, buffer);
+  }
+
+  resetReadTxn() {}
+}
+
+export function open(
+  directory: string,
+  // eslint-disable-next-line no-unused-vars
+  openOptions: DBOpenOptions,
+): LmdbWrapper {
+  return new LmdbWrapper(
+    new Lmdb({
+      path: directory,
+      asyncWrites: true,
+      mapSize: 1024 * 1024 * 1024 * 15,
+    }),
+  );
+}
+
+const pipeline: (Readable, Writable) => Promise<void> = promisify(
+  stream.pipeline,
+);
+
+export class LMDBLiteCache implements Cache {
+  fs: NodeFS;
+  dir: FilePath;
+  // $FlowFixMe
+  store: any;
+  fsCache: FSCache;
+
+  constructor(cacheDir: FilePath) {
+    this.fs = new NodeFS();
+    this.dir = cacheDir;
+    this.fsCache = new FSCache(this.fs, cacheDir);
+
+    this.store = open(cacheDir, {
+      name: 'parcel-cache',
+      encoding: 'binary',
+      compression: true,
+    });
+  }
+
+  ensure(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  serialize(): {|dir: FilePath|} {
+    return {
+      dir: this.dir,
+    };
+  }
+
+  static deserialize(opts: {|dir: FilePath|}): LMDBLiteCache {
+    return new LMDBLiteCache(opts.dir);
+  }
+
+  has(key: string): Promise<boolean> {
+    return Promise.resolve(this.store.get(key) != null);
+  }
+
+  get<T>(key: string): Promise<?T> {
+    let data = this.store.get(key);
+    if (data == null) {
+      return Promise.resolve(null);
+    }
+
+    return Promise.resolve(deserialize(data));
+  }
+
+  async set(key: string, value: mixed): Promise<void> {
+    await this.setBlob(key, serialize(value));
+  }
+
+  getStream(key: string): Readable {
+    return this.fs.createReadStream(path.join(this.dir, key));
+  }
+
+  setStream(key: string, stream: Readable): Promise<void> {
+    return pipeline(
+      stream,
+      this.fs.createWriteStream(path.join(this.dir, key)),
+    );
+  }
+
+  getBlob(key: string): Promise<Buffer> {
+    try {
+      return Promise.resolve(this.getBlobSync(key));
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  }
+
+  getBlobSync(key: string): Buffer {
+    const buffer = this.store.get(key);
+    if (buffer == null) {
+      throw new Error(`Key ${key} not found in cache`);
+    }
+    return buffer;
+  }
+
+  async setBlob(key: string, contents: Buffer | string): Promise<void> {
+    await this.store.put(key, contents);
+  }
+
+  getBuffer(key: string): Promise<?Buffer> {
+    return Promise.resolve(this.store.get(key));
+  }
+
+  #getFilePath(key: string, index: number): string {
+    return path.join(this.dir, `${key}-${index}`);
+  }
+
+  hasLargeBlob(key: string): Promise<boolean> {
+    return this.fs.exists(this.#getFilePath(key, 0));
+  }
+
+  // eslint-disable-next-line require-await
+  async getLargeBlob(key: string): Promise<Buffer> {
+    return this.fsCache.getLargeBlob(key);
+  }
+
+  // eslint-disable-next-line require-await
+  async setLargeBlob(
+    key: string,
+    contents: Buffer | string,
+    options?: {|signal?: AbortSignal|},
+  ): Promise<void> {
+    return this.fsCache.setLargeBlob(key, contents, options);
+  }
+
+  deleteLargeBlob(key: string): Promise<void> {
+    return this.fsCache.deleteLargeBlob(key);
+  }
+
+  refresh(): void {
+    // Reset the read transaction for the store. This guarantees that
+    // the next read will see the latest changes to the store.
+    // Useful in scenarios where reads and writes are multi-threaded.
+    // See https://github.com/kriszyp/lmdb-js#resetreadtxn-void
+    this.store.resetReadTxn();
+  }
+}
+
+registerSerializableClass(
+  `${packageJson.version}:LMDBLiteCache`,
+  LMDBLiteCache,
+);

--- a/packages/core/cache/src/index.js
+++ b/packages/core/cache/src/index.js
@@ -1,5 +1,6 @@
 // @flow
 export type {Cache} from './types';
 export * from './LMDBCache';
+export * from './LMDBLiteCache';
 export * from './FSCache';
 export * from './IDBCache';

--- a/packages/core/cache/test/LMDBLiteCache.test.js
+++ b/packages/core/cache/test/LMDBLiteCache.test.js
@@ -1,0 +1,32 @@
+import * as path from 'node:path';
+import {tmpdir} from 'os';
+import {LMDBLiteCache} from '../src/index';
+import {deserialize, serialize} from 'node:v8';
+import assert from 'node:assert';
+
+const cacheDir = path.join(tmpdir(), 'lmdb-lite-cache-tests');
+
+describe('LMDBLiteCache', () => {
+  it('can be constructed', async () => {
+    const cache = new LMDBLiteCache(cacheDir);
+    await cache.ensure();
+  });
+
+  it('can retrieve keys', async () => {
+    const cache = new LMDBLiteCache(cacheDir);
+    await cache.ensure();
+    await cache.setBlob('key', Buffer.from(serialize({value: 42})));
+    const buffer = await cache.getBlob('key');
+    const result = deserialize(buffer);
+    assert.equal(result.value, 42);
+  });
+
+  it('can retrieve keys synchronously', async () => {
+    const cache = new LMDBLiteCache(cacheDir);
+    await cache.ensure();
+    cache.setBlob('key', Buffer.from(serialize({value: 42})));
+    const buffer = cache.getBlobSync('key');
+    const result = deserialize(buffer);
+    assert.equal(result.value, 42);
+  });
+});

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -154,3 +154,43 @@ declare export class ResolverOld {
   resolveAsync(options: ResolveOptions): Promise<ResolveResult>;
   getInvalidations(path: string): JsInvalidations;
 }
+
+export interface LmdbOptions {
+  /** The database directory path */
+  path: string;
+  /**
+   * If enabled, the database writer will set the following flags:
+   *
+   * * MAP_ASYNC - "use asynchronous msync when MDB_WRITEMAP is used"
+   * * NO_SYNC - "don't fsync after commit"
+   * * NO_META_SYNC - "don't fsync metapage after commit"
+   *
+   * `MDB_WRITEMAP` is on by default.
+   */
+  asyncWrites: boolean;
+  /**
+   * The mmap size, this corresponds to [`mdb_env_set_mapsize`](http://www.lmdb.tech/doc/group__mdb.html#gaa2506ec8dab3d969b0e609cd82e619e5)
+   * if this isn't set it'll default to around 10MB.
+   */
+  mapSize?: number;
+}
+
+export interface LmdbEntry {
+  key: string;
+  value: Buffer;
+}
+
+declare export class Lmdb {
+  constructor(options: LmdbOptions): Lmdb;
+  get(key: string): Promise<Buffer | null | void>;
+  getSync(key: string): Buffer | null;
+  getManySync(keys: Array<string>): Array<Buffer | void | null>;
+  putMany(entries: Array<LmdbEntry>): Promise<void>;
+  put(key: string, data: Buffer): Promise<void>;
+  putNoConfirm(key: string, data: Buffer): void;
+  startReadTransaction(): void;
+  commitReadTransaction(): void;
+  startWriteTransaction(): Promise<void>;
+  commitWriteTransaction(): Promise<void>;
+  close(): void;
+}


### PR DESCRIPTION
Adds vendored LMDB parcel cache implementation.

The goal is to replace the LMDB cache back-end. There's no need for other implementation changing defaults for now.