### PR TITLE
Update package licenses

### DIFF
--- a/crates/lmdb-js-lite/package.json
+++ b/crates/lmdb-js-lite/package.json
@@ -20,7 +20,7 @@
       ]
     }
   },
-  "license": "APACHE-2",
+  "license": "Apache-2.0",
   "devDependencies": {
     "@napi-rs/cli": "^2.18.4",
     "@atlaspack/cache": "*",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/monorepo",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/bundler-default",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/bundlers/library/package.json
+++ b/packages/bundlers/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/bundler-library",
   "version": "2.11.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compressors/brotli/package.json
+++ b/packages/compressors/brotli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/compressor-brotli",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compressors/gzip/package.json
+++ b/packages/compressors/gzip/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/compressor-gzip",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compressors/raw/package.json
+++ b/packages/compressors/raw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/compressor-raw",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/configs/default/package.json
+++ b/packages/configs/default/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/config-default",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/configs/webextension/package.json
+++ b/packages/configs/webextension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/config-webextension",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/cache",
   "description": "Interface for defining caches and file-system, IDB and LMDB implementations.",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/cli",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/codeframe/package.json
+++ b/packages/core/codeframe/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/codeframe",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/core",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/diagnostic/package.json
+++ b/packages/core/diagnostic/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/diagnostic",
   "version": "2.12.0",
   "description": "Types and utilities for printing source-code located errors, warning and information messages.",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/feature-flags/package.json
+++ b/packages/core/feature-flags/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/feature-flags",
   "version": "2.12.0",
   "description": "Provides internal feature-flags for the atlaspack codebase.",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/fs",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/graph/package.json
+++ b/packages/core/graph/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/graph",
   "version": "3.2.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/integration-tests",
   "version": "2.12.0",
   "private": true,
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"

--- a/packages/core/integration-tests/test/integration/sourcemap-css-import/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-css-import/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-css/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-css/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-generate-inline/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-generate-inline/package.json
@@ -1,7 +1,6 @@
 {
   "name": "atlaspack-sourcemap-node-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true,
   "node": "dist/index.js",
   "targets": {

--- a/packages/core/integration-tests/test/integration/sourcemap-inline-sources/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-inline-sources/package.json
@@ -1,7 +1,6 @@
 {
   "name": "atlaspack-sourcemap-node-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true,
   "node": "dist/index.js",
   "targets": {

--- a/packages/core/integration-tests/test/integration/sourcemap-less/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-less/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-nested-minified/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-nested-minified/package.json
@@ -1,7 +1,6 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true,
   "node": "dist/index.js",
   "targets": {

--- a/packages/core/integration-tests/test/integration/sourcemap-nested/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-nested/package.json
@@ -1,7 +1,6 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true,
   "node": "dist/index.js",
   "targets": {

--- a/packages/core/integration-tests/test/integration/sourcemap-node/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-node/package.json
@@ -1,7 +1,6 @@
 {
   "name": "atlaspack-sourcemap-node-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true,
   "node": "dist/index.js",
   "targets": {

--- a/packages/core/integration-tests/test/integration/sourcemap-sass-imported/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-sass-imported/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-sass/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-sass/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-typescript-nested/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-typescript-nested/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-typescript-tsc/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-typescript-tsc/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap-typescript/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap-typescript/package.json
@@ -1,6 +1,5 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true
 }

--- a/packages/core/integration-tests/test/integration/sourcemap/package.json
+++ b/packages/core/integration-tests/test/integration/sourcemap/package.json
@@ -1,7 +1,6 @@
 {
   "name": "atlaspack-sourcemap-integration-test",
   "version": "1.0.0",
-  "license": "MIT",
   "private": true,
   "browser": "dist/index.js",
   "targets": {

--- a/packages/core/integration-tests/test/integration/target-source/package.json
+++ b/packages/core/integration-tests/test/integration/target-source/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@atlaspack/target-source",
   "version": "2.0.0-beta.1",
-  "license": "MIT",
   "private": true,
   "source": "src/index.js",
   "scripts": {

--- a/packages/core/integration-tests/test/integration/target-source/packages/package-a/package.json
+++ b/packages/core/integration-tests/test/integration/target-source/packages/package-a/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@atlaspack/target-source-package-a",
   "version": "2.0.0-beta.1",
-  "license": "MIT",
   "private": true,
   "source": "src/index.js",
   "devDependencies": {

--- a/packages/core/integration-tests/test/integration/target-source/packages/package-b/package.json
+++ b/packages/core/integration-tests/test/integration/target-source/packages/package-b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@atlaspack/target-source-package-b",
   "version": "2.0.0-beta.1",
-  "license": "MIT",
   "private": true,
   "source": "src/index.js",
   "devDependencies": {

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/logger",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/markdown-ansi/package.json
+++ b/packages/core/markdown-ansi/package.json
@@ -5,7 +5,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/package-manager",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/plugin",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/profiler/package.json
+++ b/packages/core/profiler/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/profiler",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/register/example/package.json
+++ b/packages/core/register/example/package.json
@@ -2,7 +2,7 @@
   "name": "register-example",
   "version": "2.0.0-beta.1",
   "main": "./index.js",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "scripts": {
     "start": "node ./index.js"
   },

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/register",
   "version": "2.12.0",
   "private": true,
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/rust/package.json
+++ b/packages/core/rust/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/rust",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/test-utils",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/core/types-internal/package.json
+++ b/packages/core/types-internal/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/types-internal",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "main": "src/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/types",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "main": "src/index.js",
   "types": "lib/index.d.ts",
   "repository": {

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/utils",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/workers",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/dev/babel-preset/package.json
+++ b/packages/dev/babel-preset/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/babel-preset",
   "version": "2.12.0",
   "private": true,
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git",

--- a/packages/dev/babel-register/package.json
+++ b/packages/dev/babel-register/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/babel-register",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/dev/bundle-stats-cli/package.json
+++ b/packages/dev/bundle-stats-cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/bundle-stats",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/dev/query/package.json
+++ b/packages/dev/query/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/query",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/examples/eslint/package.json
+++ b/packages/examples/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/eslint-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "build": "atlaspack build src/index.js"

--- a/packages/examples/html/package.json
+++ b/packages/examples/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/html-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "start": "atlaspack src/index.html --open"

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/kitchen-sink-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "start": "atlaspack src/index.html --https --open"

--- a/packages/examples/react-hmr/package.json
+++ b/packages/examples/react-hmr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/react-hmr-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "start": "atlaspack src/index.html --https --open"

--- a/packages/examples/react-refresh/package.json
+++ b/packages/examples/react-refresh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/react-refresh-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "start": "atlaspack src/index.html --open"

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/simple-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "build": "atlaspack build src/index.js"

--- a/packages/examples/typechecking/package.json
+++ b/packages/examples/typechecking/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/typechecking-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "build": "atlaspack build src/index.ts"

--- a/packages/examples/typescript/package.json
+++ b/packages/examples/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/typescript-example",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "scripts": {
     "build": "atlaspack build src/index.ts"

--- a/packages/migrations/parcel-to-atlaspack/package.json
+++ b/packages/migrations/parcel-to-atlaspack/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"
   },
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "main": "dist/cli.js",
   "bin": {
     "parcel-to-atlaspack": "dist/bin.js"

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/namer-default",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/blob-url/package.json
+++ b/packages/optimizers/blob-url/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-blob-url",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/css/package.json
+++ b/packages/optimizers/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-css",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-cssnano",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/data-url/package.json
+++ b/packages/optimizers/data-url/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-data-url",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/htmlnano/package.json
+++ b/packages/optimizers/htmlnano/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-htmlnano",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/image/package.json
+++ b/packages/optimizers/image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-image",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "main": "lib/ImageOptimizer.js",
   "source": "src/ImageOptimizer.js",
   "publishConfig": {

--- a/packages/optimizers/inline-requires/package.json
+++ b/packages/optimizers/inline-requires/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-inline-requires",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/svgo/package.json
+++ b/packages/optimizers/svgo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-svgo",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/swc/package.json
+++ b/packages/optimizers/swc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-swc",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/terser/package.json
+++ b/packages/optimizers/terser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/optimizer-terser",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-css",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-html",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-js",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/raw-url/package.json
+++ b/packages/packagers/raw-url/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-raw-url",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/raw/package.json
+++ b/packages/packagers/raw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-raw",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/svg/package.json
+++ b/packages/packagers/svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-svg",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/ts/package.json
+++ b/packages/packagers/ts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-ts",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/wasm/package.json
+++ b/packages/packagers/wasm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-wasm",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/webextension/package.json
+++ b/packages/packagers/webextension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-webextension",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/packagers/xml/package.json
+++ b/packages/packagers/xml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/packager-xml",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/build-metrics/package.json
+++ b/packages/reporters/build-metrics/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-build-metrics",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/bundle-analyzer/package.json
+++ b/packages/reporters/bundle-analyzer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-bundle-analyzer",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/bundle-buddy/package.json
+++ b/packages/reporters/bundle-buddy/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-bundle-buddy",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-cli",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/dev-server-sw/package.json
+++ b/packages/reporters/dev-server-sw/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/reporter-dev-server-sw",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -2,7 +2,7 @@
   "name": "@atlaspack/reporter-dev-server",
   "version": "2.12.0",
   "description": "Blazing fast, zero configuration web application bundler",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-json",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/lsp-reporter/package.json
+++ b/packages/reporters/lsp-reporter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-lsp",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/sourcemap-visualiser/package.json
+++ b/packages/reporters/sourcemap-visualiser/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-sourcemap-visualiser",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/reporters/tracer/package.json
+++ b/packages/reporters/tracer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/reporter-tracer",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/resolver-default",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/resolvers/glob/package.json
+++ b/packages/resolvers/glob/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/resolver-glob",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/resolvers/repl-runtimes/package.json
+++ b/packages/resolvers/repl-runtimes/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/resolver-repl-runtimes",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "private": true,
   "repository": {
     "type": "git",

--- a/packages/runtimes/hmr/package.json
+++ b/packages/runtimes/hmr/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/runtime-browser-hmr",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/runtime-js",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtimes/react-refresh/package.json
+++ b/packages/runtimes/react-refresh/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/runtime-react-refresh",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtimes/service-worker/package.json
+++ b/packages/runtimes/service-worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/runtime-service-worker",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtimes/webextension/package.json
+++ b/packages/runtimes/webextension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/runtime-webextension",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-babel",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-css",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/glsl/package.json
+++ b/packages/transformers/glsl/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-glsl",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/graphql/package.json
+++ b/packages/transformers/graphql/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-graphql",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-html",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-image",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/inline-string/package.json
+++ b/packages/transformers/inline-string/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-inline-string",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/inline/package.json
+++ b/packages/transformers/inline/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-inline",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-js",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/json/package.json
+++ b/packages/transformers/json/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-json",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/jsonld/package.json
+++ b/packages/transformers/jsonld/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-jsonld",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/less/package.json
+++ b/packages/transformers/less/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-less",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/mdx/package.json
+++ b/packages/transformers/mdx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-mdx",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-postcss",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/posthtml/package.json
+++ b/packages/transformers/posthtml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-posthtml",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/pug/package.json
+++ b/packages/transformers/pug/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-pug",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/raw/package.json
+++ b/packages/transformers/raw/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-raw",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/react-refresh-wrap/package.json
+++ b/packages/transformers/react-refresh-wrap/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-react-refresh-wrap",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-sass",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/svg-react/package.json
+++ b/packages/transformers/svg-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-svg-react",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/svg/package.json
+++ b/packages/transformers/svg/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-svg",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/toml/package.json
+++ b/packages/transformers/toml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-toml",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/typescript-tsc/package.json
+++ b/packages/transformers/typescript-tsc/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-typescript-tsc",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-typescript-types",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/webextension/package.json
+++ b/packages/transformers/webextension/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-webextension",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/webmanifest/package.json
+++ b/packages/transformers/webmanifest/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-webmanifest",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/worklet/package.json
+++ b/packages/transformers/worklet/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-worklet",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/xml/package.json
+++ b/packages/transformers/xml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-xml",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/transformers/yaml/package.json
+++ b/packages/transformers/yaml/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/transformer-yaml",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/atlaspack-lsp-protocol/package.json
+++ b/packages/utils/atlaspack-lsp-protocol/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/lsp-protocol",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/atlaspack-lsp/package.json
+++ b/packages/utils/atlaspack-lsp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/lsp",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/atlaspack-watcher-watchman-js/package.json
+++ b/packages/utils/atlaspack-watcher-watchman-js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/watcher-watchman-js",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "main": "lib/index.js",
   "source": "src/index.js",
   "publishConfig": {

--- a/packages/utils/atlaspackforvscode/package.json
+++ b/packages/utils/atlaspackforvscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "atlaspack-for-vscode",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publisher": "atlaspack",
   "icon": "logo.png",
   "displayName": "Atlaspack for VS Code",

--- a/packages/utils/babel-plugin-transform-runtime/package.json
+++ b/packages/utils/babel-plugin-transform-runtime/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/babel-plugin-transform-runtime",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/babel-preset-env/package.json
+++ b/packages/utils/babel-preset-env/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/babel-preset-env",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/create-react-app/package.json
+++ b/packages/utils/create-react-app/package.json
@@ -20,7 +20,7 @@
     "prepack": "./ensure-no-dev-lib.sh",
     "dev:prepare": "rimraf ./lib/ && mkdir -p lib && cp ./bin/dev-bin.js ./lib/bin.js"
   },
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/events",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/macros/package.json
+++ b/packages/utils/macros/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/macros",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/node-resolver-core/package.json
+++ b/packages/utils/node-resolver-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/node-resolver-core",
   "version": "3.3.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/service-worker/package.json
+++ b/packages/utils/service-worker/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/service-worker",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/ts-utils/package.json
+++ b/packages/utils/ts-utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/ts-utils",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/validators/eslint/package.json
+++ b/packages/validators/eslint/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/validator-eslint",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/validators/typescript/package.json
+++ b/packages/validators/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@atlaspack/validator-typescript",
   "version": "2.12.0",
-  "license": "MIT",
+  "license": "(MIT OR Apache-2.0)",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
## Motivation

Since forking from Parcel, we have updated the licensing. However, this change is not reflected in the published packages.

## Changes

* Rename `APACHE-2` to standardised `Apache-2.0` license for `lmdb-js-lite`
* Rename `MIT` license to represent both licenses as `(MIT OR Apache-2.0)`
* Remove integration test `package.json` fixture licenses, as the license is already listed in the containing package

## Checklist

- [x] Existing or new tests cover this change
