### PR TITLE
Use tests as module name

### DIFF
--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -368,7 +368,7 @@ impl AssetGraphBuilder {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::path::{Path, PathBuf};
   use std::sync::Arc;
 

--- a/crates/atlaspack_core/src/asset_graph.rs
+++ b/crates/atlaspack_core/src/asset_graph.rs
@@ -354,7 +354,7 @@ impl std::hash::Hash for AssetGraph {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::path::PathBuf;
 
   use crate::types::{Symbol, Target};

--- a/crates/atlaspack_core/src/plugin/reporter_plugin/composite_reporter_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/reporter_plugin/composite_reporter_plugin.rs
@@ -53,7 +53,7 @@ impl ReporterPlugin for CompositeReporterPlugin {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use crate::plugin::reporter_plugin::MockReporterPlugin;
   use anyhow::anyhow;
 

--- a/crates/atlaspack_filesystem/src/in_memory_file_system.rs
+++ b/crates/atlaspack_filesystem/src/in_memory_file_system.rs
@@ -143,7 +143,7 @@ impl FileSystem for InMemoryFileSystem {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use super::*;
 
   #[test]

--- a/crates/atlaspack_filesystem/src/os_file_system/canonicalize.rs
+++ b/crates/atlaspack_filesystem/src/os_file_system/canonicalize.rs
@@ -84,7 +84,7 @@ pub fn canonicalize(path: &Path, cache: &FileSystemRealPathCache) -> std::io::Re
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use assert_fs::prelude::*;
 
   use super::*;

--- a/crates/atlaspack_monitoring/src/crash_reporter.rs
+++ b/crates/atlaspack_monitoring/src/crash_reporter.rs
@@ -116,7 +116,7 @@ fn try_to_connect_to_server(options: &CrashReporterOptions) -> anyhow::Result<Cl
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::env::temp_dir;
 
   use super::*;

--- a/crates/atlaspack_monitoring/src/sentry_integration.rs
+++ b/crates/atlaspack_monitoring/src/sentry_integration.rs
@@ -92,7 +92,7 @@ pub fn init_sentry(options: SentryOptions) -> anyhow::Result<ClientInitGuard> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use super::*;
 
   static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/atlaspack_monitoring/src/tracer.rs
+++ b/crates/atlaspack_monitoring/src/tracer.rs
@@ -109,7 +109,7 @@ impl Tracer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use super::*;
 
   static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
+++ b/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
@@ -403,7 +403,7 @@ fn should_include_node_module(include_node_modules: &IncludeNodeModules, name: &
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use super::*;
   use atlaspack_core::{
     config_loader::ConfigLoader,

--- a/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
@@ -30,7 +30,7 @@ impl TransformerPlugin for AtlaspackInlineStringTransformerPlugin {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::{path::PathBuf, sync::Arc};
 
   use atlaspack_core::{

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -308,7 +308,7 @@ impl TransformerPlugin for AtlaspackJsTransformerPlugin {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use pretty_assertions::assert_eq;
   use std::path::PathBuf;
 

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -638,7 +638,7 @@ fn convert_source_type(source_type: &Option<atlaspack_js_swc_core::SourceType>) 
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use crate::js_transformer::test_helpers::run_swc_core_transform;
 
   use super::*;

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion/dependency_kind.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion/dependency_kind.rs
@@ -37,7 +37,7 @@ pub(crate) fn convert_specifier_type(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use crate::js_transformer::test_helpers::run_swc_core_transform;
   use atlaspack_js_swc_core::DependencyKind;
 

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion/symbol.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion/symbol.rs
@@ -49,7 +49,7 @@ pub(crate) fn transformer_exported_symbol_into_symbol(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::path::PathBuf;
 
   use atlaspack_core::types::{Location, SourceLocation};

--- a/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
@@ -27,7 +27,7 @@ impl TransformerPlugin for AtlaspackRawTransformerPlugin {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::{path::PathBuf, sync::Arc};
 
   use atlaspack_core::{

--- a/crates/lmdb-js-lite/src/lib.rs
+++ b/crates/lmdb-js-lite/src/lib.rs
@@ -347,7 +347,7 @@ impl LMDB {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use super::*;
   use rand::random;
   use std::env::temp_dir;

--- a/crates/lmdb-js-lite/src/writer.rs
+++ b/crates/lmdb-js-lite/src/writer.rs
@@ -327,7 +327,7 @@ impl DatabaseWriter {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::env::temp_dir;
   use std::sync::mpsc::channel;
 

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -1469,7 +1469,7 @@ fn match_worker_type(expr: Option<&ast::ExprOrSpread>) -> (SourceType, Option<as
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use super::*;
   use crate::test_utils::{run_fold, RunTestContext, RunVisitResult};
   use crate::DependencyDescriptor;

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -350,7 +350,7 @@ impl<'a> EnvReplacer<'a> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use crate::test_utils::{run_visit, RunTestContext, RunVisitResult};
 
   use super::*;

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -205,7 +205,7 @@ impl GlobalReplacer<'_> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::path::Path;
 
   use swc_core::ecma::atoms::JsWord;

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -222,7 +222,7 @@ impl NodeReplacer<'_> {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use crate::test_utils::run_visit;
 
   use super::*;

--- a/packages/transformers/js/core/src/test_utils.rs
+++ b/packages/transformers/js/core/src/test_utils.rs
@@ -115,7 +115,7 @@ fn run_with_transformation<R>(
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use swc_core::ecma::ast::{Lit, Str};
   use swc_core::ecma::visit::VisitMut;
 

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -81,7 +81,7 @@ impl VisitMut for TypeofReplacer {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use crate::test_utils::run_visit;
 
   use super::*;

--- a/packages/utils/node-resolver-rs-old/src/url_to_path.rs
+++ b/packages/utils/node-resolver-rs-old/src/url_to_path.rs
@@ -33,7 +33,7 @@ fn os_str_from_bytes(slice: &[u8]) -> &OsStr {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::path::PathBuf;
 
   use url::Url;

--- a/packages/utils/node-resolver-rs/src/url_to_path.rs
+++ b/packages/utils/node-resolver-rs/src/url_to_path.rs
@@ -33,7 +33,7 @@ fn os_str_from_bytes(slice: &[u8]) -> &OsStr {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
   use std::path::PathBuf;
 
   use url::Url;


### PR DESCRIPTION
## Motivation

There are some inconsistencies in the test module name

## Changes

Standardise on `mod tests` for unit tests as noted in official Rust documentation

## Checklist

- [x] Existing or new tests cover this change
