### PR TITLE
Add initial rust inline requires optimiser implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlaspack_plugin_optimizer_inline_requires"
+version = "0.1.0"
+dependencies = [
+ "atlaspack-js-swc-core",
+ "swc_core",
+]
+
+[[package]]
 name = "atlaspack_plugin_resolver"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,9 +85,9 @@ checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
 
 [[package]]
 name = "anyhow"
-version = "1.0.86"
+version = "1.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
+checksum = "10f00e1f6e58a40e807377c75c6a7f97bf9044fab57816f2414e6f5f4499d7b8"
 dependencies = [
  "backtrace",
 ]
@@ -216,7 +216,10 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha-1",
+ "sourcemap",
  "swc_core",
+ "swc_ecma_parser",
+ "thiserror",
 ]
 
 [[package]]
@@ -247,6 +250,7 @@ dependencies = [
  "atlaspack_monitoring",
  "atlaspack_napi_helpers",
  "atlaspack_package_manager",
+ "atlaspack_plugin_optimizer_inline_requires",
  "atlaspack_plugin_transformer_js",
  "crossbeam-channel",
  "getrandom",
@@ -269,6 +273,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "swc_core",
  "toml",
  "tracing",
  "tracing-appender",

--- a/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "atlaspack_plugin_optimizer_inline_requires"
+authors = ["Pedro Tacla Yamada <tacla.yamada@gmail.com>"]
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+swc_core = { version = "0.96", features = [
+    "common",
+    "common_ahash",
+    "common_sourcemap",
+    "ecma_ast",
+    "ecma_codegen",
+    "ecma_parser",
+    "ecma_preset_env",
+    "ecma_transforms",
+    "ecma_transforms_compat",
+    "ecma_transforms_optimization",
+    "ecma_transforms_proposal",
+    "ecma_transforms_react",
+    "ecma_transforms_typescript",
+    "ecma_utils",
+    "ecma_visit",
+    "stacker"
+] }
+atlaspack-js-swc-core = { path = "../../packages/transformers/js/core" }

--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/inlining_visitor.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/inlining_visitor.rs
@@ -1,0 +1,33 @@
+use std::collections::HashMap;
+use swc_core::ecma::ast::{Expr, Id};
+use swc_core::ecma::visit::{VisitMut, VisitMutWith};
+
+/// Given a set of variable IDs and a replacement expressions, this visitor will replace all
+/// identifiers that match said ID with the replacement.
+#[derive(Default)]
+pub struct IdentifierReplacementVisitor {
+  /// Replacement map for `Id` scope aware values. We can add another structure for symbol based
+  /// replacement.
+  ///
+  /// We could also generalise this a bit and have it handle finding the binding before inlining.
+  id_replacement: HashMap<Id, Expr>,
+}
+
+impl IdentifierReplacementVisitor {
+  pub fn add_replacement(&mut self, id: Id, expr: Expr) {
+    self.id_replacement.insert(id, expr);
+  }
+}
+
+impl VisitMut for IdentifierReplacementVisitor {
+  fn visit_mut_expr(&mut self, n: &mut Expr) {
+    let Expr::Ident(ident) = n else {
+      n.visit_mut_children_with(self);
+      return;
+    };
+    let Some(replacement_expression) = self.id_replacement.get(&ident.to_id()) else {
+      return;
+    };
+    *n = replacement_expression.clone();
+  }
+}

--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
@@ -1,7 +1,7 @@
 mod inlining_visitor;
 
-use std::collections::HashSet;
 use crate::inlining_visitor::IdentifierReplacementVisitor;
+use std::collections::HashSet;
 use swc_core::atoms::atom;
 use swc_core::atoms::Atom;
 use swc_core::common::Mark;
@@ -330,7 +330,7 @@ impl VisitMut for InlineRequiresOptimizer {
 
 #[cfg(test)]
 mod tests {
-  use atlaspack_js_swc_core::test_utils::{run_visit, RunVisitResult};
+  use atlaspack_js_swc_core::test_utils::{run_test_visit, RunVisitResult};
 
   use super::*;
 
@@ -344,7 +344,7 @@ function doWork() {
     "#
     .trim();
 
-    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |ctx| InlineRequiresOptimizer {
       unresolved_mark: ctx.unresolved_mark,
       ..Default::default()
     });
@@ -373,7 +373,7 @@ parcelRequire.register('moduleId', function(require, module, exports) {
     "#
     .trim();
 
-    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |ctx| InlineRequiresOptimizer {
       unresolved_mark: ctx.unresolved_mark,
       ..Default::default()
     });
@@ -397,7 +397,7 @@ const parcelHelpers = require("@atlaspack/transformer-js/src/esmodule-helpers.js
     "#
     .trim();
 
-    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |ctx| InlineRequiresOptimizer {
       unresolved_mark: ctx.unresolved_mark,
       ..Default::default()
     });
@@ -416,7 +416,7 @@ const sideEffects = require("side-effects");
     "#
     .trim();
 
-    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |ctx| InlineRequiresOptimizer {
       unresolved_mark: ctx.unresolved_mark,
       ignore_patterns: vec![IgnorePattern::ModuleId(atom!("side-effects"))],
       ..Default::default()
@@ -441,7 +441,7 @@ function run() {
     "#
     .trim();
 
-    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |ctx| InlineRequiresOptimizer {
       unresolved_mark: ctx.unresolved_mark,
       ..Default::default()
     });

--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
@@ -1,0 +1,459 @@
+mod inlining_visitor;
+
+use std::collections::HashSet;
+use crate::inlining_visitor::IdentifierReplacementVisitor;
+use swc_core::atoms::atom;
+use swc_core::atoms::Atom;
+use swc_core::common::Mark;
+use swc_core::ecma::ast::{CallExpr, Expr, Id, Ident, Lit, VarDecl, VarDeclarator};
+use swc_core::ecma::utils::ExprExt;
+use swc_core::ecma::visit::{VisitMut, VisitMutWith};
+
+/// Represents a `const i = require('module-id')` statement that has been found.
+#[derive(Debug)]
+pub struct RequireInitializer {
+  /// The variable `i` swc [`Id`] for matching it respecting scope
+  pub variable_id: Id,
+  /// The imported package atom `'module-id'`
+  pub imported_package: Atom,
+  /// The entire `require(...)` call for replacement
+  pub call_expr: CallExpr,
+}
+
+/// Default match patterns for parcel
+fn default_require_matchers() -> Vec<RequireMatcher> {
+  vec![
+    RequireMatcher::Global(atom!("require")),
+    RequireMatcher::Global(atom!("parcelRequire")),
+  ]
+}
+
+/// Default ignore patterns for parcel
+fn default_ignore_patterns() -> Vec<IgnorePattern> {
+  vec![IgnorePattern::IdentifierSymbol(atom!("parcelHelpers"))]
+}
+
+/// Extract [RequireInitializer] information from a declarator or return None.
+fn match_require_initializer(
+  decl: &VarDeclarator,
+  unresolved_mark: Mark,
+  require_matchers: &[RequireMatcher],
+  ignore_patterns: &[IgnorePattern],
+) -> Option<RequireInitializer> {
+  let expr = decl.init.as_ref()?;
+  let call_expr = expr.as_call()?;
+  let function_ident = call_expr
+    .callee
+    .as_expr()
+    .map(|expr| expr.as_ident())
+    .flatten()?;
+
+  if !require_matchers
+    .iter()
+    .any(|matcher| matcher.test(unresolved_mark, function_ident))
+  {
+    return None;
+  }
+
+  let Lit::Str(literal) = call_expr.args[0].expr.as_lit()? else {
+    return None;
+  };
+  let variable_identifier = &decl.name.as_ident()?.id;
+
+  if ignore_patterns
+    .iter()
+    .any(|pattern| pattern.test(&variable_identifier, &literal.value))
+  {
+    return None;
+  }
+
+  let variable_id = variable_identifier.to_id();
+
+  Some(RequireInitializer {
+    variable_id,
+    imported_package: literal.value.clone(),
+    call_expr: call_expr.clone(),
+  })
+}
+
+/// If this is a parcel interopDefault declaration, return the `Id` of the binding.
+///
+/// We will recursively inline it.
+///
+/// This is to handle:
+/// ```skip
+/// const app = require('x');
+/// const appDefault = parcelHelpers.interopDefault(app);
+/// ```
+///
+/// The return value is `appDefault`'s identifier.
+fn match_parcel_default_initializer(decl: &VarDeclarator) -> Option<Id> {
+  let initializer = decl.init.as_ref()?;
+  let binding = decl.name.as_ident()?.id.to_id();
+  let call_expr = initializer.as_call()?;
+  let callee = call_expr.callee.as_expr()?;
+  let callee_object = callee.as_expr().as_member()?;
+  let object = callee_object.obj.as_ident()?;
+  let property = callee_object.prop.as_ident()?;
+
+  if object.sym == atom!("parcelHelpers") && property.sym == atom!("interopDefault") {
+    return Some(binding);
+  }
+
+  None
+}
+
+/// Different ways to find a `require` call, either using a scope aware `Id` or trying to match
+/// against a global symbol.
+#[derive(Clone)]
+pub enum RequireMatcher {
+  Id(Id),
+  Global(Atom),
+}
+
+impl RequireMatcher {
+  fn test(&self, unresolved_mark: Mark, ident: &Ident) -> bool {
+    match self {
+      RequireMatcher::Id(id) => ident.to_id() == *id,
+      RequireMatcher::Global(atom) => {
+        ident.span.ctxt.outer() == unresolved_mark && ident.sym == *atom
+      }
+    }
+  }
+}
+
+/// Different ways to ignore a `require` call, either using the binding identifier or module-ids.
+pub enum IgnorePattern {
+  IdentifierSymbol(Atom),
+  ModuleId(Atom),
+  ModuleIdHashSet(HashSet<Atom>),
+}
+
+impl IgnorePattern {
+  fn test(&self, ident: &Ident, module_id: &Atom) -> bool {
+    match self {
+      IgnorePattern::IdentifierSymbol(value) => ident.sym == *value,
+      IgnorePattern::ModuleId(value) => module_id == value,
+      IgnorePattern::ModuleIdHashSet(value) => value.contains(module_id),
+    }
+  }
+}
+
+/// Internal state of the current module stack.
+/// Holds the scope aware ids of `require` statements if they are overridden by a `defineModule`
+/// style wrapper.
+struct ModuleScopeInfo {
+  require_matcher: RequireMatcher,
+}
+
+/// Builder pattern to build optimizer with defaults
+pub struct InlineRequiresOptimizerBuilder {
+  unresolved_mark: Mark,
+  require_matchers: Vec<RequireMatcher>,
+  ignore_patterns: Vec<IgnorePattern>,
+}
+
+impl Default for InlineRequiresOptimizerBuilder {
+  fn default() -> Self {
+    Self {
+      unresolved_mark: Default::default(),
+      require_matchers: default_require_matchers(),
+      ignore_patterns: default_ignore_patterns(),
+    }
+  }
+}
+
+impl InlineRequiresOptimizerBuilder {
+  pub fn unresolved_mark(mut self, mark: Mark) -> Self {
+    self.unresolved_mark = mark;
+    self
+  }
+
+  pub fn override_default_require_matchers(
+    mut self,
+    require_matchers: Vec<RequireMatcher>,
+  ) -> Self {
+    self.require_matchers = require_matchers;
+    self
+  }
+
+  pub fn override_default_ignore_patterns(mut self, ignore_patterns: Vec<IgnorePattern>) -> Self {
+    self.ignore_patterns = ignore_patterns;
+    self
+  }
+
+  pub fn add_require_matcher(mut self, require_matcher: RequireMatcher) -> Self {
+    self.require_matchers.push(require_matcher);
+    self
+  }
+
+  pub fn add_ignore_pattern(mut self, ignore_pattern: IgnorePattern) -> Self {
+    self.ignore_patterns.push(ignore_pattern);
+    self
+  }
+
+  pub fn build(self) -> InlineRequiresOptimizer {
+    InlineRequiresOptimizer {
+      unresolved_mark: self.unresolved_mark,
+      require_matchers: self.require_matchers,
+      ignore_patterns: self.ignore_patterns,
+      ..Default::default()
+    }
+  }
+}
+
+/// Inlines require statements in module definitions.
+///
+/// Use `InlineRequiresOptimizer::builder()` to construct instances.
+///
+/// You may add ignore patterns to skip certain modules or variable identifier bindings.
+///
+/// You may add require matchers to match against certain function names or Ids for `require`.
+///
+/// The `unresolved_mark` must be set to respect scope and not replace any `require` variable in
+/// the module that might not be relevant.
+///
+/// Defaults can be overridden (do not match on `require`, do not ignore `parcelHelpers`).
+///
+/// After replacement has been executed, `InlineRequiresOptimizer::require_initializers()` may be
+/// used to retrieve which statements have been matched against. This would be used for diagnostics
+/// purposes only.
+#[non_exhaustive]
+pub struct InlineRequiresOptimizer {
+  unresolved_mark: Mark,
+  require_matchers: Vec<RequireMatcher>,
+  module_stack: Vec<ModuleScopeInfo>,
+  require_initializers: Vec<RequireInitializer>,
+  ignore_patterns: Vec<IgnorePattern>,
+  identifier_replacement_visitor: IdentifierReplacementVisitor,
+}
+
+impl Default for InlineRequiresOptimizer {
+  fn default() -> Self {
+    InlineRequiresOptimizer {
+      unresolved_mark: Default::default(),
+      require_matchers: default_require_matchers(),
+      ignore_patterns: default_ignore_patterns(),
+      module_stack: vec![],
+      require_initializers: vec![],
+      identifier_replacement_visitor: Default::default(),
+    }
+  }
+}
+
+impl InlineRequiresOptimizer {
+  /// Get the results for what initializers have been replaced
+  pub fn require_initializers(&self) -> &[RequireInitializer] {
+    &self.require_initializers
+  }
+
+  pub fn builder() -> InlineRequiresOptimizerBuilder {
+    InlineRequiresOptimizerBuilder::default()
+  }
+}
+
+impl VisitMut for InlineRequiresOptimizer {
+  fn visit_mut_expr(&mut self, n: &mut Expr) {
+    self.identifier_replacement_visitor.visit_mut_expr(n);
+
+    match n {
+      Expr::Fn(fn_expr) => {
+        if fn_expr.function.params.len() < 3 {
+          n.visit_mut_children_with(self);
+          return;
+        }
+        let (Some(require_ident), Some(module_ident), Some(exports_ident)) = (
+          fn_expr.function.params[0].pat.as_ident(),
+          fn_expr.function.params[1].pat.as_ident(),
+          fn_expr.function.params[2].pat.as_ident(),
+        ) else {
+          n.visit_mut_children_with(self);
+          return;
+        };
+
+        if require_ident.sym == atom!("require")
+          && module_ident.sym == atom!("module")
+          && exports_ident.sym == atom!("exports")
+        {
+          self.module_stack.push(ModuleScopeInfo {
+            require_matcher: RequireMatcher::Id(require_ident.to_id()),
+          });
+          fn_expr.visit_mut_children_with(self);
+          let _ = self.module_stack.pop();
+        }
+      }
+      _ => {
+        n.visit_mut_children_with(self);
+      }
+    }
+  }
+
+  fn visit_mut_var_decl(&mut self, n: &mut VarDecl) {
+    for decl in n.decls.iter_mut() {
+      let mut require_matchers = self.require_matchers.clone();
+      if let Some(module_stack_info) = self.module_stack.last() {
+        require_matchers.push(module_stack_info.require_matcher.clone());
+      }
+
+      if let Some(default_initializer_id) = match_parcel_default_initializer(&decl) {
+        // first let the normal replacement run on this expression so we inline the require
+        decl.visit_mut_children_with(self);
+        // get the value we've replaced and carry it forward, we'll inline this value now
+        let Some(init) = &decl.init else { continue };
+        let init = init.as_expr().clone();
+        decl.init = None;
+        self
+          .identifier_replacement_visitor
+          .add_replacement(default_initializer_id, init);
+        continue;
+      }
+
+      let Some(initializer) = match_require_initializer(
+        decl,
+        self.unresolved_mark,
+        &require_matchers,
+        &self.ignore_patterns,
+      ) else {
+        decl.visit_mut_children_with(self);
+        continue;
+      };
+
+      self.identifier_replacement_visitor.add_replacement(
+        initializer.variable_id.clone(),
+        Expr::Call(initializer.call_expr.clone()),
+      );
+      self.require_initializers.push(initializer);
+      decl.init = None;
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use atlaspack_js_swc_core::test_utils::{run_visit, RunVisitResult};
+
+  use super::*;
+
+  #[test]
+  fn it_inlines_require_statements_in_simple_commonjs_modules() {
+    let code = r#"
+const fs = require('fs');
+function doWork() {
+    return fs.readFileSync('./something');
+}
+    "#
+    .trim();
+
+    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+      unresolved_mark: ctx.unresolved_mark,
+      ..Default::default()
+    });
+
+    let expected_output = r#"
+const fs;
+function doWork() {
+    return require('fs').readFileSync('./something');
+}
+    "#
+    .trim();
+    assert_eq!(output_code.trim(), expected_output);
+  }
+
+  #[test]
+  fn is_inlines_require_statements_in_parcel_module_wrappers() {
+    let code = r#"
+parcelRequire.register('moduleId', function(require, module, exports) {
+
+    const fs = require('fs');
+    function doWork() {
+        return fs.readFileSync('./something');
+    }
+
+});
+    "#
+    .trim();
+
+    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+      unresolved_mark: ctx.unresolved_mark,
+      ..Default::default()
+    });
+
+    let expected_output = r#"
+parcelRequire.register('moduleId', function(require, module, exports) {
+    const fs;
+    function doWork() {
+        return require('fs').readFileSync('./something');
+    }
+});
+    "#
+    .trim();
+    assert_eq!(output_code.trim(), expected_output);
+  }
+
+  #[test]
+  fn ignores_parcel_helpers_require_statements() {
+    let code = r#"
+const parcelHelpers = require("@atlaspack/transformer-js/src/esmodule-helpers.js");
+    "#
+    .trim();
+
+    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+      unresolved_mark: ctx.unresolved_mark,
+      ..Default::default()
+    });
+
+    let expected_output = r#"
+const parcelHelpers = require("@atlaspack/transformer-js/src/esmodule-helpers.js");
+    "#
+    .trim();
+    assert_eq!(output_code.trim(), expected_output);
+  }
+
+  #[test]
+  fn ignores_modules_that_are_on_the_ignore_list() {
+    let code = r#"
+const sideEffects = require("side-effects");
+    "#
+    .trim();
+
+    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+      unresolved_mark: ctx.unresolved_mark,
+      ignore_patterns: vec![IgnorePattern::ModuleId(atom!("side-effects"))],
+      ..Default::default()
+    });
+
+    let expected_output = r#"
+const sideEffects = require("side-effects");
+    "#
+    .trim();
+    assert_eq!(output_code.trim(), expected_output);
+  }
+
+  #[test]
+  fn handles_interop_default_calls() {
+    let code = r#"
+const app = require("./App");
+const appDefault = parcelHelpers.interopDefault(app);
+
+function run() {
+    return appDefault.test();
+}
+    "#
+    .trim();
+
+    let RunVisitResult { output_code, .. } = run_visit(code, |ctx| InlineRequiresOptimizer {
+      unresolved_mark: ctx.unresolved_mark,
+      ..Default::default()
+    });
+
+    let expected_output = r#"
+const app;
+const appDefault;
+function run() {
+    return parcelHelpers.interopDefault(require("./App")).test();
+}
+    "#
+    .trim();
+    assert_eq!(output_code.trim(), expected_output);
+  }
+}

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -18,6 +18,7 @@ atlaspack_monitoring = { path = "../atlaspack_monitoring" }
 atlaspack-resolver = { path = "../../packages/utils/node-resolver-rs" }
 atlaspack-resolver-old = { path = "../../packages/utils/node-resolver-rs-old" }
 atlaspack_package_manager = { path = "../atlaspack_package_manager" }
