### PR TITLE
[V3] Add inline string transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "atlaspack_package_manager",
  "atlaspack_plugin_resolver",
  "atlaspack_plugin_rpc",
+ "atlaspack_plugin_transformer_inline_string",
  "atlaspack_plugin_transformer_js",
  "dyn-hash",
  "indexmap 2.2.6",
@@ -414,6 +415,14 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "serde",
+]
+
+[[package]]
+name = "atlaspack_plugin_transformer_inline_string"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atlaspack_core",
 ]
 
 [[package]]

--- a/crates/atlaspack/Cargo.toml
+++ b/crates/atlaspack/Cargo.toml
@@ -13,6 +13,7 @@ atlaspack_core = { path = "../atlaspack_core" }
 atlaspack_filesystem = { path = "../atlaspack_filesystem" }
 atlaspack_package_manager = { path = "../atlaspack_package_manager" }
 atlaspack_plugin_resolver = { path = "../atlaspack_plugin_resolver" }
+atlaspack_plugin_transformer_inline_string = { path = "../atlaspack_plugin_transformer_inline_string" }
 atlaspack_plugin_transformer_js = { path = "../atlaspack_plugin_transformer_js" }
 atlaspack_plugin_rpc = { path = "../atlaspack_plugin_rpc" }
 atlaspack-resolver = { path = "../../packages/utils/node-resolver-rs" }

--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -29,6 +29,7 @@ use atlaspack_plugin_rpc::plugin::RpcResolverPlugin;
 use atlaspack_plugin_rpc::plugin::RpcRuntimePlugin;
 use atlaspack_plugin_rpc::plugin::RpcTransformerPlugin;
 use atlaspack_plugin_rpc::RpcWorkerRef;
+use atlaspack_plugin_transformer_inline_string::AtlaspackInlineStringTransformerPlugin;
 use atlaspack_plugin_transformer_js::AtlaspackJsTransformerPlugin;
 
 use super::Plugins;
