### PR TITLE
[V3] Add json transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "atlaspack_plugin_rpc",
  "atlaspack_plugin_transformer_inline_string",
  "atlaspack_plugin_transformer_js",
+ "atlaspack_plugin_transformer_json",
  "atlaspack_plugin_transformer_raw",
  "dyn-hash",
  "indexmap 2.2.6",
@@ -441,6 +442,18 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "swc_core",
+]
+
+[[package]]
+name = "atlaspack_plugin_transformer_json"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atlaspack_core",
+ "atlaspack_filesystem",
+ "json",
+ "json5",
+ "serde_json",
 ]
 
 [[package]]
@@ -1834,6 +1847,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]

--- a/crates/atlaspack/Cargo.toml
+++ b/crates/atlaspack/Cargo.toml
@@ -15,6 +15,7 @@ atlaspack_package_manager = { path = "../atlaspack_package_manager" }
 atlaspack_plugin_resolver = { path = "../atlaspack_plugin_resolver" }
 atlaspack_plugin_transformer_inline_string = { path = "../atlaspack_plugin_transformer_inline_string" }
 atlaspack_plugin_transformer_js = { path = "../atlaspack_plugin_transformer_js" }
+atlaspack_plugin_transformer_json = { path = "../atlaspack_plugin_transformer_json" }
 atlaspack_plugin_transformer_raw = { path = "../atlaspack_plugin_transformer_raw" }
 atlaspack_plugin_rpc = { path = "../atlaspack_plugin_rpc" }
 atlaspack-resolver = { path = "../../packages/utils/node-resolver-rs" }

--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -31,6 +31,7 @@ use atlaspack_plugin_rpc::plugin::RpcTransformerPlugin;
 use atlaspack_plugin_rpc::RpcWorkerRef;
 use atlaspack_plugin_transformer_inline_string::AtlaspackInlineStringTransformerPlugin;
 use atlaspack_plugin_transformer_js::AtlaspackJsTransformerPlugin;
+use atlaspack_plugin_transformer_json::AtlaspackJsonTransformerPlugin;
 use atlaspack_plugin_transformer_raw::AtlaspackRawTransformerPlugin;
 
 use super::Plugins;