+atlaspack_plugin_optimizer_inline_requires = { path = "../atlaspack_plugin_optimizer_inline_requires" }
 atlaspack_plugin_transformer_js = { path = "../atlaspack_plugin_transformer_js" }
 atlaspack_napi_helpers = { path = "../atlaspack_napi_helpers" }
 lmdb-js-lite = { path = "../lmdb-js-lite" }
@@ -51,6 +52,7 @@ napi = { version = "2.16.4", features = ["async", "napi4", "napi5", "serde-json"
 once_cell = { version = "1.19.0" }
 oxipng = "8.0.0"
 rayon = "1.7.0"
+swc_core = { version = "0.96" }
 
 # Crash reporting dependencies
 

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -24,6 +24,7 @@ mod image;
 mod atlaspack;
 #[cfg(not(test))]
 pub mod lmdb;
+mod optimizers;
 mod resolver;
 mod resolver_old;
 mod transformer;

--- a/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
+++ b/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
@@ -39,7 +39,7 @@ pub fn run_inline_requires_optimizer(
     output_code: result.output_code,
     source_map: if input.source_maps {
       let source_map = String::from_utf8(result.source_map).map_err(|err| {
-        napi::Error::from_reason(format!("[napi] Non-utf8 source-map output: {}", err))
+        napi::Error::from_reason(format!("[napi] Invalid utf-8 source map output: {}", err))
       })?;
       Some(source_map)
     } else {

--- a/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
+++ b/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
@@ -1,0 +1,49 @@
+use atlaspack_js_swc_core::runner::run_visit;
+use atlaspack_plugin_optimizer_inline_requires::IgnorePattern;
+use napi_derive::napi;
+use swc_core::atoms::Atom;
+
+#[napi(object)]
+pub struct InlineRequiresOptimizerInput {
+  pub input_code: String,
+  pub source_maps: bool,
+  pub assets_to_ignore: Vec<String>,
+}
+
+#[napi(object)]
+pub struct InlineRequiresOptimizerResult {
+  pub output_code: String,
+  pub source_map: Option<String>,
+}
+
+#[napi]
+pub fn run_inline_requires_optimizer(
+  input: InlineRequiresOptimizerInput,
+) -> napi::Result<InlineRequiresOptimizerResult> {
+  let result = run_visit(&input.input_code, |ctx| {
+    let visitor = atlaspack_plugin_optimizer_inline_requires::InlineRequiresOptimizer::builder()
+      .unresolved_mark(ctx.unresolved_mark)
+      .add_ignore_pattern(IgnorePattern::ModuleIdHashSet(
+        input
+          .assets_to_ignore
+          .into_iter()
+          .map(|s| Atom::new(s))
+          .collect(),
+      ))
+      .build();
+    visitor
+  })
+  .map_err(|err| napi::Error::from_reason(format!("[napi] failed to run optimizer: {}", err)))?;
+
+  Ok(InlineRequiresOptimizerResult {
+    output_code: result.output_code,
+    source_map: if input.source_maps {
+      let source_map = String::from_utf8(result.source_map).map_err(|err| {
+        napi::Error::from_reason(format!("[napi] Non-utf8 source-map output: {}", err))
+      })?;
+      Some(source_map)
+    } else {
+      None
+    },
+  })
+}

--- a/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
+++ b/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
@@ -33,7 +33,12 @@ pub fn run_inline_requires_optimizer(
       .build();
     visitor
   })
-  .map_err(|err| napi::Error::from_reason(format!("[napi] Failed to run inline require optimizer: {}", err)))?;
+  .map_err(|err| {
+    napi::Error::from_reason(format!(
+      "[napi] Failed to run inline require optimizer: {}",
+      err
+    ))
+  })?;
 
   Ok(InlineRequiresOptimizerResult {
     output_code: result.output_code,

--- a/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
+++ b/crates/node-bindings/src/optimizers/inline_requires_optimizer.rs
@@ -33,7 +33,7 @@ pub fn run_inline_requires_optimizer(
       .build();
     visitor
   })
-  .map_err(|err| napi::Error::from_reason(format!("[napi] failed to run optimizer: {}", err)))?;
+  .map_err(|err| napi::Error::from_reason(format!("[napi] Failed to run inline require optimizer: {}", err)))?;
 
   Ok(InlineRequiresOptimizerResult {
     output_code: result.output_code,

--- a/crates/node-bindings/src/optimizers/mod.rs
+++ b/crates/node-bindings/src/optimizers/mod.rs
@@ -1,0 +1,1 @@
+mod inline_requires_optimizer;

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -10,6 +10,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   atlaspackV3: false,
   useWatchmanWatcher: false,
   importRetry: false,
+  fastOptimizeInlineRequires: false,
   fastNeedsDefaultInterop: false,
   ownedResolverStructures: false,
 };

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -16,6 +16,10 @@ export type FeatureFlags = {|
    */
   importRetry: boolean,
   /**
+   * Enable rust based inline requires optimization
+   */
+  fastOptimizeInlineRequires: boolean,
+  /**
    * Enable fast path for needsDefaultInterop.
    *
    * This improves bundling performance of large applications very significantly.

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -196,12 +196,12 @@ declare export class Lmdb {
 }
 
 export interface InlineRequiresOptimizerInput {
-  inputCode: string;
+  code: string;
   sourceMaps: boolean;
-  assetsToIgnore: Array<string>;
+  ignoreModuleIds: Array<string>;
 }
 export interface InlineRequiresOptimizerResult {
-  outputCode: string;
+  code: string;
   sourceMap?: string;
 }
 

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -194,3 +194,15 @@ declare export class Lmdb {
   commitWriteTransaction(): Promise<void>;
   close(): void;
 }
+
+export interface InlineRequiresOptimizerInput {
+  inputCode: string;
+  sourceMaps: boolean;
+  assetsToIgnore: Array<string>;
+}
+export interface InlineRequiresOptimizerResult {
+  outputCode: string;
+  sourceMap?: string;
+}
+
+declare export function runInlineRequiresOptimizer(input: InlineRequiresOptimizerInput): InlineRequiresOptimizerResult;

--- a/packages/core/rust/package.json
+++ b/packages/core/rust/package.json
@@ -33,6 +33,7 @@
     "build": "napi build --platform --cargo-cwd ../../../crates/node-bindings",
     "build-canary": "napi build --platform --profile canary --features canary --cargo-cwd ../../../crates/node-bindings",
     "build-release": "napi build --platform --release --cargo-cwd ../../../crates/node-bindings",
+    "test": "mocha",
     "wasm:build": "cargo build -p atlaspack-node-bindings --target wasm32-unknown-unknown && cp ../../../target/wasm32-unknown-unknown/debug/atlaspack_node_bindings.wasm .",
     "wasm:build-release": "CARGO_PROFILE_RELEASE_LTO=true cargo build -p atlaspack-node-bindings --target wasm32-unknown-unknown --release && wasm-opt --strip-debug -O ../../../target/wasm32-unknown-unknown/release/atlaspack_node_bindings.wasm -o atlaspack_node_bindings.wasm"
   }

--- a/packages/core/rust/test/InlineRequiresNative.test.js
+++ b/packages/core/rust/test/InlineRequiresNative.test.js
@@ -6,18 +6,18 @@ import {runInlineRequiresOptimizer} from '..';
 describe('runInlineRequiresOptimizer', () => {
   it('replaces inline code on source', () => {
     const result = runInlineRequiresOptimizer({
-      inputCode: `
+      code: `
 const fs = require('fs');
 
 function main() {
     return fs.readFile('./something');
 }`,
-      assetsToIgnore: [],
+      ignoreModuleIds: [],
       sourceMaps: true,
     });
 
     assert.equal(
-      result.outputCode,
+      result.code,
       `
 const fs;
 function main() {

--- a/packages/core/rust/test/InlineRequiresNative.test.js
+++ b/packages/core/rust/test/InlineRequiresNative.test.js
@@ -1,0 +1,31 @@
+// @flow strict-local
+
+import {runInlineRequiresOptimizer} from '..';
+import assert from 'node:assert';
+
+describe.only('runInlineRequiresOptimizer', () => {
+  it('replaces inline code on source', () => {
+    const result = runInlineRequiresOptimizer({
+      inputCode: `
+const fs = require('fs');
+
+function main() {
+    return fs.readFile('./something');
+}`,
+      assetsToIgnore: [],
+      sourceMaps: true,
+    });
+
+    assert.equal(
+      result.outputCode,
+      `
+const fs;
+function main() {
+    return require('fs').readFile('./something');
+}
+`.trimStart(),
+    );
+    const sourceMap = JSON.parse(result.sourceMap);
+    assert.ok(sourceMap);
+  });
+});

--- a/packages/core/rust/test/InlineRequiresNative.test.js
+++ b/packages/core/rust/test/InlineRequiresNative.test.js
@@ -1,9 +1,9 @@
 // @flow strict-local
 
+import assert from 'assert';
 import {runInlineRequiresOptimizer} from '..';
-import assert from 'node:assert';
 
-describe.only('runInlineRequiresOptimizer', () => {
+describe('runInlineRequiresOptimizer', () => {
   it('replaces inline code on source', () => {
     const result = runInlineRequiresOptimizer({
       inputCode: `
@@ -25,6 +25,7 @@ function main() {
 }
 `.trimStart(),
     );
+    // $FlowFixMe
     const sourceMap = JSON.parse(result.sourceMap);
     assert.ok(sourceMap);
   });

--- a/packages/optimizers/inline-requires/package.json
+++ b/packages/optimizers/inline-requires/package.json
@@ -16,7 +16,9 @@
     "parcel": "^2.12.0"
   },
   "dependencies": {
+    "@atlaspack/feature-flags": "2.12.0",
     "@atlaspack/plugin": "2.12.0",
+    "@atlaspack/rust": "^2.12.0",
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/types": "2.12.0",
     "@swc/core": "^1.3.36",

--- a/packages/optimizers/inline-requires/src/InlineRequires.js
+++ b/packages/optimizers/inline-requires/src/InlineRequires.js
@@ -62,9 +62,9 @@ module.exports = new Optimizer<empty, BundleConfig>({
       if (getFeatureFlag('fastOptimizeInlineRequires')) {
         let sourceMap = null;
         const result = runInlineRequiresOptimizer({
-          inputCode: contents.toString(),
+          code: contents.toString(),
           sourceMaps: !!bundle.env.sourceMap,
-          assetsToIgnore: Array.from(
+          ignoreModuleIds: Array.from(
             bundleConfig.assetPublicIdsWithSideEffects,
           ),
         });
@@ -76,7 +76,7 @@ module.exports = new Optimizer<empty, BundleConfig>({
             sourceMap.extends(originalMap);
           }
         }
-        return {contents: result.outputCode, map: originalMap};
+        return {contents: result.code, map: originalMap};
       }
 
       let measurement = tracer.createMeasurement(

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 crate-type = ["rlib"]
 
 [dependencies]
+thiserror = "1.0.63"
 swc_core = { version = "0.96", features = [
   "common",
   "common_ahash",
@@ -26,6 +27,8 @@ swc_core = { version = "0.96", features = [
   "ecma_visit",
   "stacker"
 ] }
+sourcemap = "*"
+swc_ecma_parser = "*"
 indoc = "1.0.3"
 serde = "1.0.123"
 serde_bytes = "0.11.5"

--- a/packages/transformers/js/core/src/dependency_collector.rs
+++ b/packages/transformers/js/core/src/dependency_collector.rs
@@ -1471,11 +1471,11 @@ fn match_worker_type(expr: Option<&ast::ExprOrSpread>) -> (SourceType, Option<as
 #[cfg(test)]
 mod tests {
   use super::*;
-  use crate::test_utils::{run_fold, RunTestContext, RunVisitResult};
+  use crate::test_utils::{run_test_fold, RunContext, RunVisitResult};
   use crate::DependencyDescriptor;
 
   fn make_dependency_collector<'a>(
-    context: RunTestContext,
+    context: RunContext,
     items: &'a mut Vec<DependencyDescriptor>,
     diagnostics: &'a mut Vec<Diagnostic>,
     config: &'a Config,
@@ -1516,7 +1516,7 @@ mod tests {
       const { x } = await import('other');
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1557,7 +1557,7 @@ mod tests {
       import { x } from 'other';
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1593,7 +1593,7 @@ mod tests {
       export { x } from 'other';
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1629,7 +1629,7 @@ mod tests {
       export * from 'other';
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1665,7 +1665,7 @@ mod tests {
       const { x } = require('other');
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1708,7 +1708,7 @@ try {
 } catch (err) {}
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1752,7 +1752,7 @@ try {{
 Promise.resolve().then(() => require('other'));
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1794,7 +1794,7 @@ Promise.resolve().then(()=>require("{}"));
 Promise.resolve().then(() => doSomething(require('other')));
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1838,7 +1838,7 @@ Promise.resolve().then(function() {{
 Promise.resolve().then(function() { return doSomething(require('other')); });
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1884,7 +1884,7 @@ Promise.resolve().then(function() {{
 new Promise((resolve) => resolve(require("other")));
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1926,7 +1926,7 @@ new Promise((resolve)=>resolve(require("{}")));
 new Promise(function(resolve) { return resolve(require("other")) });
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -1970,7 +1970,7 @@ new Promise(function(resolve) {{
 Promise.resolve(require("other"));
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -2011,7 +2011,7 @@ Promise.resolve(require("{}"));
       new Worker(new URL('other', import.meta.url), {type: 'module'});
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -2052,7 +2052,7 @@ Promise.resolve(require("{}"));
       navigator.serviceWorker.register(new URL('other', import.meta.url), {type: 'module'});
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -2093,7 +2093,7 @@ Promise.resolve(require("{}"));
       CSS.paintWorklet.addModule(new URL('other', import.meta.url));
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 
@@ -2136,7 +2136,7 @@ img.src = new URL('hero.jpg', import.meta.url);
 document.body.appendChild(img);
     "#;
 
-    let RunVisitResult { output_code, .. } = run_fold(input_code, |context| {
+    let RunVisitResult { output_code, .. } = run_test_fold(input_code, |context| {
       make_dependency_collector(context, &mut items, &mut diagnostics, &config)
     });
 

--- a/packages/transformers/js/core/src/env_replacer.rs
+++ b/packages/transformers/js/core/src/env_replacer.rs
@@ -351,7 +351,7 @@ impl<'a> EnvReplacer<'a> {
 
 #[cfg(test)]
 mod tests {
-  use crate::test_utils::{run_visit, RunTestContext, RunVisitResult};
+  use crate::test_utils::{run_test_visit, RunTestContext, RunVisitResult};
 
   use super::*;
 
@@ -378,7 +378,7 @@ mod tests {
     let mut used_env = HashSet::new();
     let mut diagnostics = Vec::new();
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"process.browser = '1234';
 console.log('thing' in process.env);
 const isTest = process.env.IS_TEST === "true";
@@ -414,7 +414,7 @@ const { package, IS_TEST: isTest2, ...other } = process.env;
     let mut used_env = HashSet::new();
     let mut diagnostics = Vec::new();
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 process.browser = '1234';
 other = '1234';
@@ -446,7 +446,7 @@ console.log(other = false);
     let mut used_env = HashSet::new();
     let mut diagnostics = Vec::new();
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 process.env = {};
     "#,
@@ -472,7 +472,7 @@ process.env = {};
     let mut used_env = HashSet::new();
     let mut diagnostics = Vec::new();
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 process.env.PROP = 'other';
 delete process.env.PROP;
@@ -516,7 +516,7 @@ undefined;
 
     env.insert("foo".into(), "foo".into());
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 console.log(foo = process.env);
 const x = ({ foo, ...others } = process.env);
@@ -544,7 +544,7 @@ const x = (foo = "foo", others = {}, {});
     let mut used_env = HashSet::new();
     let mut diagnostics = Vec::new();
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 console.log(process.browser);
 function run(enabled = process.browser) {}
@@ -574,7 +574,7 @@ function run(enabled = true) {}
 
     env.insert("thing".into(), "here".into());
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 console.log('thing' in process.env);
 console.log('other' in process.env);
@@ -602,7 +602,7 @@ console.log(false);
     let mut used_env = HashSet::new();
     let mut diagnostics = Vec::new();
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 const isTest = process.something;
 const version = process.env.hasOwnProperty('version');
@@ -634,7 +634,7 @@ const version = process.env.hasOwnProperty('version');
     env.insert("VERSION".into(), "1.2.3".into());
     env.insert("package".into(), "atlaspack".into());
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 const isTest = process.env.IS_TEST === "true";
 const version = process.env['VERSION'];
@@ -672,7 +672,7 @@ const package = "atlaspack", isTest2 = "true";
 
     env.insert("package".into(), "atlaspack".into());
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 const { package, ...other } = process.env;
     "#,
@@ -702,7 +702,7 @@ const { package, ...other } = process.env;
     env.insert("B".into(), "B".into());
     env.insert("C".into(), "C".into());
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 const env = process.env;
     "#,

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -211,7 +211,7 @@ mod tests {
   use swc_core::ecma::atoms::JsWord;
 
   use crate::global_replacer::GlobalReplacer;
-  use crate::test_utils::{run_visit, RunTestContext, RunVisitResult};
+  use crate::test_utils::{run_test_visit, RunTestContext, RunVisitResult};
   use crate::{DependencyDescriptor, DependencyKind};
 
   fn make_global_replacer(
@@ -234,7 +234,7 @@ mod tests {
   fn test_globals_visitor_with_require_process() {
     let mut items = vec![];
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 console.log(process.test);
     "#,
@@ -255,7 +255,7 @@ console.log(process.test);
   fn test_transforms_computed_property() {
     let mut items = vec![];
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 object[process.test];
 object[__dirname];
@@ -276,7 +276,7 @@ object[__dirname];
   fn test_does_not_transform_member_property() {
     let mut items = vec![];
 
-    let RunVisitResult { output_code, .. } = run_visit(
+    let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
 object.process.test;
 object.__filename;

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -7,8 +7,7 @@ mod global_replacer;
 mod hoist;
 mod modules;
 mod node_replacer;
-#[cfg(test)]
-mod test_utils;
+pub mod test_utils;
 mod typeof_replacer;
 mod utils;
 

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -7,6 +7,7 @@ mod global_replacer;
 mod hoist;
 mod modules;
 mod node_replacer;
+pub mod runner;
 pub mod test_utils;
 mod typeof_replacer;
 mod utils;

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -223,7 +223,7 @@ impl NodeReplacer<'_> {
 
 #[cfg(test)]
 mod tests {
-  use crate::test_utils::run_visit;
+  use crate::test_utils::run_test_visit;
 
   use super::*;
 
@@ -236,7 +236,7 @@ mod tests {
 const filename = __filename;
 console.log(__filename);
     "#;
-    let output_code = run_visit(code, |context| NodeReplacer {
+    let output_code = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -270,7 +270,7 @@ console.log($parcel$__filename);
 const dirname = __dirname;
 console.log(__dirname);
     "#;
-    let output_code = run_visit(code, |context| NodeReplacer {
+    let output_code = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -307,7 +307,7 @@ function something(__filename, __dirname) {
     console.log(__dirname);
 }
     "#;
-    let output_code = run_visit(code, |context| NodeReplacer {
+    let output_code = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -339,7 +339,7 @@ function something(__filename, __dirname) {
     let code = r#"
 const filename = obj.__filename;
     "#;
-    let output_code = run_visit(code, |context| NodeReplacer {
+    let output_code = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -367,7 +367,7 @@ const filename = obj.__filename;
     let code = r#"
 const filename = obj[__filename];
     "#;
-    let output_code = run_visit(code, |context| NodeReplacer {
+    let output_code = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),

--- a/packages/transformers/js/core/src/runner.rs
+++ b/packages/transformers/js/core/src/runner.rs
@@ -76,7 +76,7 @@ pub enum RunWithTransformationError {
   IoError(#[from] std::io::Error),
   #[error("Non-utf 8 output: {0}")]
   NonUtfOutput(#[from] FromUtf8Error),
-  #[error("Source-map failure")]
+  #[error("Failed to generate source map")]
   SourceMap(#[from] sourcemap::Error),
 }
 

--- a/packages/transformers/js/core/src/runner.rs
+++ b/packages/transformers/js/core/src/runner.rs
@@ -50,7 +50,6 @@ pub fn run_visit<V: VisitMut>(
 }
 
 /// Same as `run_visit` but for `Fold` instances
-#[allow(unused)]
 pub fn run_fold<V: Fold>(
   code: &str,
   make_fold: impl FnOnce(RunContext) -> V,

--- a/packages/transformers/js/core/src/runner.rs
+++ b/packages/transformers/js/core/src/runner.rs
@@ -76,7 +76,6 @@ pub enum RunWithTransformationError {
   IoError(#[from] std::io::Error),
   #[error("Invalid utf-8 output: {0}")]
   InvalidUtf8Output(#[from] FromUtf8Error),
-  NonUtfOutput(#[from] FromUtf8Error),
   #[error("Failed to generate source map")]
   SourceMap(#[from] sourcemap::Error),
 }

--- a/packages/transformers/js/core/src/runner.rs
+++ b/packages/transformers/js/core/src/runner.rs
@@ -74,7 +74,8 @@ pub enum RunWithTransformationError {
   SwcParse(swc_ecma_parser::error::Error),
   #[error("IO Error: {0}")]
   IoError(#[from] std::io::Error),
-  #[error("Non-utf 8 output: {0}")]
+  #[error("Invalid utf-8 output: {0}")]
+  InvalidUtf8Output(#[from] FromUtf8Error),
   NonUtfOutput(#[from] FromUtf8Error),
   #[error("Failed to generate source map")]
   SourceMap(#[from] sourcemap::Error),

--- a/packages/transformers/js/core/src/runner.rs
+++ b/packages/transformers/js/core/src/runner.rs
@@ -1,0 +1,187 @@
+use std::string::FromUtf8Error;
+use swc_core::common::input::StringInput;
+use swc_core::common::sync::Lrc;
+use swc_core::common::util::take::Take;
+use swc_core::common::{FileName, Globals, Mark, SourceMap, GLOBALS};
+use swc_core::ecma::ast::Module;
+use swc_core::ecma::codegen::text_writer::JsWriter;
+use swc_core::ecma::parser::lexer::Lexer;
+use swc_core::ecma::parser::Parser;
+use swc_core::ecma::transforms::base::resolver;
+use swc_core::ecma::visit::{Fold, FoldWith, VisitMut, VisitMutWith};
+
+pub struct RunContext {
+  /// Source-map in use
+  pub source_map: Lrc<SourceMap>,
+  /// Global mark from SWC resolver
+  pub global_mark: Mark,
+  /// Unresolved mark from SWC resolver
+  pub unresolved_mark: Mark,
+}
+
+pub struct RunVisitResult<V> {
+  pub output_code: String,
+  #[allow(unused)]
+  pub visitor: V,
+  pub source_map: Vec<u8>,
+}
+
+/// Runner of SWC transformations
+///
+/// * Parse `code` with SWC
+/// * Run a visitor over it
+/// * Return the result
+///
+pub fn run_visit<V: VisitMut>(
+  code: &str,
+  make_visit: impl FnOnce(RunContext) -> V,
+) -> Result<RunVisitResult<V>, RunWithTransformationError> {
+  let (output_code, visitor, source_map) =
+    run_with_transformation(code, |run_test_context: RunContext, module: &mut Module| {
+      let mut visit = make_visit(run_test_context);
+      module.visit_mut_with(&mut visit);
+      visit
+    })?;
+  Ok(RunVisitResult {
+    output_code,
+    visitor,
+    source_map,
+  })
+}
+
+/// Same as `run_visit` but for `Fold` instances
+#[allow(unused)]
+pub fn run_fold<V: Fold>(
+  code: &str,
+  make_fold: impl FnOnce(RunContext) -> V,
+) -> Result<RunVisitResult<V>, RunWithTransformationError> {
+  let (output_code, visitor, source_map) =
+    run_with_transformation(code, |run_test_context: RunContext, module: &mut Module| {
+      let mut visit = make_fold(run_test_context);
+      *module = module.take().fold_with(&mut visit);
+      visit
+    })?;
+  Ok(RunVisitResult {
+    output_code,
+    visitor,
+    source_map,
+  })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum RunWithTransformationError {
+  #[error("Failed to parse")]
+  SwcParse(swc_ecma_parser::error::Error),
+  #[error("IO Error: {0}")]
+  IoError(#[from] std::io::Error),
+  #[error("Non-utf 8 output: {0}")]
+  NonUtfOutput(#[from] FromUtf8Error),
+  #[error("Source-map failure")]
+  SourceMap(#[from] sourcemap::Error),
+}
+
+type RunWithTransformationOutput<R> = (String, R, Vec<u8>);
+
+/// Parse code, run resolver over it, then run the `tranform` function with the parsed module
+/// codegen and return the results.
+fn run_with_transformation<R>(
+  code: &str,
+  transform: impl FnOnce(RunContext, &mut Module) -> R,
+) -> Result<RunWithTransformationOutput<R>, RunWithTransformationError> {
+  let source_map = Lrc::new(SourceMap::default());
+  let source_file = source_map.new_source_file(FileName::Anon, code.into());
+
+  let lexer = Lexer::new(
+    Default::default(),
+    Default::default(),
+    StringInput::from(&*source_file),
+    None,
+  );
+
+  let mut parser = Parser::new_from(lexer);
+  let module = parser
+    .parse_module()
+    .map_err(|err| RunWithTransformationError::SwcParse(err))?;
+
+  GLOBALS.set(
+    &Globals::new(),
+    || -> Result<RunWithTransformationOutput<R>, RunWithTransformationError> {
+      let global_mark = Mark::new();
+      let unresolved_mark = Mark::new();
+      let mut module = module.fold_with(&mut resolver(unresolved_mark, global_mark, false));
+
+      let context = RunContext {
+        source_map: source_map.clone(),
+        global_mark,
+        unresolved_mark,
+      };
+      let result = transform(context, &mut module);
+
+      let mut line_pos_buffer = vec![];
+      let mut output_buffer = vec![];
+      let writer = JsWriter::new(
+        source_map.clone(),
+        "\n",
+        &mut output_buffer,
+        Some(&mut line_pos_buffer),
+      );
+      let mut emitter = swc_core::ecma::codegen::Emitter {
+        cfg: Default::default(),
+        cm: source_map.clone(),
+        comments: None,
+        wr: writer,
+      };
+      emitter.emit_module(&module)?;
+      let output_code = String::from_utf8(output_buffer)?;
+      let source_map = source_map.build_source_map(&line_pos_buffer);
+      let mut output_map_buffer = vec![];
+      source_map.to_writer(&mut output_map_buffer)?;
+
+      Ok((output_code, result, output_map_buffer))
+    },
+  )
+}
+
+#[cfg(test)]
+mod tests {
+  use swc_core::ecma::ast::{Lit, Str};
+  use swc_core::ecma::visit::VisitMut;
+
+  use super::*;
+
+  #[test]
+  fn test_example() {
+    struct Visitor;
+    impl VisitMut for Visitor {
+      fn visit_mut_lit(&mut self, n: &mut Lit) {
+        *n = Lit::Str(Str::from("replacement"));
+      }
+    }
+
+    let code = r#"console.log('test!')"#;
+    let RunVisitResult { output_code, .. } = run_visit(code, |_: RunContext| Visitor).unwrap();
+    assert_eq!(
+      output_code,
+      r#"console.log("replacement");
+"#
+    );
+  }
+
+  #[test]
+  fn test_fold() {
+    struct Folder;
+    impl Fold for Folder {
+      fn fold_lit(&mut self, _n: Lit) -> Lit {
+        Lit::Str(Str::from("replacement"))
+      }
+    }
+
+    let code = r#"console.log('test!')"#;
+    let RunVisitResult { output_code, .. } = run_fold(code, |_: RunContext| Folder).unwrap();
+    assert_eq!(
+      output_code,
+      r#"console.log("replacement");
+"#
+    );
+  }
+}

--- a/packages/transformers/js/core/src/runner.rs
+++ b/packages/transformers/js/core/src/runner.rs
@@ -70,7 +70,7 @@ pub fn run_fold<V: Fold>(
 
 #[derive(Debug, thiserror::Error)]
 pub enum RunWithTransformationError {
-  #[error("Failed to parse")]
+  #[error("Failed to parse module")]
   SwcParse(swc_ecma_parser::error::Error),
   #[error("IO Error: {0}")]
   IoError(#[from] std::io::Error),

--- a/packages/transformers/js/core/src/test_utils.rs
+++ b/packages/transformers/js/core/src/test_utils.rs
@@ -9,7 +9,7 @@ use swc_core::ecma::parser::Parser;
 use swc_core::ecma::transforms::base::resolver;
 use swc_core::ecma::visit::{Fold, FoldWith, VisitMut, VisitMutWith};
 
-pub(crate) struct RunTestContext {
+pub struct RunTestContext {
   /// Source-map in use
   pub source_map: Lrc<SourceMap>,
   /// Global mark from SWC resolver
@@ -18,7 +18,7 @@ pub(crate) struct RunTestContext {
   pub unresolved_mark: Mark,
 }
 
-pub(crate) struct RunVisitResult<V> {
+pub struct RunVisitResult<V> {
   pub output_code: String,
   #[allow(unused)]
   pub visitor: V,
@@ -30,7 +30,7 @@ pub(crate) struct RunVisitResult<V> {
 /// * Run a visitor over it
 /// * Return the result
 ///
-pub(crate) fn run_visit<V: VisitMut>(
+pub fn run_visit<V: VisitMut>(
   code: &str,
   make_visit: impl FnOnce(RunTestContext) -> V,
 ) -> RunVisitResult<V> {
@@ -50,7 +50,7 @@ pub(crate) fn run_visit<V: VisitMut>(
 
 /// Same as `run_visit` but for `Fold` instances
 #[allow(unused)]
-pub(crate) fn run_fold<V: Fold>(
+pub fn run_fold<V: Fold>(
   code: &str,
   make_fold: impl FnOnce(RunTestContext) -> V,
 ) -> RunVisitResult<V> {

--- a/packages/transformers/js/core/src/test_utils.rs
+++ b/packages/transformers/js/core/src/test_utils.rs
@@ -1,28 +1,10 @@
-use swc_core::common::input::StringInput;
-use swc_core::common::sync::Lrc;
-use swc_core::common::util::take::Take;
-use swc_core::common::{FileName, Globals, Mark, SourceMap, GLOBALS};
-use swc_core::ecma::ast::Module;
-use swc_core::ecma::codegen::text_writer::JsWriter;
-use swc_core::ecma::parser::lexer::Lexer;
-use swc_core::ecma::parser::Parser;
-use swc_core::ecma::transforms::base::resolver;
-use swc_core::ecma::visit::{Fold, FoldWith, VisitMut, VisitMutWith};
+use swc_core::ecma::visit::{Fold, VisitMut};
 
-pub struct RunTestContext {
-  /// Source-map in use
-  pub source_map: Lrc<SourceMap>,
-  /// Global mark from SWC resolver
-  pub global_mark: Mark,
-  /// Unresolved mark from SWC resolver
-  pub unresolved_mark: Mark,
-}
+use crate::runner::{run_fold, run_visit};
+pub use crate::runner::{RunContext, RunVisitResult};
 
-pub struct RunVisitResult<V> {
-  pub output_code: String,
-  #[allow(unused)]
-  pub visitor: V,
-}
+/// In the future this might be a different type to `RunContext`
+pub type RunTestContext = RunContext;
 
 /// Helper to test SWC visitors.
 ///
@@ -30,130 +12,18 @@ pub struct RunVisitResult<V> {
 /// * Run a visitor over it
 /// * Return the result
 ///
-pub fn run_visit<V: VisitMut>(
+pub fn run_test_visit<V: VisitMut>(
   code: &str,
   make_visit: impl FnOnce(RunTestContext) -> V,
 ) -> RunVisitResult<V> {
-  let (output_code, visitor) = run_with_transformation(
-    code,
-    |run_test_context: RunTestContext, module: &mut Module| {
-      let mut visit = make_visit(run_test_context);
-      module.visit_mut_with(&mut visit);
-      visit
-    },
-  );
-  RunVisitResult {
-    output_code,
-    visitor,
-  }
+  run_visit(code, make_visit).unwrap()
 }
 
 /// Same as `run_visit` but for `Fold` instances
 #[allow(unused)]
-pub fn run_fold<V: Fold>(
+pub fn run_test_fold<V: Fold>(
   code: &str,
   make_fold: impl FnOnce(RunTestContext) -> V,
 ) -> RunVisitResult<V> {
-  let (output_code, visitor) = run_with_transformation(
-    code,
-    |run_test_context: RunTestContext, module: &mut Module| {
-      let mut visit = make_fold(run_test_context);
-      *module = module.take().fold_with(&mut visit);
-      visit
-    },
-  );
-  RunVisitResult {
-    output_code,
-    visitor,
-  }
-}
-
-/// Parse code, run resolver over it, then run the `tranform` function with the parsed module
-/// codegen and return the results.
-fn run_with_transformation<R>(
-  code: &str,
-  transform: impl FnOnce(RunTestContext, &mut Module) -> R,
-) -> (String, R) {
-  let source_map = Lrc::new(SourceMap::default());
-  let source_file = source_map.new_source_file(FileName::Anon, code.into());
-
-  let lexer = Lexer::new(
-    Default::default(),
-    Default::default(),
-    StringInput::from(&*source_file),
-    None,
-  );
-
-  let mut parser = Parser::new_from(lexer);
-  let module = parser.parse_module().unwrap();
-
-  GLOBALS.set(&Globals::new(), || {
-    let global_mark = Mark::new();
-    let unresolved_mark = Mark::new();
-    let mut module = module.fold_with(&mut resolver(unresolved_mark, global_mark, false));
-
-    let context = RunTestContext {
-      source_map: source_map.clone(),
-      global_mark,
-      unresolved_mark,
-    };
-    let result = transform(context, &mut module);
-
-    let mut output_buffer = vec![];
-    let writer = JsWriter::new(source_map.clone(), "\n", &mut output_buffer, None);
-    let mut emitter = swc_core::ecma::codegen::Emitter {
-      cfg: Default::default(),
-      cm: source_map,
-      comments: None,
-      wr: writer,
-    };
-    emitter.emit_module(&module).unwrap();
-    let output_code = String::from_utf8(output_buffer).unwrap();
-
-    (output_code, result)
-  })
-}
-
-#[cfg(test)]
-mod tests {
-  use swc_core::ecma::ast::{Lit, Str};
-  use swc_core::ecma::visit::VisitMut;
-
-  use super::*;
-
-  #[test]
-  fn test_example() {
-    struct Visitor;
-    impl VisitMut for Visitor {
-      fn visit_mut_lit(&mut self, n: &mut Lit) {
-        *n = Lit::Str(Str::from("replacement"));
-      }
-    }
-
-    let code = r#"console.log('test!')"#;
-    let RunVisitResult { output_code, .. } = run_visit(code, |_: RunTestContext| Visitor);
-    assert_eq!(
-      output_code,
-      r#"console.log("replacement");
-"#
-    );
-  }
-
-  #[test]
-  fn test_fold() {
-    struct Folder;
-    impl Fold for Folder {
-      fn fold_lit(&mut self, _n: Lit) -> Lit {
-        Lit::Str(Str::from("replacement"))
-      }
-    }
-
-    let code = r#"console.log('test!')"#;
-    let RunVisitResult { output_code, .. } = run_fold(code, |_: RunTestContext| Folder);
-    assert_eq!(
-      output_code,
-      r#"console.log("replacement");
-"#
-    );
-  }
+  run_fold(code, make_fold).unwrap()
 }

--- a/packages/transformers/js/core/src/typeof_replacer.rs
+++ b/packages/transformers/js/core/src/typeof_replacer.rs
@@ -82,7 +82,7 @@ impl VisitMut for TypeofReplacer {
 
 #[cfg(test)]
 mod tests {
-  use crate::test_utils::run_visit;
+  use crate::test_utils::run_test_visit;
 
   use super::*;
 
@@ -94,7 +94,7 @@ const m = typeof module;
 const e = typeof exports;
 "#;
 
-    let output_code = run_visit(code, |context| TypeofReplacer {
+    let output_code = run_test_visit(code, |context| TypeofReplacer {
       unresolved_mark: context.unresolved_mark,
     })
     .output_code;
@@ -114,7 +114,7 @@ const e = "object";
 const x = typeof require === 'function';
 "#;
 
-    let output_code = run_visit(code, |context| TypeofReplacer {
+    let output_code = run_test_visit(code, |context| TypeofReplacer {
       unresolved_mark: context.unresolved_mark,
     })
     .output_code;
@@ -136,7 +136,7 @@ function wrapper({ require, exports }) {
 }
     "#;
 
-    let output_code = run_visit(code, |context| TypeofReplacer {
+    let output_code = run_test_visit(code, |context| TypeofReplacer {
       unresolved_mark: context.unresolved_mark,
     })
     .output_code;

--- a/packages/utils/node-resolver-rs/benches/node_resolver_bench.rs
+++ b/packages/utils/node-resolver-rs/benches/node_resolver_bench.rs
@@ -109,6 +109,11 @@ impl FileSystem for PreloadingFileSystem {
     Ok(())
   }
 
+  fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
+    #[allow(unreachable_code)]
+    todo!()
+  }
+
   fn read_to_string(&self, path: &Path) -> std::io::Result<String> {
     let files = self.files.read();
     let file = files.get(path);


### PR DESCRIPTION
This change adds a rust implementation of the inline requires optimiser. This should avoid passing the AST back and forward to rust ; also since this is operating on large output files, the implementation might be a bit more efficient.

I've changed parts of the core SWC transformer wrapper code so that it can be used as a testing library on the new optimiser crate and so that it can run outputting source-maps.

At the moment there's waste, and even if source-maps aren't enabled they'll be partially generated. Some source-map file-naming might need to be patched as well as an anonymous file name is used.

## Motivation

The motivation for this change is to improve performance of the packaging phase of bundling.

## Checklist

- [x] Existing or new tests cover this change

There are no integration tests for inline requires that I could find.

There's a minor difference in output code as I'm not wrapping the inlined expressions in `(0, ...)`