@@ -207,6 +208,13 @@ impl Plugins for ConfigPlugins {
 
       if transformer.package_name == "@atlaspack/transformer-js" {
         transformers.push(Box::new(AtlaspackJsTransformerPlugin::new(&self.ctx)?));
+        continue;
+      }
+
+      if transformer.package_name == "@atlaspack/transformer-inline-string" {
+        transformers.push(Box::new(AtlaspackInlineStringTransformerPlugin::new(
+          &self.ctx,
+        )?));
         continue;
       }
 

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -153,7 +153,11 @@ impl AssetGraphBuilder {
         query,
         can_defer,
       } => {
-        if !side_effects && can_defer && requested_symbols.is_empty() && dependency.has_symbols {
+        if !side_effects
+          && can_defer
+          && requested_symbols.is_empty()
+          && !dependency.symbols.is_none()
+        {
           *state = DependencyState::Deferred;
           return;
         }
@@ -260,7 +264,13 @@ impl AssetGraphBuilder {
           // dependencies post-transform but that needs further investigation to
           // resolve and understand...
           d.meta.append(&mut dependency.meta);
-          d.symbols.extend(dependency.symbols.clone());
+          if let Some(symbols) = d.symbols.as_mut() {
+            if let Some(merge_symbols) = dependency.symbols.as_ref() {
+              symbols.extend(merge_symbols.clone());
+            }
+          } else {
+            d.symbols = dependency.symbols.clone();
+          }
         })
         .or_insert(dependency.clone());
     }

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -107,7 +107,7 @@ pub struct Asset {
   pub stats: AssetStats,
 
   /// The symbols that the asset exports
-  pub symbols: Vec<Symbol>,
+  pub symbols: Option<Vec<Symbol>>,
 
   /// A unique key that identifies an asset
   ///
@@ -161,10 +161,6 @@ pub struct Asset {
   /// export const MY_CONSTANT = 'some-value';
   /// ```
   pub is_constant_module: bool,
-
-  /// True if `Asset::symbols` has been populated. This field is deprecated and should be phased
-  /// out.
-  pub has_symbols: bool,
 }
 
 impl Asset {
@@ -190,14 +186,15 @@ impl Asset {
     let is_source = !file_path.ancestors().any(|p| p.ends_with("/node_modules"));
 
     Ok(Self {
-      id: create_asset_id(&env, &file_path, &pipeline, &query, &None),
-      file_path,
-      env,
       code: Arc::new(code),
-      side_effects,
+      id: create_asset_id(&env, &file_path, &pipeline, &query, &None),
+      env,
+      file_path,
       file_type,
       is_bundle_splittable: true,
       is_source,
+      pipeline,
+      side_effects,
       ..Asset::default()
     })
   }
@@ -220,6 +217,7 @@ impl Asset {
     self.meta.insert("shouldWrap".into(), value.into());
     self.should_wrap = value;
   }
+
   pub fn set_is_constant_module(&mut self, is_constant_module: bool) {
     self.is_constant_module = is_constant_module;
     if is_constant_module {

--- a/crates/atlaspack_core/src/types/dependency.rs
+++ b/crates/atlaspack_core/src/types/dependency.rs
@@ -78,7 +78,7 @@ pub struct Dependency {
   ///
   /// We might want to split this information from this type.
   #[serde(default)]
-  pub symbols: Vec<Symbol>,
+  pub symbols: Option<Vec<Symbol>>,
 
   /// The target associated with an entry, if any
   #[serde(default)]
@@ -109,31 +109,27 @@ pub struct Dependency {
   /// import expression.
   pub is_esm: bool,
 
-  /// Whether the symbols vector of this dependency has had symbols added to it.
-  pub has_symbols: bool,
-
   pub placeholder: Option<String>,
 }
 
 impl Dependency {
   pub fn entry(entry: String, target: Target) -> Dependency {
     let is_library = target.env.is_library;
-    let mut symbols = Vec::new();
+    let mut symbols = None;
 
     if is_library {
-      symbols.push(Symbol {
+      symbols = Some(vec![Symbol {
         exported: "*".into(),
         is_esm_export: false,
         is_weak: true,
         loc: None,
         local: "*".into(),
         self_referenced: false,
-      });
+      }]);
     }
 
     Dependency {
       env: target.env.clone(),
-      has_symbols: is_library,
       is_entry: true,
       needs_stable_name: true,
       specifier: entry,
@@ -202,7 +198,7 @@ impl Hash for Dependency {
     self.package_conditions.hash(state);
     self.pipeline.hash(state);
     self.priority.hash(state);
-    self.source_path.hash(state);
+    self.source_asset_id.hash(state);
     self.specifier.hash(state);
     self.specifier_type.hash(state);
   }

--- a/crates/atlaspack_plugin_transformer_inline_string/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_inline_string/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "atlaspack_plugin_transformer_inline_string"
+version = "0.1.0"
+edition = "2021"
+description = "Inline String Transformer Plugin for the Atlaspack Bundler"
+
+[dependencies]
+atlaspack_core = { path = "../atlaspack_core" }
+
+anyhow = "1"

--- a/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
@@ -1,0 +1,33 @@
+use anyhow::Error;
+use atlaspack_core::plugin::TransformResult;
+use atlaspack_core::plugin::{PluginContext, TransformerPlugin};
+use atlaspack_core::types::{Asset, BundleBehavior};
+
+#[derive(Debug)]
+pub struct AtlaspackInlineStringTransformerPlugin {}
+
+impl AtlaspackInlineStringTransformerPlugin {
+  pub fn new(_ctx: &PluginContext) -> Result<Self, Error> {
+    Ok(AtlaspackInlineStringTransformerPlugin {})
+  }
+}
+
+impl TransformerPlugin for AtlaspackInlineStringTransformerPlugin {
+  fn transform(&mut self, asset: Asset) -> Result<TransformResult, Error> {
+    let mut asset = asset.clone();
+
+    asset.bundle_behavior = BundleBehavior::Inline;
+    asset
+      .meta
+      .insert(String::from("inlineType"), "string".into());
+
+    Ok(TransformResult {
+      asset,
+      dependencies: Vec::new(),
+      invalidate_on_file_change: Vec::new(),
+    })
+  }
+}
+
+#[cfg(test)]
+mod test {}

--- a/crates/atlaspack_plugin_transformer_inline_string/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_inline_string/src/lib.rs
@@ -1,0 +1,3 @@
+pub use inline_string_transformer::AtlaspackInlineStringTransformerPlugin;
+
+mod inline_string_transformer;

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -369,8 +369,7 @@ mod test {
           file_type: FileType::Js,
           // SWC inserts a newline here
           code: Arc::new(Code::from(String::from("function hello() {}\n"))),
-          symbols: vec![],
-          has_symbols: true,
+          symbols: Some(Vec::new()),
           unique_key: Some(target_asset.id.clone()),
           ..target_asset
         },
@@ -408,12 +407,12 @@ exports.hello = function() {};
       source_path: Some(PathBuf::from("mock_path.js")),
       specifier: String::from("other"),
       specifier_type: SpecifierType::CommonJS,
-      symbols: vec![Symbol {
+      symbols: Some(vec![Symbol {
         exported: String::from("*"),
         loc: None,
         local: String::from("$other$"),
         ..Symbol::default()
-      }],
+      }]),
       ..Default::default()
     }];
     expected_dependencies[0].set_placeholder("e83f3db3d6f57ea6");
@@ -431,7 +430,7 @@ exports.hello = function() {};
           code: Arc::new(Code::from(String::from(
             "var x = require(\"e83f3db3d6f57ea6\");\nexports.hello = function() {};\n"
           ))),
-          symbols: vec![
+          symbols: Some(vec![
             Symbol {
               exported: String::from("hello"),
               loc: Some(SourceLocation {
@@ -461,8 +460,7 @@ exports.hello = function() {};
               local: format!("${asset_id}$exports"),
               ..Default::default()
             }
-          ],
-          has_symbols: true,
+          ]),
           unique_key: Some(asset_id),
           ..empty_asset()
         },

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -186,9 +186,8 @@ function getAssetGraph(serializedGraph, options) {
         committed: true,
         contentKey: id,
         filePath: toProjectPath(options.projectRoot, asset.filePath),
-        symbols: asset.hasSymbols
-          ? new Map(asset.symbols.map(mapSymbols))
-          : null,
+        symbols:
+          asset.symbols != null ? new Map(asset.symbols.map(mapSymbols)) : null,
       };
 
       cachedAssets.set(id, asset.code);
@@ -217,16 +216,6 @@ function getAssetGraph(serializedGraph, options) {
         bundleBehavior:
           dependency.bundleBehavior === 255 ? null : dependency.bundleBehavior,
         contentKey: id,
-        sourcePath: dependency.sourcePath
-          ? toProjectPath(options.projectRoot, dependency.sourcePath)
-          : null,
-        symbols:
-          // Dependency.symbols are always set to an empty map when scope hoisting
-          // is enabled. Some tests will fail if this is not the case. We should
-          // make this consistant when we re-visit packaging.
-          dependency.hasSymbols || dependency.env.shouldScopeHoist
-            ? new Map(dependency.symbols.map(mapSymbols))
-            : undefined,
         loc: dependency.loc
           ? {
               ...dependency.loc,
@@ -236,6 +225,16 @@ function getAssetGraph(serializedGraph, options) {
               ),
             }
           : undefined,
+        sourcePath: dependency.sourcePath
+          ? toProjectPath(options.projectRoot, dependency.sourcePath)
+          : null,
+        symbols:
+          // Dependency.symbols are always set to an empty map when scope hoisting
+          // is enabled. Some tests will fail if this is not the case. We should
+          // make this consistant when we re-visit packaging.
+          dependency.symbols != null || dependency.env.shouldScopeHoist
+            ? new Map(dependency.symbols?.map(mapSymbols))
+            : undefined,
       };
       let usedSymbolsDown = new Set();
       let usedSymbolsUp = new Map();

--- a/packages/core/integration-tests/test/bundle-text.js
+++ b/packages/core/integration-tests/test/bundle-text.js
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import {join} from 'path';
 import {
   assertBundles,
   bundle,
@@ -10,13 +11,13 @@ import {
   run,
 } from '@atlaspack/test-utils';
 
-describe.v2('bundle-text:', function () {
+describe('bundle-text:', function () {
   beforeEach(async () => {
     await removeDistDirectory();
   });
 
-  it('inlines and compiles a css bundle', async () => {
-    await fsFixture(overlayFS)`
+  it.v2('inlines and compiles a css bundle', async () => {
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         import cssText from 'bundle-text:./styles.css';
         export default cssText;
@@ -33,7 +34,7 @@ describe.v2('bundle-text:', function () {
         }
     `;
 
-    let b = await bundle('index.js', {inputFS: overlayFS});
+    let b = await bundle(join(__dirname, 'index.js'), {inputFS: overlayFS});
 
     assertBundles(b, [
       {
@@ -68,8 +69,8 @@ describe.v2('bundle-text:', function () {
     assert(!cssBundleContent.includes('sourceMappingURL'));
   });
 
-  it('inlines and compiles a html bundle', async () => {
-    await fsFixture(overlayFS)`
+  it.v2('inlines and compiles a html bundle', async () => {
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         import html from 'bundle-text:./index.html';
         export default html;
@@ -79,7 +80,7 @@ describe.v2('bundle-text:', function () {
         <script>console.log('test')</script>
     `;
 
-    let b = await bundle('index.js', {
+    let b = await bundle(join(__dirname, 'index.js'), {
       inputFS: overlayFS,
     });
 
@@ -91,7 +92,7 @@ describe.v2('bundle-text:', function () {
   });
 
   it('inlines and compiles a javascript bundle', async () => {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         import jsText from 'bundle-text:./main.js';
         export default jsText;
@@ -103,7 +104,7 @@ describe.v2('bundle-text:', function () {
         import './log';
     `;
 
-    let b = await bundle('index.js', {
+    let b = await bundle(join(__dirname, 'index.js'), {
       inputFS: overlayFS,
     });
 
@@ -120,8 +121,8 @@ describe.v2('bundle-text:', function () {
     assert.deepEqual(logs, []);
   });
 
-  it('inlines and compiles a bundle using a dynamic import', async () => {
-    await fsFixture(overlayFS)`
+  it.v2('inlines and compiles a bundle using a dynamic import', async () => {
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         export default import('bundle-text:./styles.css');
 
@@ -137,7 +138,7 @@ describe.v2('bundle-text:', function () {
         }
     `;
 
-    let b = await bundle('index.js', {inputFS: overlayFS});
+    let b = await bundle(join(__dirname, 'index.js'), {inputFS: overlayFS});
 
     let promise = (await run(b)).default;
     assert.equal(typeof promise.then, 'function');
@@ -158,4 +159,111 @@ describe.v2('bundle-text:', function () {
 
     assert(!cssBundleContent.includes('sourceMappingURL'));
   });
+
+  for (const scopeHoist of [false, true]) {
+    describe(`when scope hoisting is ${
+      scopeHoist ? 'enabled' : 'disabled'
+    }`, () => {
+      let options = scopeHoist
+        ? {
+            defaultTargetOptions: {
+              isLibrary: true,
+              outputFormat: 'esmodule',
+              shouldScopeHoist: true,
+            },
+          }
+        : {};
+
+      it('can be used with an import that points to the same asset', async function () {
+        await fsFixture(overlayFS, __dirname)`
+          index.js:
+            import Test from './main';
+            import jsText from 'bundle-text:./main';
+
+            // Workaround bug with exports of symbols with bailouts...
+            const t = jsText;
+            export { Test, t as jsText };
+
+          main.js:
+            export default class Test {};
+
+          package.json: {}
+        `;
+
+        let b = await bundle(join(__dirname, 'index.js'), {
+          inputFS: overlayFS,
+          ...options,
+        });
+
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: [
+              'index.js',
+              'main.js',
+              !scopeHoist && 'esmodule-helpers.js',
+            ].filter(Boolean),
+          },
+          {
+            type: 'js',
+            assets: scopeHoist
+              ? ['main.js']
+              : ['main.js', 'esmodule-helpers.js'],
+          },
+        ]);
+
+        let res = await run(b);
+        assert.equal(typeof res.Test, 'function');
+        assert.equal(typeof res.jsText, 'string');
+      });
+
+      it('can be used with a dynamic import that points to the same asset', async function () {
+        await fsFixture(overlayFS, __dirname)`
+          index.js:
+            import text from 'bundle-text:./main';
+
+            export const lazy = import('./main').then(({ default: Test }) => Test);
+            export const jsText = text;
+
+          main.js:
+            export default class Test {};
+        `;
+
+        let b = await bundle(join(__dirname, 'index.js'), {
+          inputFS: overlayFS,
+          ...options,
+        });
+
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: scopeHoist
+              ? ['index.js']
+              : [
+                  'index.js',
+                  'esmodule-helpers.js',
+                  'bundle-url.js',
+                  'cacheLoader.js',
+                  'js-loader.js',
+                ],
+          },
+          {
+            type: 'js',
+            assets: ['main.js'],
+          },
+          {
+            type: 'js',
+            assets: scopeHoist
+              ? ['main.js']
+              : ['main.js', 'esmodule-helpers.js'],
+          },
+        ]);
+
+        let res = await run(b);
+        assert.equal(typeof res.lazy, 'object');
+        assert.equal(typeof (await res.lazy), 'function');
+        assert.equal(typeof res.jsText, 'string');
+      });
+    });
+  }
 });

--- a/packages/core/integration-tests/test/integration/multiple-import-types/dynamic-inline.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/dynamic-inline.js
@@ -1,4 +1,0 @@
-import t from 'bundle-text:./other';
-
-export const lazy = import('./other').then(({default: LazyFoo}) => LazyFoo);
-export const text = t;

--- a/packages/core/integration-tests/test/integration/multiple-import-types/static-inline.js
+++ b/packages/core/integration-tests/test/integration/multiple-import-types/static-inline.js
@@ -1,6 +1,0 @@
-import Foo from './other';
-import text from 'bundle-text:./other';
-
-// Get around bug with exports of symbols with bailouts...
-const t = text;
-export {Foo, t as text};

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -21,7 +21,6 @@ import {
   outputFS,
   inputFS,
   fsFixture,
-  isAtlaspackV3,
 } from '@atlaspack/test-utils';
 import {makeDeferredWithPromise, normalizePath} from '@atlaspack/utils';
 import Logger from '@atlaspack/logger';
@@ -3404,22 +3403,19 @@ describe('javascript', function () {
     assert.deepEqual(res, {a: 4});
   });
 
-  it.v2(
-    'should not use arrow functions for reexport declarations unless supported',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, 'integration/js-export-arrow-support/index.js'),
-        {
-          // Remove comments containing "=>"
-          defaultTargetOptions: {
-            shouldOptimize: true,
-          },
+  it('should not use arrow functions for reexport declarations unless supported', async function () {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-export-arrow-support/index.js'),
+      {
+        // Remove comments containing "=>"
+        defaultTargetOptions: {
+          shouldOptimize: true,
         },
-      );
-      let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-      assert(!content.includes('=>'));
-    },
-  );
+      },
+    );
+    let content = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+    assert(!content.includes('=>'));
+  });
 
   it('should support import namespace declarations of other ES modules', async function () {
     let b = await bundle(
@@ -3690,39 +3686,36 @@ describe('javascript', function () {
     assert.equal(await res, true);
   });
 
-  it.v2(
-    'should support runtime module deduplication with scope hoisting',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, 'integration/js-runtime-dedup/index.js'),
-        {
-          mode: 'production',
-        },
-      );
+  it('should support runtime module deduplication with scope hoisting', async function () {
+    let b = await bundle(
+      path.join(__dirname, 'integration/js-runtime-dedup/index.js'),
+      {
+        mode: 'production',
+      },
+    );
 
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: [
-            'index.js',
-            'bundle-url.js',
-            'cacheLoader.js',
-            'js-loader.js',
-            'bundle-manifest.js',
-          ],
-        },
-        {
-          assets: ['async1.js', 'shared.js'],
-        },
-        {
-          assets: ['async2.js', 'shared.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'index.js',
+          'bundle-url.js',
+          'cacheLoader.js',
+          'js-loader.js',
+          'bundle-manifest.js',
+        ],
+      },
+      {
+        assets: ['async1.js', 'shared.js'],
+      },
+      {
+        assets: ['async2.js', 'shared.js'],
+      },
+    ]);
 
-      let res = await run(b);
-      assert.equal(await res, true);
-    },
-  );
+    let res = await run(b);
+    assert.equal(await res, true);
+  });
 
   it.v2(
     'should remap locations in diagnostics using the input source map',
@@ -4097,36 +4090,33 @@ describe('javascript', function () {
       assert.equal(res.Foo, await res.LazyFoo);
     });
 
-    it.v2(
-      'supports both static and dynamic imports to the same specifier in the same file with scope hoisting',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/static-dynamic.js',
-          ),
-          {
-            defaultTargetOptions: {
-              outputFormat: 'esmodule',
-              isLibrary: true,
-              shouldScopeHoist: true,
-            },
+    it('supports both static and dynamic imports to the same specifier in the same file with scope hoisting', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-dynamic.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
           },
-        );
+        },
+      );
 
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: ['static-dynamic.js', 'other.js'],
-          },
-        ]);
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-dynamic.js', 'other.js'],
+        },
+      ]);
 
-        let res = await run(b);
-        assert.equal(typeof res.Foo, 'function');
-        assert.equal(typeof res.LazyFoo, 'object');
-        assert.equal(res.Foo, await res.LazyFoo);
-      },
-    );
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.LazyFoo, 'object');
+      assert.equal(res.Foo, await res.LazyFoo);
+    });
 
     it('supports static, dynamic, and url to the same specifier in the same file', async function () {
       let b = await bundle(
@@ -4164,44 +4154,41 @@ describe('javascript', function () {
       );
     });
 
-    it.v2(
-      'supports static, dynamic, and url to the same specifier in the same file with scope hoisting',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/static-dynamic-url.js',
-          ),
-          {
-            defaultTargetOptions: {
-              outputFormat: 'esmodule',
-              isLibrary: true,
-              shouldScopeHoist: true,
-            },
+    it('supports static, dynamic, and url to the same specifier in the same file with scope hoisting', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/static-dynamic-url.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
           },
-        );
+        },
+      );
 
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: ['static-dynamic-url.js', 'other.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js'],
-          },
-        ]);
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['static-dynamic-url.js', 'other.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+      ]);
 
-        let res = await run(b);
-        assert.equal(typeof res.Foo, 'function');
-        assert.equal(typeof res.LazyFoo, 'object');
-        assert.equal(res.Foo, await res.LazyFoo);
-        assert.equal(
-          res.url,
-          'http://localhost/' + path.basename(b.getBundles()[1].filePath),
-        );
-      },
-    );
+      let res = await run(b);
+      assert.equal(typeof res.Foo, 'function');
+      assert.equal(typeof res.LazyFoo, 'object');
+      assert.equal(res.Foo, await res.LazyFoo);
+      assert.equal(
+        res.url,
+        'http://localhost/' + path.basename(b.getBundles()[1].filePath),
+      );
+    });
 
     it('supports dynamic import and url to the same specifier in the same file', async function () {
       let b = await bundle(
@@ -4236,181 +4223,40 @@ describe('javascript', function () {
       );
     });
 
-    it.v2(
-      'supports dynamic import and url to the same specifier in the same file with scope hoisting',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/dynamic-url.js',
-          ),
-          {
-            defaultTargetOptions: {
-              outputFormat: 'esmodule',
-              isLibrary: true,
-              shouldScopeHoist: true,
-            },
+    it('supports dynamic import and url to the same specifier in the same file with scope hoisting', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/multiple-import-types/dynamic-url.js',
+        ),
+        {
+          defaultTargetOptions: {
+            outputFormat: 'esmodule',
+            isLibrary: true,
+            shouldScopeHoist: true,
           },
-        );
+        },
+      );
 
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: ['dynamic-url.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js'],
-          },
-        ]);
+      assertBundles(b, [
+        {
+          type: 'js',
+          assets: ['dynamic-url.js'],
+        },
+        {
+          type: 'js',
+          assets: ['other.js'],
+        },
+      ]);
 
-        let res = await run(b);
-        assert.equal(typeof res.lazy, 'object');
-        assert.equal(typeof (await res.lazy), 'function');
-        assert.equal(
-          res.url,
-          'http://localhost/' + path.basename(b.getBundles()[1].filePath),
-        );
-      },
-    );
-
-    it.v2(
-      'supports static import and inline bundle for the same asset',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/static-inline.js',
-          ),
-        );
-
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: ['static-inline.js', 'other.js', 'esmodule-helpers.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js', 'esmodule-helpers.js'],
-          },
-        ]);
-
-        let res = await run(b);
-        assert.equal(typeof res.Foo, 'function');
-        assert.equal(typeof res.text, 'string');
-      },
-    );
-
-    it.v2(
-      'supports static import and inline bundle for the same asset with scope hoisting',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/static-inline.js',
-          ),
-          {
-            defaultTargetOptions: {
-              outputFormat: 'esmodule',
-              isLibrary: true,
-              shouldScopeHoist: true,
-            },
-          },
-        );
-
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: ['static-inline.js', 'other.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js'],
-          },
-        ]);
-
-        let res = await run(b);
-        assert.equal(typeof res.Foo, 'function');
-        assert.equal(typeof res.text, 'string');
-      },
-    );
-
-    it.v2(
-      'supports dynamic import and inline bundle for the same asset',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/dynamic-inline.js',
-          ),
-        );
-
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: [
-              'dynamic-inline.js',
-              'esmodule-helpers.js',
-              'bundle-url.js',
-              'cacheLoader.js',
-              'js-loader.js',
-            ],
-          },
-          {
-            type: 'js',
-            assets: ['other.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js', 'esmodule-helpers.js'],
-          },
-        ]);
-
-        let res = await run(b);
-        assert.equal(typeof res.lazy, 'object');
-        assert.equal(typeof (await res.lazy), 'function');
-        assert.equal(typeof res.text, 'string');
-      },
-    );
-
-    it.v2(
-      'supports dynamic import and inline bundle for the same asset with scope hoisting',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/multiple-import-types/dynamic-inline.js',
-          ),
-          {
-            defaultTargetOptions: {
-              outputFormat: 'esmodule',
-              isLibrary: true,
-              shouldScopeHoist: true,
-            },
-          },
-        );
-
-        assertBundles(b, [
-          {
-            type: 'js',
-            assets: ['dynamic-inline.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js'],
-          },
-          {
-            type: 'js',
-            assets: ['other.js'],
-          },
-        ]);
-
-        let res = await run(b);
-        assert.equal(typeof res.lazy, 'object');
-        assert.equal(typeof (await res.lazy), 'function');
-        assert.equal(typeof res.text, 'string');
-      },
-    );
+      let res = await run(b);
+      assert.equal(typeof res.lazy, 'object');
+      assert.equal(typeof (await res.lazy), 'function');
+      assert.equal(
+        res.url,
+        'http://localhost/' + path.basename(b.getBundles()[1].filePath),
+      );
+    });
   });
 
   it('should avoid creating a bundle for lazy dependencies already available in a shared bundle', async function () {
@@ -5060,11 +4906,6 @@ describe('javascript', function () {
             // A different dependency order, but this is deemed acceptable as it's sideeffect free
             assert.deepEqual(calls, ['foo', 'key', 'index']);
           }
-        } else if (isAtlaspackV3) {
-          // Native AssetGraph doesn't skip the unused asset when
-          // transforming. We may choose to add this later, but it's not
-          // functionally broken.
-          assert.deepEqual(calls, ['key', 'foo', 'bar', 'types', 'index']);
         } else {
           assert.deepEqual(calls, ['key', 'foo', 'types', 'index']);
         }
@@ -5555,13 +5396,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        // Native AssetGraph doesn't skip the unused asset when
-        // transforming. We may choose to add this later, but it's not
-        // functionally broken.
-        let expectedCalls =
-          isAtlaspackV3 && !usesSymbolPropagation
-            ? ['other', 'index']
-            : ['index'];
+        let expectedCalls = ['index'];
 
         assert.deepEqual(calls, expectedCalls);
         assert.deepEqual(res.output, 'Message 1');
@@ -5877,12 +5712,7 @@ describe('javascript', function () {
           {require: false},
         );
 
-        // Native AssetGraph doesn't skip the unused asset when
-        // transforming. We may choose to add this later, but it's not
-        // functionally broken.
-        let devCalls = isAtlaspackV3
-          ? ['esm1', 'other', 'esm2', 'index']
-          : ['esm1', 'index'];
+        let devCalls = ['esm1', 'index'];
 
         assert.deepEqual(calls, shouldScopeHoist ? ['esm1'] : devCalls);
         assert.deepEqual(res.output, 'Message 1');


### PR DESCRIPTION
## Motivation

Some tests fail because we do not have an inline string transformer. These changes port the transformer to Rust and fix some pre-existing bugs that were highlighted with the change.

## Changes

* Add `atlaspack_plugin_transformer_inline_string` crate
* Update plugins to use the rust inline string transformer when `@atlaspack/transformer-inline-string` is encountered
* Add missing `pipeline` to assets
* Add in missing `bundle_behavior` to dependencies
* Remove `has_symbols` in favour of `Option<Vec<Symbol>>` since there were a lot of inconsistencies and bugs around when it was set
* Use `source_asset_id` instead of `source_asset_path` for the hash to match v2
* Enable some `bundle-text:` tests, and refactor a couple from the JavaScript suite into here

## Checklist

- [x] Existing or new tests cover this change
