### PR TITLE
Add no-op importCond API

### DIFF
--- a/packages/core/conditional-import-types/index.d.ts
+++ b/packages/core/conditional-import-types/index.d.ts
@@ -5,6 +5,8 @@ type ErrorMessage =
 type ConditionalImport<CondT, CondF> = CondT | CondF;
 
 /**
+ * **IMPORTANT: This API is currently a no-op. Do not use until this message is removed.**
+ *
  * Conditionally import a dependency, based on the specified condition.
  *
  * This is a synchronous import that differs from conditionally loading a dynamic import (`import()`)

--- a/packages/core/conditional-import-types/index.d.ts
+++ b/packages/core/conditional-import-types/index.d.ts
@@ -1,0 +1,26 @@
+type ModuleRef<_> = string;
+type ErrorMessage =
+  "You must annotate type with \"<typeof import('a'), typeof import('b')>\"";
+
+type ConditionalImport<CondT, CondF> = CondT | CondF;
+
+/**
+ * Conditionally import a dependency, based on the specified condition.
+ *
+ * This is a synchronous import that differs from conditionally loading a dynamic import (`import()`)
+ *
+ * This function requires server to guarantee the dependency is loaded.
+ *
+ * @param condition Condition evaluated by the server
+ * @param ifTrueDependency Dependency returned if the condition is true
+ * @param ifFalseDependency Dependency returned if the condition is false
+ */
+declare function importCond<CondT, CondF>(
+  condition: string,
+  ifTrueDependency: CondT extends void ? ErrorMessage : ModuleRef<CondT>,
+  ifFalseDependency: CondF extends void ? ErrorMessage : ModuleRef<CondF>,
+): CondT extends void
+  ? never
+  : CondF extends void
+  ? never
+  : ConditionalImport<CondT, CondF>;

--- a/packages/core/conditional-import-types/package.json
+++ b/packages/core/conditional-import-types/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@atlaspack/conditional-import-types",
+  "version": "2.12.0",
+  "license": "MIT",
+  "types": "index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/atlaspack.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -12,6 +12,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   importRetry: false,
   fastNeedsDefaultInterop: false,
   ownedResolverStructures: false,
+  conditionalBundlingApi: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -25,4 +25,10 @@ export type FeatureFlags = {|
    * Enable resolver refactor into owned data structures.
    */
   ownedResolverStructures: boolean,
+  /**
+   * Enables an experimental "conditional bundling" API - this allows the use of `importCond` syntax
+   * in order to have (consumer) feature flag driven bundling. This feature is very experimental,
+   * and requires server-side support.
+   */
+  conditionalBundlingApi: boolean,
 |};

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "express": "*",
-    "@atlaspack/cli": "^2.12.0"
+    "@atlaspack/cli": "^2.12.0",
+    "@types/react-dom": "^17.0.2"
   }
 }

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@atlaspack/conditional-bundling-example",
+  "version": "2.12.0",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "build:on": "atlaspack build --feature-flag conditionalBundlingApi=true src/index.html",
+    "build:off": "atlaspack build --feature-flag conditionalBundlingApi=false src/index.html",
+    "build:inspect:on": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --feature-flag conditionalBundlingApi=true src/index.html",
+    "build:inspect:off": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --feature-flag conditionalBundlingApi=false src/index.html",
+    "dev:on": "yarn build:on && npx nodemon serve.js",
+    "dev:off": "yarn build:off && npx nodemon serve.js"
+  },
+  "dependencies": {
+    "@atlaskit/button": "*",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
+  },
+  "devDependencies": {
+    "express": "*",
+    "@atlaspack/cli": "^2.12.0"
+  }
+}

--- a/packages/examples/conditional-bundling/serve.js
+++ b/packages/examples/conditional-bundling/serve.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const FEATURES = {
+  'my.feature': true,
+  'feature.async.condition': true,
+  'feature.ui': true,
+};
+
+const app = express();
+
+app.get('/', (req, res, next) => {
+  const manifest = JSON.parse(
+    fs.readFileSync('dist/conditional-manifest.json', 'utf8'),
+  );
+  let index = fs.readFileSync('dist/index.html', 'utf-8');
+  const scripts = [];
+  for (const [feature, state] of Object.entries(FEATURES)) {
+    const featureManifest = manifest[feature];
+    if (!featureManifest) continue;
+    for (const asset of featureManifest[
+      state ? 'ifTrueBundles' : 'ifFalseBundles'
+    ]) {
+      const script = `<script type="module" src="/${path.relative(
+        'dist/',
+        asset,
+      )}"></script>`;
+      scripts.push(script);
+    }
+  }
+  const pos = index.indexOf('<script');
+  index = `${index.slice(0, pos)}<script>window.__conditions = ${JSON.stringify(
+    FEATURES,
+  )}</script>${scripts.join('\n')}${index.slice(pos)}`;
+  index.slice(pos);
+  res.contentType = 'text/html';
+  res.send(index);
+});
+app.use(express.static('dist'));
+app.listen(3000, () => {
+  console.log('Server is running on http://localhost:3000');
+});