@@ -221,6 +222,11 @@ impl Plugins for ConfigPlugins {
 
       if transformer.package_name == "@atlaspack/transformer-raw" {
         transformers.push(Box::new(AtlaspackRawTransformerPlugin::new(&self.ctx)?));
+        continue;
+      }
+
+      if transformer.package_name == "@atlaspack/transformer-json" {
+        transformers.push(Box::new(AtlaspackJsonTransformerPlugin::new(&self.ctx)?));
         continue;
       }
 

--- a/crates/atlaspack_plugin_transformer_json/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_json/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "atlaspack_plugin_transformer_json"
+version = "0.1.0"
+edition = "2021"
+description = "Json transformer plugin for the Atlaspack Bundler"
+
+[dependencies]
+atlaspack_core = { path = "../atlaspack_core" }
+
+anyhow = "1"
+json = "0.12.4"
+json5 = "0.4.1"
+serde_json = "1.0.116"
+
+[dev-dependencies]
+atlaspack_filesystem = { path = "../atlaspack_filesystem" }

--- a/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
@@ -1,0 +1,144 @@
+use std::sync::Arc;
+
+use anyhow::Error;
+use atlaspack_core::plugin::TransformResult;
+use atlaspack_core::plugin::{PluginContext, TransformerPlugin};
+use atlaspack_core::types::{Asset, Code, FileType};
+
+#[derive(Debug)]
+pub struct AtlaspackJsonTransformerPlugin {}
+
+impl AtlaspackJsonTransformerPlugin {
+  pub fn new(_ctx: &PluginContext) -> Result<Self, Error> {
+    Ok(AtlaspackJsonTransformerPlugin {})
+  }
+}
+
+impl TransformerPlugin for AtlaspackJsonTransformerPlugin {
+  fn transform(&mut self, asset: Asset) -> Result<TransformResult, Error> {
+    let mut asset = asset.clone();
+
+    let code = std::str::from_utf8(asset.code.bytes())?;
+    let code = json5::from_str::<serde_json::Value>(code)?;
+    let code = json5::to_string(&code)?;
+    let code = json::stringify(code);
+
+    asset.code = Arc::new(Code::from(format!("module.exports = JSON.parse({code});")));
+    asset.file_type = FileType::Js;
+
+    Ok(TransformResult {
+      asset,
+      dependencies: Vec::new(),
+      invalidate_on_file_change: Vec::new(),
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{path::PathBuf, sync::Arc};
+
+  use atlaspack_core::{
+    config_loader::ConfigLoader,
+    plugin::{PluginLogger, PluginOptions},
+  };
+  use atlaspack_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  fn create_json_plugin() -> AtlaspackJsonTransformerPlugin {
+    let file_system = Arc::new(InMemoryFileSystem::default());
+
+    AtlaspackJsonTransformerPlugin::new(&PluginContext {
+      config: Arc::new(ConfigLoader {
+        fs: file_system.clone(),
+        project_root: PathBuf::default(),
+        search_path: PathBuf::default(),
+      }),
+      file_system,
+      logger: PluginLogger::default(),
+      options: Arc::new(PluginOptions::default()),
+    })
+    .expect("Expected json transformer to initialize")
+  }
+
+  #[test]
+  fn returns_js_asset_from_json() {
+    let mut plugin = create_json_plugin();
+
+    let asset = Asset {
+      code: Arc::new(Code::from(
+        r#"
+          {
+            "a": "b",
+            "c": {
+              "d": true,
+              "e": 1
+            }
+          }
+        "#
+        .to_string(),
+      )),
+      file_type: FileType::Json,
+      ..Asset::default()
+    };
+
+    assert_eq!(
+      plugin.transform(asset).map_err(|e| e.to_string()),
+      Ok(TransformResult {
+        asset: Asset {
+          code: Arc::new(Code::from(
+            r#"module.exports = JSON.parse("{\"a\":\"b\",\"c\":{\"d\":true,\"e\":1}}");"#
+              .to_string()
+          )),
+          file_type: FileType::Js,
+          ..Asset::default()
+        },
+        dependencies: Vec::new(),
+        invalidate_on_file_change: Vec::new()
+      })
+    );
+  }
+
+  #[test]
+  fn returns_js_asset_from_json5() {
+    let mut plugin = create_json_plugin();
+
+    let asset = Asset {
+      code: Arc::new(Code::from(
+        r#"
+          /* start */
+          {
+            // leading
+            "a": "b",
+            "c": {
+              "d": true, // inline
+              "e": 1,
+            },
+            /* trailing */
+          }
+          /* end */
+        "#
+        .to_string(),
+      )),
+      file_type: FileType::Json,
+      ..Asset::default()
+    };
+
+    assert_eq!(
+      plugin.transform(asset).map_err(|e| e.to_string()),
+      Ok(TransformResult {
+        asset: Asset {
+          code: Arc::new(Code::from(
+            r#"module.exports = JSON.parse("{\"a\":\"b\",\"c\":{\"d\":true,\"e\":1}}");"#
+              .to_string()
+          )),
+          file_type: FileType::Js,
+          ..Asset::default()
+        },
+        dependencies: Vec::new(),
+        invalidate_on_file_change: Vec::new()
+      })
+    );
+  }
+}

--- a/crates/atlaspack_plugin_transformer_json/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_json/src/lib.rs
@@ -1,0 +1,3 @@
+pub use json_transformer::AtlaspackJsonTransformerPlugin;
+
+mod json_transformer;

--- a/packages/core/integration-tests/test/json.js
+++ b/packages/core/integration-tests/test/json.js
@@ -13,13 +13,13 @@ import {
   run,
 } from '@atlaspack/test-utils';
 
-describe.v2('json', function () {
+describe('json', function () {
   beforeEach(async () => {
     await removeDistDirectory();
   });
 
   it('files can be required in JavaScript', async function () {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         const test = require('./test.json');
 
@@ -34,7 +34,7 @@ describe.v2('json', function () {
         }
     `;
 
-    let b = await bundle('index.js', {inputFS: overlayFS});
+    let b = await bundle(join(__dirname, 'index.js'), {inputFS: overlayFS});
 
     assertBundles(b, [
       {
@@ -49,14 +49,14 @@ describe.v2('json', function () {
   });
 
   it('files are minified', async function () {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.json:
         {
           "test": "test"
         }
     `;
 
-    let b = await bundle('index.json', {
+    let b = await bundle(join(__dirname, 'index.json'), {
       defaultTargetOptions: {
         shouldOptimize: true,
         shouldScopeHoist: false,
@@ -65,7 +65,7 @@ describe.v2('json', function () {
     });
 
     let json = await outputFS.readFile(join(distDir, 'index.js'), 'utf8');
-    assert(json.includes('{"test":"test"}'));
+    assert(json.includes(`JSON.parse('{"test":"test"}')`));
 
     let output = await run(b);
     assert.deepEqual(output, {test: 'test'});

--- a/packages/core/integration-tests/test/json5.js
+++ b/packages/core/integration-tests/test/json5.js
@@ -13,13 +13,13 @@ import {
   removeDistDirectory,
 } from '@atlaspack/test-utils';
 
-describe.v2('json5', function () {
+describe('json5', function () {
   beforeEach(async () => {
     await removeDistDirectory();
   });
 
   it('files can be required in JavaScript', async function () {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         const test = require('./test.json5');
 
@@ -38,7 +38,7 @@ describe.v2('json5', function () {
         /* end */
     `;
 
-    let b = await bundle('index.js', {inputFS: overlayFS});
+    let b = await bundle(join(__dirname, 'index.js'), {inputFS: overlayFS});
 
     assertBundles(b, [
       {
@@ -53,7 +53,7 @@ describe.v2('json5', function () {
   });
 
   it('files are minified', async function () {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.json5:
         /*
          * comment
@@ -64,7 +64,7 @@ describe.v2('json5', function () {
         /* end */
     `;
 
-    let b = await bundle(join('index.json5'), {
+    let b = await bundle(join(__dirname, 'index.json5'), {
       defaultTargetOptions: {
         shouldOptimize: true,
         shouldScopeHoist: false,
@@ -73,7 +73,7 @@ describe.v2('json5', function () {
     });
 
     let json = await outputFS.readFile(join(distDir, 'index.js'), 'utf8');
-    assert(json.includes('{"test":"test"}'));
+    assert(json.includes(`JSON.parse('{"test":"test"}')`));
 
     let output = await run(b);
     assert.deepEqual(output, {test: 'test'});


### PR DESCRIPTION
## Motivation

These changes port the json transformer to Rust so that more functionality works in v3

## Changes

* Add `atlaspack_plugin_transformer_json` crate
* Use json transformer when `@atlaspack/transformer-json` is encountered
* Enable json and json5 integration tests

## Checklist

- [x] Existing or new tests cover this change
