### PR TITLE
[V3] Use string ids

### DIFF
--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -248,7 +248,7 @@ impl AssetGraphBuilder {
       .insert(request_id, asset_node_index);
 
     // Connect dependencies of the Asset
-    let mut unique_deps: IndexMap<u64, Dependency> = IndexMap::new();
+    let mut unique_deps: IndexMap<String, Dependency> = IndexMap::new();
 
     for mut dependency in dependencies {
       unique_deps

--- a/crates/atlaspack_core/src/asset_graph.rs
+++ b/crates/atlaspack_core/src/asset_graph.rs
@@ -266,13 +266,6 @@ impl AssetGraph {
 
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SerializedAsset {
-  id: String,
-  asset: Asset,
-}
-
-#[derive(serde::Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct SerializedDependency {
   id: String,
   dependency: Dependency,
@@ -292,18 +285,13 @@ impl serde::Serialize for AssetGraph {
         AssetGraphNode::Asset(idx) => {
           let asset = self.assets[*idx].asset.clone();
 
-          SerializedAssetGraphNode::Asset {
-            value: SerializedAsset {
-              id: asset.id.to_string(),
-              asset,
-            },
-          }
+          SerializedAssetGraphNode::Asset { value: asset }
         }
         AssetGraphNode::Dependency(idx) => {
           let dependency = self.dependencies[*idx].dependency.clone();
           SerializedAssetGraphNode::Dependency {
             value: SerializedDependency {
-              id: dependency.id().to_string(),
+              id: dependency.id(),
               dependency: dependency.as_ref().clone(),
             },
             has_deferred: self.dependencies[*idx].state == DependencyState::Deferred,
@@ -324,7 +312,7 @@ impl serde::Serialize for AssetGraph {
       Root,
       Entry,
       Asset {
-        value: SerializedAsset,
+        value: Asset,
       },
       Dependency {
         value: SerializedDependency,

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -53,7 +53,7 @@ fn create_asset_id(
   pipeline: &Option<String>,
   query: &Option<String>,
   unique_key: &Option<String>,
-) -> u64 {
+) -> String {
   let mut hasher = crate::hash::IdentifierHasher::default();
 
   env.hash(&mut hasher);
@@ -62,7 +62,8 @@ fn create_asset_id(
   query.hash(&mut hasher);
   unique_key.hash(&mut hasher);
 
-  hasher.finish()
+  // Ids must be 16 characters for scope hoisting to replace imports correctly in REPLACEMENT_RE
+  format!("{:016x}", hasher.finish())
 }
 
 /// An asset is a file or part of a file that may represent any data type including source code, binary data, etc.
@@ -74,7 +75,7 @@ fn create_asset_id(
 pub struct Asset {
   /// The main identify hash for the asset. It is consistent for the entire
   /// build and between builds.
-  pub id: u64,
+  pub id: String,
 
   /// Controls which bundle the asset is placed into
   pub bundle_behavior: BundleBehavior,

--- a/crates/atlaspack_core/src/types/dependency.rs
+++ b/crates/atlaspack_core/src/types/dependency.rs
@@ -153,10 +153,11 @@ impl Dependency {
     }
   }
 
-  pub fn id(&self) -> u64 {
+  pub fn id(&self) -> String {
     let mut hasher = crate::hash::IdentifierHasher::default();
     self.hash(&mut hasher);
-    hasher.finish()
+    // Ids must be 16 characters for scope hoisting to replace imports correctly in REPLACEMENT_RE
+    format!("{:016x}", hasher.finish())
   }
 
   pub fn set_placeholder(&mut self, placeholder: impl Into<serde_json::Value>) {

--- a/crates/atlaspack_core/src/types/environment/engines.rs
+++ b/crates/atlaspack_core/src/types/environment/engines.rs
@@ -10,11 +10,11 @@ use super::OutputFormat;
 /// The engines field in package.json
 #[derive(Clone, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct Engines {
+  pub atlaspack: Option<Version>,
   #[serde(default)]
   pub browsers: Browsers,
   pub electron: Option<Version>,
   pub node: Option<Version>,
-  pub atlaspack: Option<Version>,
 }
 
 /// List of environment features that may be supported by an engine

--- a/crates/atlaspack_plugin_transformer_js/src/transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/transformer.rs
@@ -249,7 +249,7 @@ mod test {
     let asset_2 = create_asset("mock_path", "function helloButDifferent() {}");
 
     // This nº should not change across runs / compilation
-    assert_eq!(asset_1.id, 6312461515062137255);
+    assert_eq!(asset_1.id, "579a5e4d979a51a7");
     assert_eq!(asset_1.id, asset_2.id);
   }
 
@@ -268,7 +268,7 @@ mod test {
           code: Arc::new(Code::from(String::from("function hello() {}\n"))),
           symbols: vec![],
           has_symbols: true,
-          unique_key: Some(format!("{:016x}", target_asset.id)),
+          unique_key: Some(target_asset.id.clone()),
           ..target_asset
         },
         dependencies: vec![],
@@ -285,7 +285,7 @@ exports.hello = function() {};
     "#;
 
     let target_asset = create_asset("mock_path.js", source_code);
-    let asset_id = target_asset.id;
+    let asset_id = target_asset.id.clone();
     let result = run_test(target_asset).unwrap();
 
     let mut expected_dependencies = vec![Dependency {
@@ -301,7 +301,7 @@ exports.hello = function() {};
         },
       }),
       placeholder: Some("e83f3db3d6f57ea6".to_string()),
-      source_asset_id: Some(asset_id.to_string()),
+      source_asset_id: Some(asset_id.clone()),
       source_path: Some(PathBuf::from("mock_path.js")),
       specifier: String::from("other"),
       specifier_type: SpecifierType::CommonJS,
@@ -321,7 +321,7 @@ exports.hello = function() {};
       result,
       TransformResult {
         asset: Asset {
-          id: asset_id,
+          id: asset_id.clone(),
           file_path: "mock_path.js".into(),
           file_type: FileType::Js,
           // SWC inserts a newline here
@@ -355,12 +355,12 @@ exports.hello = function() {};
             Symbol {
               exported: String::from("*"),
               loc: None,
-              local: format!("${}$exports", asset_id),
+              local: format!("${asset_id}$exports"),
               ..Default::default()
             }
           ],
           has_symbols: true,
-          unique_key: Some(format!("{:016x}", asset_id)),
+          unique_key: Some(asset_id),
           ..empty_asset()
         },
         dependencies: expected_dependencies,

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -124,6 +124,7 @@ function getAssetGraph(serializedGraph, options) {
   let cachedAssets = new Map();
   let changedAssets = new Map();
   let entry = 0;
+
   for (let node of serializedGraph.nodes) {
     if (node.type === 'root') {
       let index = graph.addNodeByContentKey('@@root', {
@@ -142,13 +143,13 @@ function getAssetGraph(serializedGraph, options) {
         value: null,
       });
     } else if (node.type === 'asset') {
-      let id = node.value.id;
-      let asset = node.value.asset;
+      let asset = node.value;
+      let id = asset.id;
+
       asset.meta.id = id;
 
       asset = {
         ...asset,
-        id,
         env: {
           ...asset.env,
           sourceType: sourceTypeLookup[asset.env.sourceType],

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1272,10 +1272,8 @@ describe('javascript', function () {
     let b = await bundle(
       path.join(__dirname, '/integration/globals/multiple.js'),
       {
-        mode: 'production',
         defaultTargetOptions: {
           shouldScopeHoist: true,
-          shouldOptimize: false,
         },
       },
     );


### PR DESCRIPTION
## Motivation

We must use string ids that are 16 characters long, otherwise we may produce invalid bundles when the ids are less than 16 characters. This issue occurs during scope hoisting, as it will no longer replace dependencies from the hardcoded string lengths `{16,20}` specified in the `REPLACEMENT_RE` [regex](https://github.com/atlassian-labs/atlaspack/blob/main/packages/packagers/js/src/ScopeHoistingPackager.js#L40). This is the underlying reason why the integration tests in https://github.com/atlassian-labs/atlaspack/pull/36 were failing.

## Changes

Replace `u64` with `String` for both asset and dependency ids

## Checklist

- [x] Existing or new tests cover this change