--- a/packages/examples/conditional-bundling/src/async-feature-disabled.ts
+++ b/packages/examples/conditional-bundling/src/async-feature-disabled.ts
@@ -1,0 +1,3 @@
+const Feature = () => 'The feature is DISABLED';
+export default Feature;
+export const add = (a: number, b: number) => a + b;

--- a/packages/examples/conditional-bundling/src/async-feature-enabled.ts
+++ b/packages/examples/conditional-bundling/src/async-feature-enabled.ts
@@ -1,0 +1,3 @@
+const Feature = () => 'The feature is ENABLED';
+
+export default Feature;

--- a/packages/examples/conditional-bundling/src/feature-disabled.ts
+++ b/packages/examples/conditional-bundling/src/feature-disabled.ts
@@ -1,2 +1,2 @@
-export const Feature = () => 'The feature is DISABLED';
+export default () => 'The feature is DISABLED';
 export const add = (a, b) => a + b;

--- a/packages/examples/conditional-bundling/src/feature-disabled.ts
+++ b/packages/examples/conditional-bundling/src/feature-disabled.ts
@@ -1,0 +1,2 @@
+export const Feature = () => 'The feature is DISABLED';
+export const add = (a, b) => a + b;

--- a/packages/examples/conditional-bundling/src/feature-enabled.ts
+++ b/packages/examples/conditional-bundling/src/feature-enabled.ts
@@ -1,1 +1,1 @@
-export const Feature = () => 'The feature is ENABLED';
+export default () => 'The feature is ENABLED';

--- a/packages/examples/conditional-bundling/src/feature-enabled.ts
+++ b/packages/examples/conditional-bundling/src/feature-enabled.ts
@@ -1,0 +1,1 @@
+export const Feature = () => 'The feature is ENABLED';

--- a/packages/examples/conditional-bundling/src/feature-ui-disabled.tsx
+++ b/packages/examples/conditional-bundling/src/feature-ui-disabled.tsx
@@ -1,0 +1,3 @@
+export function Component() {
+    return <button>No fancy</button>;
+}

