### PR TITLE
[V3] Support * engines version

### DIFF
--- a/crates/atlaspack_core/src/types/environment/version.rs
+++ b/crates/atlaspack_core/src/types/environment/version.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use serde::Serializer;
 
 /// Minimum semantic version range for browsers and engines
-#[derive(PartialEq, Clone, Copy, PartialOrd, Ord, Eq, Hash)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct Version(NonZeroU16);
 
 impl Version {
@@ -83,6 +83,10 @@ impl<'de> Deserialize<'de> for Version {
     D: serde::Deserializer<'de>,
   {
     let v: String = Deserialize::deserialize(deserializer)?;
+    if v == "*" {
+      return Ok(Version(NonZeroU16::new(1 as u16).unwrap()));
+    }
+
     if let Some(version) = SemVerRange::parse(v.as_str())
       .ok()
       .and_then(|r| r.min_version())


### PR DESCRIPTION
## Motivation

Currently when `*` is provided as an engines version, v3 will fail to parse it. It is considered valid in the specification per [here](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#engines) so we should continue to support it:

> And, like with dependencies, if you don't specify the version (or if you specify "*" as the version), then any version of node will do.

## Changes

Handle `*` engine versions

## Checklist

- [x] Existing or new tests cover this change
