### PR TITLE
Read RUST_LOG for std tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,8 +1389,8 @@ dependencies = [
  "aho-corasick",
  "bstr",
  "log",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
 ]
 
 [[package]]
@@ -1700,7 +1700,7 @@ dependencies = [
  "globset",
  "log",
  "memchr",
- "regex-automata",
+ "regex-automata 0.4.6",
  "same-file",
  "walkdir",
  "winapi-util",
@@ -1992,6 +1992,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -2974,8 +2983,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.6",
+ "regex-syntax 0.8.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -2986,8 +3004,14 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.3",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4733,10 +4757,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/crates/atlaspack_monitoring/Cargo.toml
+++ b/crates/atlaspack_monitoring/Cargo.toml
@@ -18,7 +18,7 @@ required-features = ["canary"]
 anyhow = "1.0.86"
 thiserror = "1.0.63"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 tracing-appender = "0.2.3"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_json = "1.0.122"

--- a/crates/atlaspack_monitoring/src/tracer.rs
+++ b/crates/atlaspack_monitoring/src/tracer.rs
@@ -7,6 +7,7 @@ use anyhow::anyhow;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::EnvFilter;
 
 use crate::from_env::{optional_var, FromEnvError};
 
@@ -70,9 +71,13 @@ impl Tracer {
   pub fn new(options: TracerMode) -> anyhow::Result<Self> {
     let worker_guard = match options {
       TracerMode::Stdout => {
-        tracing_subscriber::fmt().try_init().map_err(|err| {
-          anyhow::anyhow!(err).context("Failed to setup stdout tracing, is another tracer running?")
-        })?;
+        tracing_subscriber::fmt()
+          .with_env_filter(EnvFilter::from_default_env())
+          .try_init()
+          .map_err(|err| {
+            anyhow::anyhow!(err)
+              .context("Failed to setup stdout tracing, is another tracer running?")
+          })?;
         None
       }
       TracerMode::File {


### PR DESCRIPTION
## Motivation

The `tracing_subscriber` crate does not appear to output any logs unless a filter is specified. These changes apply a filter using the default env `RUST_LOG` so that it can be used like so:

```
ATLASPACK_TRACING_MODE=stdout RUST_LOG=debug yarn test:integration
```

## Changes

Add a filter to std tracing based on the default env