--- a/packages/examples/conditional-bundling/src/feature-ui-disabled.tsx
+++ b/packages/examples/conditional-bundling/src/feature-ui-disabled.tsx
@@ -1,3 +1,3 @@
-export function Component() {
-    return <button>No fancy</button>;
+export default function Component() {
+  return <button>No fancy</button>;
 }

--- a/packages/examples/conditional-bundling/src/feature-ui-enabled.tsx
+++ b/packages/examples/conditional-bundling/src/feature-ui-enabled.tsx
@@ -1,6 +1,6 @@
-import Button from '@atlaskit/button';
+import Button from '@atlaskit/button/new';
 import React from 'react';
 
-export function Component() {
+export default function Component() {
   return <Button>Hello button</Button>;
 }

--- a/packages/examples/conditional-bundling/src/feature-ui-enabled.tsx
+++ b/packages/examples/conditional-bundling/src/feature-ui-enabled.tsx
@@ -1,0 +1,6 @@
+import Button from '@atlaskit/button';
+import React from 'react';
+
+export function Component() {
+  return <Button>Hello button</Button>;
+}

--- a/packages/examples/conditional-bundling/src/index.html
+++ b/packages/examples/conditional-bundling/src/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Conditional bundling demo</title>
+  </head>
+  <body>
+    <div id="container"></div>
+    <script type="module" src="./index.tsx"></script>
+  </body>
+</html>

--- a/packages/examples/conditional-bundling/src/index.tsx
+++ b/packages/examples/conditional-bundling/src/index.tsx
@@ -3,11 +3,11 @@ import ReactDOM from 'react-dom';
 import RegularExport from './regular-import';
 console.log(RegularExport);
 
-const feature = importCond<
+const Feature = importCond<
   typeof import('./feature-enabled'),
   typeof import('./feature-disabled')
 >('my.feature', './feature-enabled', './feature-disabled');
-const featureWithUI = importCond<
+const FeatureWithUI = importCond<
   typeof import('./feature-ui-enabled'),
   typeof import('./feature-ui-disabled')
 >('feature.ui', './feature-ui-enabled', './feature-ui-disabled');
@@ -24,15 +24,15 @@ function LazyComponentContainer() {
 const App = () => {
   const [showLazyComponent, setShowLazyComponent] = useState(false);
 
-  console.log(feature, featureWithUI);
+  console.log(Feature, FeatureWithUI);
   return (
     <div>
       <p>Hello from React</p>
       <button onClick={() => setShowLazyComponent(!showLazyComponent)}>
         Toggle lazy component
       </button>
-      <p>Conditional Feature: {feature.Feature()}</p>
-      <featureWithUI.Component />
+      <p>Conditional Feature: {Feature()}</p>
+      <FeatureWithUI />
       {showLazyComponent ? <LazyComponentContainer /> : null}
     </div>
   );

--- a/packages/examples/conditional-bundling/src/index.tsx
+++ b/packages/examples/conditional-bundling/src/index.tsx
@@ -1,0 +1,41 @@
+import React, {lazy, Suspense, useState} from 'react';
+import ReactDOM from 'react-dom';
+import RegularExport from './regular-import';
+console.log(RegularExport);
+
+const feature = importCond<
+  typeof import('./feature-enabled'),
+  typeof import('./feature-disabled')
+>('my.feature', './feature-enabled', './feature-disabled');
+const featureWithUI = importCond<
+  typeof import('./feature-ui-enabled'),
+  typeof import('./feature-ui-disabled')
+>('feature.ui', './feature-ui-enabled', './feature-ui-disabled');
+
+const LazyComponent = lazy(() => import('./lazy-component'));
+function LazyComponentContainer() {
+  return (
+    <Suspense fallback={<p>Loading...</p>}>
+      <LazyComponent />
+    </Suspense>
+  );
+}
+
+const App = () => {
+  const [showLazyComponent, setShowLazyComponent] = useState(false);
+
+  console.log(feature, featureWithUI);
+  return (
+    <div>
+      <p>Hello from React</p>
+      <button onClick={() => setShowLazyComponent(!showLazyComponent)}>
+        Toggle lazy component
+      </button>
+      <p>Conditional Feature: {feature.Feature()}</p>
+      <featureWithUI.Component />
+      {showLazyComponent ? <LazyComponentContainer /> : null}
+    </div>
+  );
+};
+
+ReactDOM.render(<App />, document.getElementById('container'));

--- a/packages/examples/conditional-bundling/src/lazy-component.tsx
+++ b/packages/examples/conditional-bundling/src/lazy-component.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import Button from '@atlaskit/button';
+
+export default function LazyComponent() {
+  return (
+    <p>
+      This is a lazy component. It has a button. <Button>Lazy button</Button>
+    </p>
+  );
+}

--- a/packages/examples/conditional-bundling/src/regular-dynamic-import.ts
+++ b/packages/examples/conditional-bundling/src/regular-dynamic-import.ts
@@ -1,0 +1,11 @@
+export const DynamicExport = () => 'This is a DynamicExport';
+export const DynamicExportWithCondition = () => {
+  return importCond<
+    typeof import('./async-feature-enabled'),
+    typeof import('./async-feature-disabled')
+  >(
+    'feature.async.condition',
+    './async-feature-enabled.ts',
+    './async-feature-disabled.ts',
+  ).Feature();
+};

--- a/packages/examples/conditional-bundling/src/regular-import.ts
+++ b/packages/examples/conditional-bundling/src/regular-import.ts
@@ -1,0 +1,1 @@
+export default 'Regular Export';

--- a/packages/examples/conditional-bundling/tsconfig.json
+++ b/packages/examples/conditional-bundling/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "jsx": "react",
+    "typeRoots": ["./types.d.ts"],
+    "esModuleInterop": true,
+    "lib": ["ESNext", "DOM"]
+  }
+}

--- a/packages/examples/conditional-bundling/types.d.ts
+++ b/packages/examples/conditional-bundling/types.d.ts
@@ -1,0 +1,1 @@
+import '@atlaspack/conditional-import-types';

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -127,6 +127,7 @@ pub struct Config {
   pub is_swc_helpers: bool,
   pub standalone: bool,
   pub inline_constants: bool,
+  pub conditional_bundling: bool,
 }
 
 #[derive(Serialize, Debug, Default)]

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -459,6 +459,7 @@ export default (new Transformer({
       is_swc_helpers: /@swc[/\\]helpers/.test(asset.filePath),
       standalone: asset.query.has('standalone'),
       inline_constants: config.inlineConstants,
+      conditional_bundling: options.featureFlags.conditionalBundlingApi,
       callMacro: asset.isSource
         ? async (err, src, exportName, args, loc) => {
             let mod;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2823,6 +2823,13 @@
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"
   integrity sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==
 
+"@types/react-dom@^17.0.2":
+  version "17.0.25"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.25.tgz#e0e5b3571e1069625b3a3da2b279379aa33a0cb5"
+  integrity sha512-urx7A7UxkZQmThYA4So0NelOVjx3V4rNFVJwp0WZlbIK5eM4rNJDiN3R/E9ix0MBh6kAEojk/9YL+Te6D9zHNA==
+  dependencies:
+    "@types/react" "^17"
+
 "@types/react@^17":
   version "17.0.76"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.76.tgz#bfdf762046699e265655cd8f67a51beab6cd1e80"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Add the conditional bundling API. By adding the API outside of the feature flag, we can start with simple no-op behaviour (making the return value the false branch of the condition). I'll follow up with iterative PRs to add the conditional behaviour behind the feature flag.

## Changes

New import called `importCond` which (when implemented) will allow developers to conditionally load _sync_ dependencies based on the result of the condition param.
