### PR TITLE
[V3] Add image transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,6 +90,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 dependencies = [
  "backtrace",
+]
+
+[[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -131,6 +154,7 @@ dependencies = [
  "atlaspack_package_manager",
  "atlaspack_plugin_resolver",
  "atlaspack_plugin_rpc",
+ "atlaspack_plugin_transformer_image",
  "atlaspack_plugin_transformer_inline_string",
  "atlaspack_plugin_transformer_js",
  "atlaspack_plugin_transformer_json",
@@ -420,6 +444,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlaspack_plugin_transformer_image"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atlaspack_core",
+ "atlaspack_filesystem",
+ "image 0.25.2",
+ "url-search-params",
+]
+
+[[package]]
 name = "atlaspack_plugin_transformer_inline_string"
 version = "0.1.0"
 dependencies = [
@@ -483,6 +518,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "av1-grain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +595,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +614,12 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "bitstream-io"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b81e1519b0d82120d2fd469d5bfb2919a9361c48b02d82d04befc1cdd2002452"
 
 [[package]]
 name = "bitvec"
@@ -601,6 +671,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "built"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
+
+[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,6 +699,12 @@ name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -676,6 +758,16 @@ checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
 dependencies = [
  "jobserver",
  "libc",
+]
+
+[[package]]
+name = "cfg-expr"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d067ad48b8650848b989a59a86c6c36a995d02d2bf778d45c3c5d57bc2718f02"
+dependencies = [
+ "smallvec",
+ "target-lexicon",
 ]
 
 [[package]]
@@ -1178,6 +1270,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "exr"
+version = "1.72.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "887d93f60543e9a9362ef8a21beedd0a833c5d9610e18c67abe15a5963dcb1a4"
+dependencies = [
+ "bit_field",
+ "flume",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1230,6 +1338,15 @@ checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "spin",
 ]
 
 [[package]]
@@ -1363,6 +1480,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fb2d69b19215e18bb912fa30f7ce15846e301408695e44e0ef719f1da9e19f2"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1436,6 +1563,12 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "heed"
@@ -1720,6 +1853,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1747,6 +1919,17 @@ name = "indoc"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "ipnet"
@@ -1797,6 +1980,15 @@ dependencies = [
 
 [[package]]
 name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -1841,6 +2033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
 name = "js-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1880,6 +2078,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +2105,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e285aa6a046fd338b2592c16bee148b2b00789138ed6b7bb56bb13d585050d"
 dependencies = [
  "libdeflate-sys",
+]
+
+[[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1977,6 +2192,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "lz4_flex"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2001,6 +2225,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2315,6 +2548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,6 +2597,17 @@ version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -2493,7 +2743,7 @@ dependencies = [
  "clap 3.2.25",
  "crossbeam-channel",
  "filetime",
- "image",
+ "image 0.24.9",
  "indexmap 1.9.3",
  "itertools 0.10.5",
  "libdeflater",
@@ -2539,6 +2789,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-slash"
@@ -2844,6 +3100,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +3126,21 @@ checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -2935,6 +3225,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12a5a2d6c7039059af621472a4389be1215a816df61aa4d531cfe85264aee95f"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "simd_helpers",
+ "system-deps",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f0bfd976333248de2078d350bfdf182ff96e168a24d23d2436cef320dd4bdd"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rgb",
 ]
 
 [[package]]
@@ -3066,9 +3405,9 @@ dependencies = [
 
 [[package]]
 name = "rgb"
-version = "0.8.37"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05aaa8004b64fd573fc9d002f4e632d51ad4f026c2b5ba95fcb6c2f32c2c47d8"
+checksum = "57397d16646700483b67d2dd6511d79318f9d057fdbd21a4066aeac8b41d310a"
 dependencies = [
  "bytemuck",
 ]
@@ -3603,6 +3942,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +4027,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "st-map"
@@ -4474,10 +4825,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "system-deps"
+version = "6.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e535eb8dded36d55ec13eddacd30dec501792ff23a0b1682c38601b8cf2349"
+dependencies = [
+ "cfg-expr",
+ "heck",
+ "pkg-config",
+ "toml",
+ "version-compare",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
@@ -4540,6 +4910,17 @@ checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",
+]
+
+[[package]]
+name = "tiff"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1310fcea54c6a9a4fd1aad794ecc02c31682f6bfbecdf460bf19533eed1e3e"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -4912,12 +5293,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "url-search-params"
+version = "12.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4b5120022ae7548d0005c9e99f9a695a33bcd732deffb578f7e85516dbb7a6"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a183cf7feeba97b4dd1c0d46788634f6221d87fa961b305bed08c851829efcc0"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4943,6 +5341,12 @@ dependencies = [
  "regex",
  "rustversion",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
@@ -5071,6 +5475,12 @@ checksum = "b3de34ae270483955a94f4b21bdaaeb83d508bb84a01435f393818edb0012009"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "whoami"
@@ -5357,4 +5767,28 @@ dependencies = [
  "log",
  "simd-adler32",
  "typed-arena",
+]
+
+[[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
+dependencies = [
+ "zune-core",
 ]

--- a/crates/atlaspack/Cargo.toml
+++ b/crates/atlaspack/Cargo.toml
@@ -13,6 +13,7 @@ atlaspack_core = { path = "../atlaspack_core" }
 atlaspack_filesystem = { path = "../atlaspack_filesystem" }
 atlaspack_package_manager = { path = "../atlaspack_package_manager" }
 atlaspack_plugin_resolver = { path = "../atlaspack_plugin_resolver" }
+atlaspack_plugin_transformer_image = { path = "../atlaspack_plugin_transformer_image" }
 atlaspack_plugin_transformer_inline_string = { path = "../atlaspack_plugin_transformer_inline_string" }
 atlaspack_plugin_transformer_js = { path = "../atlaspack_plugin_transformer_js" }
 atlaspack_plugin_transformer_json = { path = "../atlaspack_plugin_transformer_json" }

--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -29,6 +29,7 @@ use atlaspack_plugin_rpc::plugin::RpcResolverPlugin;
 use atlaspack_plugin_rpc::plugin::RpcRuntimePlugin;
 use atlaspack_plugin_rpc::plugin::RpcTransformerPlugin;
 use atlaspack_plugin_rpc::RpcWorkerRef;
+use atlaspack_plugin_transformer_image::AtlaspackImageTransformerPlugin;
 use atlaspack_plugin_transformer_inline_string::AtlaspackInlineStringTransformerPlugin;
 use atlaspack_plugin_transformer_js::AtlaspackJsTransformerPlugin;
 use atlaspack_plugin_transformer_json::AtlaspackJsonTransformerPlugin;
@@ -217,6 +218,11 @@ impl Plugins for ConfigPlugins {
         transformers.push(Box::new(AtlaspackInlineStringTransformerPlugin::new(
           &self.ctx,
         )?));
+        continue;
+      }
+
+      if transformer.package_name == "@atlaspack/transformer-image" {
+        transformers.push(Box::new(AtlaspackImageTransformerPlugin::new(&self.ctx)?));
         continue;
       }
 

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -164,12 +164,12 @@ impl AssetGraphBuilder {
 
         *state = DependencyState::Resolved;
         AssetRequest {
-          file_path: path,
           code: code.clone(),
-          pipeline: pipeline.clone(),
-          side_effects,
           env: dependency.env.clone(),
+          file_path: path,
+          pipeline: pipeline.clone(),
           query,
+          side_effects,
         }
       }
       PathRequestOutput::Excluded => {

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -24,12 +24,12 @@ use super::RequestResult;
 /// - Finally, returns the complete Asset and it's discovered Dependencies
 #[derive(Clone, Debug, Hash, PartialEq)]
 pub struct AssetRequest {
+  pub code: Option<String>,
   pub env: Arc<Environment>,
   pub file_path: PathBuf,
-  pub code: Option<String>,
   pub pipeline: Option<String>,
-  pub side_effects: bool,
   pub query: Option<String>,
+  pub side_effects: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/atlaspack_core/src/types/file_type.rs
+++ b/crates/atlaspack_core/src/types/file_type.rs
@@ -8,14 +8,20 @@ use serde::Serialize;
 /// Defaults to `FileType::Js` for convenience.
 #[derive(Default, Debug, Clone, PartialEq, Hash)]
 pub enum FileType {
+  Avif,
   Css,
+  Gif,
   Html,
   #[default]
   Js,
   Json,
+  Jpeg,
+  Png,
   Jsx,
+  Tiff,
   Ts,
   Tsx,
+  WebP,
   Other(String),
 }
 
@@ -42,12 +48,18 @@ impl FileType {
   pub fn extension(&self) -> &str {
     match self {
       FileType::Js => "js",
-      FileType::Json => "json",
       FileType::Jsx => "jsx",
       FileType::Ts => "ts",
       FileType::Tsx => "tsx",
       FileType::Css => "css",
+      FileType::Json => "json",
+      FileType::Jpeg => "jpeg",
+      FileType::Png => "png",
+      FileType::Gif => "gif",
       FileType::Html => "html",
+      FileType::Avif => "avif",
+      FileType::Tiff => "tiff",
+      FileType::WebP => "webp",
       FileType::Other(s) => s.as_str(),
     }
   }
@@ -60,9 +72,17 @@ impl FileType {
       "jsx" => FileType::Jsx,
       "ts" => FileType::Ts,
       "tsx" => FileType::Tsx,
-      "json" => FileType::Json,
       "css" => FileType::Css,
+      "json" => FileType::Json,
+      "jpg" => FileType::Jpeg,
+      "jpeg" => FileType::Jpeg,
+      "png" => FileType::Png,
+      "gif" => FileType::Gif,
       "html" => FileType::Html,
+      "avif" => FileType::Avif,
+      "avifs" => FileType::Avif,
+      "tiff" => FileType::Tiff,
+      "webp" => FileType::WebP,
       ext => FileType::Other(ext.to_string()),
     }
   }

--- a/crates/atlaspack_filesystem/src/in_memory_file_system.rs
+++ b/crates/atlaspack_filesystem/src/in_memory_file_system.rs
@@ -107,6 +107,11 @@ impl FileSystem for InMemoryFileSystem {
     Ok(())
   }
 
+  fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+    let str = self.read_to_string(path)?;
+    Ok(str.as_bytes().to_vec())
+  }
+
   fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     let path = self.canonicalize_impl(path);
     let files = self.files.read().unwrap();

--- a/crates/atlaspack_filesystem/src/lib.rs
+++ b/crates/atlaspack_filesystem/src/lib.rs
@@ -60,6 +60,7 @@ pub trait FileSystem {
     ))
   }
 
+  fn read(&self, path: &Path) -> std::io::Result<Vec<u8>>;
   fn read_to_string(&self, path: &Path) -> std::io::Result<String>;
   fn is_file(&self, path: &Path) -> bool;
   fn is_dir(&self, path: &Path) -> bool;

--- a/crates/atlaspack_filesystem/src/os_file_system.rs
+++ b/crates/atlaspack_filesystem/src/os_file_system.rs
@@ -23,6 +23,10 @@ impl FileSystem for OsFileSystem {
     std::fs::create_dir_all(path)
   }
 
+  fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+    std::fs::read(path)
+  }
+
   fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     std::fs::read_to_string(path)
   }

--- a/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
+++ b/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
@@ -342,22 +342,23 @@ impl ResolverPlugin for AtlaspackResolver {
       .map_err(|err| self.to_diagnostic_error(&ctx.specifier, err))?;
 
     match resolution {
-      (atlaspack_resolver::Resolution::Path(path), _invalidations) => Ok(Resolved {
+      (atlaspack_resolver::Resolution::Path(path), query) => Ok(Resolved {
         invalidations: Vec::new(),
         resolution: Resolution::Resolved(ResolvedResolution {
           file_path: path,
+          query,
           side_effects,
           ..ResolvedResolution::default()
         }),
       }),
-      (atlaspack_resolver::Resolution::Builtin(builtin), _invalidations) => {
+      (atlaspack_resolver::Resolution::Builtin(builtin), _query) => {
         self.resolve_builtin(&ctx, builtin)
       }
       (atlaspack_resolver::Resolution::Empty, _invalidations) => Ok(Resolved {
         invalidations: Vec::new(),
         resolution: Resolution::Resolved(self.resolve_empty(side_effects)),
       }),
-      (atlaspack_resolver::Resolution::External, _invalidations) => {
+      (atlaspack_resolver::Resolution::External, _query) => {
         if let Some(_source_path) = &ctx.dependency.source_path {
           if ctx.dependency.env.is_library && ctx.dependency.specifier_type != SpecifierType::Url {
             todo!("check excluded dependency for libraries");
@@ -369,11 +370,12 @@ impl ResolverPlugin for AtlaspackResolver {
           resolution: Resolution::Excluded,
         })
       }
-      (atlaspack_resolver::Resolution::Global(global), _invalidations) => Ok(Resolved {
+      (atlaspack_resolver::Resolution::Global(global), query) => Ok(Resolved {
         invalidations: Vec::new(),
         resolution: Resolution::Resolved(ResolvedResolution {
           code: Some(format!("module.exports={};", global)),
           file_path: format!("{}.js", global).into(),
+          query,
           side_effects,
           ..ResolvedResolution::default()
         }),

--- a/crates/atlaspack_plugin_transformer_image/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_image/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "atlaspack_plugin_transformer_image"
+version = "0.1.0"
+edition = "2021"
+description = "Image transformer plugin for the Atlaspack Bundler"
+
+[dependencies]
+atlaspack_core = { path = "../atlaspack_core" }
+
+anyhow = "1"
+image = "0.25.2"
+url-search-params = "12.0.0"
+
+[dev-dependencies]
+atlaspack_filesystem = { path = "../atlaspack_filesystem" }

--- a/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
@@ -1,0 +1,138 @@
+use std::io::Cursor;
+use std::sync::Arc;
+
+use anyhow::Error;
+use atlaspack_core::diagnostic_error;
+use atlaspack_core::plugin::TransformResult;
+use atlaspack_core::plugin::{PluginContext, TransformerPlugin};
+use atlaspack_core::types::{Asset, BundleBehavior, Code, FileType};
+use image::imageops::FilterType;
+use image::{ImageFormat, ImageReader};
+use url_search_params::parse_url_search_params;
+
+#[derive(Debug)]
+pub struct AtlaspackImageTransformerPlugin {}
+
+impl AtlaspackImageTransformerPlugin {
+  pub fn new(_ctx: &PluginContext) -> Result<Self, Error> {
+    Ok(AtlaspackImageTransformerPlugin {})
+  }
+}
+
+impl TransformerPlugin for AtlaspackImageTransformerPlugin {
+  fn transform(&mut self, asset: Asset) -> Result<TransformResult, Error> {
+    let mut asset = asset.clone();
+
+    if asset.bundle_behavior == BundleBehavior::None {
+      asset.bundle_behavior = BundleBehavior::Isolated;
+    }
+
+    // TODO: Optimize this in resolver / change asset query type
+    let query = asset
+      .query
+      .clone()
+      .map(|q| parse_url_search_params(&q[1..]))
+      .unwrap_or_default();
+
+    let width = query
+      .get("width")
+      .map_or(Ok(None), |w| w.parse::<u32>().map(|w| Some(w)))?;
+
+    let height = query
+      .get("height")
+      .map_or(Ok(None), |h| h.parse::<u32>().map(|h| Some(h)))?;
+
+    let target_file_type = query.get("as").map(|f| FileType::from_extension(f));
+
+    if width.is_some() || height.is_some() || target_file_type.is_some() {
+      let format = image_format(&asset.file_type)?;
+      let target_format = target_file_type
+        .clone()
+        .map_or(Ok(None), |f| image_format(&f).map(|f| Some(f)))?
+        .unwrap_or(format);
+
+      let img = ImageReader::with_format(Cursor::new(asset.code.bytes()), format).decode()?;
+      let filter = FilterType::Triangle;
+      let img = if let (Some(width), Some(height)) = (width, height) {
+        img.resize_exact(width, height, filter)
+      } else if let Some(width) = width {
+        img.resize(width, img.height(), filter)
+      } else if let Some(height) = height {
+        img.resize(img.width(), height, filter)
+      } else {
+        img
+      };
+
+      let mut bytes: Vec<u8> = Vec::new();
+      img.write_to(&mut Cursor::new(&mut bytes), target_format)?;
+
+      asset.code = Arc::new(Code::new(bytes));
+      asset.file_type = target_file_type.unwrap_or(asset.file_type);
+    }
+
+    Ok(TransformResult {
+      asset,
+      dependencies: Vec::new(),
+      invalidate_on_file_change: Vec::new(),
+    })
+  }
+}
+
+fn image_format(file_type: &FileType) -> Result<ImageFormat, Error> {
+  match file_type {
+    FileType::Avif => Ok(ImageFormat::Avif),
+    FileType::Gif => Ok(ImageFormat::Gif),
+    FileType::Jpeg => Ok(ImageFormat::Jpeg),
+    FileType::Png => Ok(ImageFormat::Png),
+    FileType::Tiff => Ok(ImageFormat::Tiff),
+    FileType::WebP => Ok(ImageFormat::WebP),
+    _ => Err(diagnostic_error!(
+      "Unsupported image file type: {}",
+      file_type.extension()
+    )),
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{path::PathBuf, sync::Arc};
+
+  use atlaspack_core::{
+    config_loader::ConfigLoader,
+    plugin::{PluginLogger, PluginOptions},
+  };
+  use atlaspack_filesystem::in_memory_file_system::InMemoryFileSystem;
+
+  use super::*;
+
+  #[test]
+  fn returns_image_asset() {
+    let file_system = Arc::new(InMemoryFileSystem::default());
+    let mut plugin = AtlaspackImageTransformerPlugin::new(&PluginContext {
+      config: Arc::new(ConfigLoader {
+        fs: file_system.clone(),
+        project_root: PathBuf::default(),
+        search_path: PathBuf::default(),
+      }),
+      file_system,
+      logger: PluginLogger::default(),
+      options: Arc::new(PluginOptions::default()),
+    })
+    .expect("Expected image transformer to initialize");
+
+    let asset = Asset::default();
+
+    assert_ne!(asset.bundle_behavior, BundleBehavior::Isolated);
+    assert_eq!(
+      plugin.transform(asset).map_err(|e| e.to_string()),
+      Ok(TransformResult {
+        asset: Asset {
+          bundle_behavior: BundleBehavior::Isolated,
+          ..Asset::default()
+        },
+        dependencies: Vec::new(),
+        invalidate_on_file_change: Vec::new()
+      })
+    );
+  }
+}

--- a/crates/atlaspack_plugin_transformer_image/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_image/src/lib.rs
@@ -1,0 +1,3 @@
+pub use image_transformer::AtlaspackImageTransformerPlugin;
+
+mod image_transformer;

--- a/crates/node-bindings/src/atlaspack/atlaspack.rs
+++ b/crates/node-bindings/src/atlaspack/atlaspack.rs
@@ -18,8 +18,7 @@ use atlaspack_core::types::AtlaspackOptions;
 use atlaspack_napi_helpers::JsTransferable;
 use atlaspack_package_manager::PackageManagerRef;
 
-use crate::file_system::FileSystemNapi;
-
+use super::file_system_napi::FileSystemNapi;
 use super::package_manager_napi::PackageManagerNapi;
 
 #[napi(object)]

--- a/crates/node-bindings/src/atlaspack/file_system_napi.rs
+++ b/crates/node-bindings/src/atlaspack/file_system_napi.rs
@@ -57,6 +57,15 @@ impl FileSystem for FileSystemNapi {
       .map_err(|e| io::Error::other(e))
   }
 
+  fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+    let result = self
+      .read_file_fn
+      .call_with_return_serde(path.to_path_buf())
+      .map_err(|e| io::Error::other(e));
+
+    result
+  }
+
   fn read_to_string(&self, path: &Path) -> io::Result<String> {
     self
       .read_file_fn

--- a/crates/node-bindings/src/atlaspack/mod.rs
+++ b/crates/node-bindings/src/atlaspack/mod.rs
@@ -1,4 +1,5 @@
 pub mod atlaspack;
+pub mod file_system_napi;
 pub mod monitoring;
 pub mod package_manager_napi;
 pub mod worker;

--- a/crates/node-bindings/src/file_system/mod.rs
+++ b/crates/node-bindings/src/file_system/mod.rs
@@ -1,2 +1,0 @@
-pub mod file_system_napi;
-pub use self::file_system_napi::*;

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -13,9 +13,6 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-#[cfg(not(target_arch = "wasm32"))]
-mod file_system;
-
 /// napi versions of `crate::core::requests`
 #[cfg(not(target_arch = "wasm32"))]
 mod fs_search;

--- a/crates/node-bindings/src/resolver.rs
+++ b/crates/node-bindings/src/resolver.rs
@@ -143,6 +143,10 @@ impl FileSystem for JsFileSystem {
 
     is_dir().unwrap_or(false)
   }
+
+  fn read(&self, _path: &Path) -> std::io::Result<Vec<u8>> {
+    todo!()
+  }
 }
 
 #[napi(object)]

--- a/crates/node-bindings/src/resolver_old.rs
+++ b/crates/node-bindings/src/resolver_old.rs
@@ -143,6 +143,10 @@ impl FileSystem for JsFileSystem {
 
     is_dir().unwrap_or(false)
   }
+
+  fn read(&self, _path: &Path) -> std::io::Result<Vec<u8>> {
+    todo!()
+  }
 }
 
 #[napi(object)]

--- a/packages/core/core/src/atlaspack-v3/fs.js
+++ b/packages/core/core/src/atlaspack-v3/fs.js
@@ -15,9 +15,14 @@ export function toFileSystemV3(fs: ClassicFileSystem): FileSystem {
     canonicalize: jsCallable((path: FilePath) => fs.realpathSync(path)),
     createDirectory: jsCallable((path: FilePath) => fs.mkdirp(path)),
     cwd: jsCallable(() => fs.cwd()),
-    readFile: jsCallable((path: string, encoding?: Encoding) =>
-      fs.readFileSync(path, encoding ?? 'utf8'),
-    ),
+    readFile: jsCallable((path: string, encoding?: Encoding) => {
+      if (!encoding) {
+        // $FlowFixMe
+        return [...fs.readFileSync(path)];
+      } else {
+        return fs.readFileSync(path, encoding);
+      }
+    }),
     isFile: (path: string) => {
       try {
         return fs.statSync(path).isFile();

--- a/packages/core/integration-tests/test/data-url.js
+++ b/packages/core/integration-tests/test/data-url.js
@@ -52,9 +52,7 @@ describe('data-url:', function () {
     }
   });
 
-  // TODO: I believe we need to change the code type to handle binary data / bytes over string for
-  // this to succeed
-  it.v2('inlines binary content as a data url', async () => {
+  it('inlines binary content as a data url', async () => {
     let b = await bundle(join(__dirname, '/integration/data-url/binary.js'));
     let binary = (await run(b)).default;
 

--- a/packages/core/integration-tests/test/integration/image-exif/resized.html
+++ b/packages/core/integration-tests/test/integration/image-exif/resized.html
@@ -1,1 +1,0 @@
-<img src="right.jpg?width=240">

--- a/packages/core/integration-tests/test/integration/image-exif/resized.js
+++ b/packages/core/integration-tests/test/integration/image-exif/resized.js
@@ -1,0 +1,3 @@
+import url from './right.jpg?width=240';
+
+module.exports = url;

--- a/packages/core/integration-tests/test/integration/image-multiple-queries/index.css
+++ b/packages/core/integration-tests/test/integration/image-multiple-queries/index.css
@@ -1,0 +1,11 @@
+.test-1 {
+  background-image: url('snow.jpg?as=webp&width=400');
+}
+
+.test-2 {
+  background-image: url('snow.jpg?as=jpg&width=400');
+}
+
+.test-3 {
+  background-image: url('snow.jpg?as=jpg&width=800');
+}

--- a/packages/core/integration-tests/test/integration/image-multiple-queries/index.js
+++ b/packages/core/integration-tests/test/integration/image-multiple-queries/index.js
@@ -1,0 +1,9 @@
+import url1 from './snow.jpg?as=webp&width=400';
+import url2 from './snow.jpg?as=jpg&width=400';
+import url3 from './snow.jpg?as=jpg&width=800';
+
+module.exports = {
+  url1,
+  url2,
+  url3,
+};

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@atlaspack/diagnostic": "2.12.0",
+    "@atlaspack/feature-flags": "2.12.0",
     "@atlaspack/plugin": "2.12.0",
     "@atlaspack/rust": "2.12.0",
     "@parcel/source-map": "^2.1.1",


### PR DESCRIPTION
## Motivation

These changes port the image transformer to Rust so that more functionality works in v3. It also removes the overhead of calling into JavaScript plugins by using Rust directly.

## Changes

* Represent `Code` type as bytes instead of a string for binary data
* Add `atlaspack_plugin_transformer_image` crate which supports most of the pre-existing types in the original image transformer. Note that the sharp config file is not supported since it uses a different underlying implementation. The `image` dependency may be revisited at a later time if necessary.
* Use image transformer when `@atlaspack/transformer-image` is encountered
* Add supported image file types to `FileType`
* Add `read` function to `FileSystem` trait to handle binary data when reading an asset file
* Add missing query to resolver resolution
* Update `readFile` in JavaScript filesystem to handle binary data when there is no encoding
* Enable relevant tests and expand test cases

## Checklist

- [x] Existing or new tests cover this change
