### PR TITLE
Use inline requires when importCond flag is disabled

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,8 +5,17 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "lldb",
+      "request": "attach",
+      "name": "Attach",
+      "pid": "${command:pickMyProcess}" // use ${command:pickProcess} to pick other users' processes
+    },
+    {
       "name": "Run Integration Tests (lldb)",
-      "args": ["${workspaceFolder}/node_modules/.bin/_mocha"],
+      "args": [
+        "${workspaceFolder}/node_modules/.bin/_mocha",
+        "${input:integration-tests-args}"
+      ],
       "cwd": "${workspaceFolder}/packages/core/integration-tests",
       "program": "node",
       "request": "launch",
@@ -24,6 +33,14 @@
       "preLaunchTask": "Watch VSCode Extension",
       "request": "launch",
       "type": "extensionHost"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "integration-tests-args",
+      "type": "promptString",
+      "description": "Command args",
+      "default": ""
     }
   ]
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,6 +202,7 @@ dependencies = [
  "parking_lot",
  "path-slash",
  "pathdiff",
+ "regex",
  "serde",
  "serde_bytes",
  "sha-1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4183,6 +4183,7 @@ dependencies = [
  "swc_ecma_codegen",
  "swc_ecma_parser",
  "swc_ecma_preset_env",
+ "swc_ecma_quote_macros",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",
  "swc_ecma_transforms_optimization",
@@ -4481,6 +4482,23 @@ dependencies = [
  "swc_ecma_transforms",
  "swc_ecma_utils",
  "swc_ecma_visit",
+]
+
+[[package]]
+name = "swc_ecma_quote_macros"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9537bc1a7daca42be1922137f4e59458bd72dd330cf9c96877e191e632bc2a8a"
+dependencies = [
+ "anyhow",
+ "proc-macro2",
+ "quote",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_macros_common",
+ "syn",
 ]
 
 [[package]]

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -1,0 +1,45 @@
+import assert from 'assert';
+import path from 'path';
+import {
+  bundle,
+  describe,
+  fsFixture,
+  it,
+  run,
+  overlayFS,
+  removeDistDirectory,
+} from '@atlaspack/test-utils';
+
+describe('conditional bundling', function () {
+  beforeEach(async () => {
+    await removeDistDirectory();
+  });
+
+  it(`when disabled, should treat importCond as a sync import`, async function () {
+    const dir = path.join(__dirname, 'disabled-import-cond');
+    overlayFS.mkdirp(dir);
+
+    await fsFixture(overlayFS, dir)`
+      index.js:
+        globalThis.__MOD_COND = { 'cond': true };
+
+        const result = importCond('cond', './a.js', './b.js');
+
+        export default result;
+
+      a.js:
+        export default 'module-a';
+
+      b.js:
+        export default 'module-b';
+    `;
+
+    let b = await bundle(path.join(dir, '/index.js'), {
+      inputFS: overlayFS,
+      featureFlags: {conditionalBundlingApi: false},
+    });
+
+    let output = await run(b);
+    assert.deepEqual(output?.default, 'module-a');
+  });
+});

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -21,7 +21,7 @@ describe('conditional bundling', function () {
 
     await fsFixture(overlayFS, dir)`
       index.js:
-        globalThis.__MOD_COND = { 'cond': true };
+        globalThis.__MCOND = (key) => ({ 'cond': true })[key];
 
         const result = importCond('cond', './a.js', './b.js');
 
@@ -35,6 +35,34 @@ describe('conditional bundling', function () {
     `;
 
     let b = await bundle(path.join(dir, '/index.js'), {
+      inputFS: overlayFS,
+      featureFlags: {conditionalBundlingApi: false},
+    });
+
+    let output = await run(b);
+    assert.deepEqual(output?.default, 'module-a');
+  });
+
+  it(`when disabled, should transform types in importCond`, async function () {
+    const dir = path.join(__dirname, 'disabled-import-cond');
+    overlayFS.mkdirp(dir);
+
+    await fsFixture(overlayFS, dir)`
+      index.ts:
+        globalThis.__MCOND = (key) => ({ 'cond': true })[key];
+
+        const result = importCond<typeof import('./a.js'), typeof import('./b.js')>('cond', './a.js', './b.js');
+
+        export default result;
+
+      a.js:
+        export default 'module-a';
+
+      b.js:
+        export default 'module-b';
+    `;
+
+    let b = await bundle(path.join(dir, '/index.ts'), {
       inputFS: overlayFS,
       featureFlags: {conditionalBundlingApi: false},
     });

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -4,12 +4,13 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "build:on": "atlaspack build --feature-flag conditionalBundlingApi=true src/index.html",
-    "build:off": "atlaspack build --feature-flag conditionalBundlingApi=false src/index.html",
-    "build:inspect:on": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --feature-flag conditionalBundlingApi=true src/index.html",
-    "build:inspect:off": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --feature-flag conditionalBundlingApi=false src/index.html",
-    "dev:on": "yarn build:on && npx nodemon serve.js",
-    "dev:off": "yarn build:off && npx nodemon serve.js"
+    "build:inspect:off": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --no-cache --feature-flag conditionalBundlingApi=false src/index.html",
+    "build:inspect:on": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
+    "build:off": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=false src/index.html",
+    "build:on": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=true --feature-flag fastNeedsDefaultInterop=true src/index.html",
+    "dev:off": "npx nodemon -e 'ts, tsx, json, .parcelrc' --watch . --ignore 'dist/' --exec 'yarn build:off && node serve.js'",
+    "dev:on": "npx nodemon -e 'ts, tsx, json, .parcelrc' --watch . --ignore 'dist/' --exec 'yarn build:on && node serve.js'",
+    "serve:on": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=true --feature-flag fastNeedsDefaultInterop=true src/index.html"
   },
   "dependencies": {
     "@atlaskit/button": "*",
@@ -17,8 +18,8 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "express": "*",
     "@atlaspack/cli": "^2.12.0",
-    "@types/react-dom": "^17.0.2"
+    "@types/react-dom": "^17.0.2",
+    "express": "*"
   }
 }

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -7,10 +7,10 @@
     "build:inspect:off": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --no-cache --feature-flag conditionalBundlingApi=false src/index.html",
     "build:inspect:on": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
     "build:off": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=false src/index.html",
-    "build:on": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=true --feature-flag fastNeedsDefaultInterop=true src/index.html",
+    "build:on": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
     "dev:off": "npx nodemon -e 'ts, tsx, json, .parcelrc' --watch . --ignore 'dist/' --exec 'yarn build:off && node serve.js'",
     "dev:on": "npx nodemon -e 'ts, tsx, json, .parcelrc' --watch . --ignore 'dist/' --exec 'yarn build:on && node serve.js'",
-    "serve:on": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=true --feature-flag fastNeedsDefaultInterop=true src/index.html"
+    "serve:on": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=true src/index.html"
   },
   "dependencies": {
     "@atlaskit/button": "*",

--- a/packages/examples/conditional-bundling/serve.js
+++ b/packages/examples/conditional-bundling/serve.js
@@ -30,7 +30,10 @@ app.get('/', (req, res, next) => {
     }
   }
   const pos = index.indexOf('<script');
-  index = `${index.slice(0, pos)}<script>window.__conditions = ${JSON.stringify(
+  index = `${index.slice(
+    0,
+    pos,
+  )}<script>globalThis.__MOD_COND = ${JSON.stringify(
     FEATURES,
   )}</script>${scripts.join('\n')}${index.slice(pos)}`;
   index.slice(pos);

--- a/packages/examples/conditional-bundling/serve.js
+++ b/packages/examples/conditional-bundling/serve.js
@@ -45,12 +45,11 @@ app.get('/', (req, res, next) => {
   }
 
   const pos = index.indexOf('<script');
-  index = `${index.slice(
-    0,
-    pos,
-  )}<script>globalThis.__MOD_COND = ${JSON.stringify(
+  index = `${index.slice(0, pos)}<script>const features = ${JSON.stringify(
     FEATURES,
-  )}</script>${scripts.join('\n')}${index.slice(pos)}`;
+  )};globalThis.__MCOND = (key) => features[key];</script>${scripts.join(
+    '\n',
+  )}${index.slice(pos)}`;
   index.slice(pos);
   res.contentType = 'text/html';
   res.send(index);

--- a/packages/examples/conditional-bundling/serve.js
+++ b/packages/examples/conditional-bundling/serve.js
@@ -6,29 +6,44 @@ const FEATURES = {
   'my.feature': true,
   'feature.async.condition': true,
   'feature.ui': true,
+  'my.feature.lazy': true,
 };
 
 const app = express();
 
 app.get('/', (req, res, next) => {
-  const manifest = JSON.parse(
-    fs.readFileSync('dist/conditional-manifest.json', 'utf8'),
-  );
+  let manifest = {};
+  try {
+    manifest = JSON.parse(
+      fs.readFileSync('dist/conditional-manifest.json', 'utf8'),
+    );
+  } catch (err) {
+    console.log('Manifest not loaded or found');
+  }
   let index = fs.readFileSync('dist/index.html', 'utf-8');
   const scripts = [];
-  for (const [feature, state] of Object.entries(FEATURES)) {
-    const featureManifest = manifest[feature];
-    if (!featureManifest) continue;
-    for (const asset of featureManifest[
-      state ? 'ifTrueBundles' : 'ifFalseBundles'
-    ]) {
-      const script = `<script type="module" src="/${path.relative(
-        'dist/',
-        asset,
-      )}"></script>`;
-      scripts.push(script);
+
+  for (const [script, condition] of Object.entries(manifest)) {
+    if (script.startsWith('index.')) {
+      const scriptManifest = manifest[script];
+      for (const [feature, state] of Object.entries(FEATURES)) {
+        const featureManifest = scriptManifest[feature];
+
+        if (!featureManifest) continue;
+
+        for (const asset of featureManifest[
+          state ? 'ifTrueBundles' : 'ifFalseBundles'
+        ]) {
+          const script = `<script type="module" src="/${path.relative(
+            'dist/',
+            asset,
+          )}"></script>`;
+          scripts.push(script);
+        }
+      }
     }
   }
+
   const pos = index.indexOf('<script');
   index = `${index.slice(
     0,

--- a/packages/examples/conditional-bundling/src/feature-ui-disabled.tsx
+++ b/packages/examples/conditional-bundling/src/feature-ui-disabled.tsx
@@ -1,3 +1,5 @@
+import React from "react";
+
 export default function Component() {
   return <button>No fancy</button>;
 }

--- a/packages/examples/conditional-bundling/src/index.tsx
+++ b/packages/examples/conditional-bundling/src/index.tsx
@@ -13,6 +13,7 @@ const FeatureWithUI = importCond<
 >('feature.ui', './feature-ui-enabled', './feature-ui-disabled');
 
 const LazyComponent = lazy(() => import('./lazy-component'));
+
 function LazyComponentContainer() {
   return (
     <Suspense fallback={<p>Loading...</p>}>
@@ -24,7 +25,8 @@ function LazyComponentContainer() {
 const App = () => {
   const [showLazyComponent, setShowLazyComponent] = useState(false);
 
-  console.log(Feature, FeatureWithUI);
+  console.log('FeatureWithUI', FeatureWithUI);
+  console.log('Feature', Feature);
   return (
     <div>
       <p>Hello from React</p>

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -41,3 +41,4 @@ path-slash = "0.1.4"
 indexmap = "1.9.2"
 atlaspack-macros = { path = "../../../../crates/macros" }
 parking_lot = "0.12"
+regex = "1.10.5"

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -25,6 +25,7 @@ swc_core = { version = "0.96", features = [
   "ecma_transforms_typescript",
   "ecma_utils",
   "ecma_visit",
+  "ecma_quote",
   "stacker"
 ] }
 sourcemap = "*"

--- a/packages/transformers/js/core/src/conditional_imports_fallback.rs
+++ b/packages/transformers/js/core/src/conditional_imports_fallback.rs
@@ -1,0 +1,123 @@
+use swc_core::common::{Mark, DUMMY_SP};
+use swc_core::ecma::ast::{
+  ComputedPropName, CondExpr, Expr, MemberExpr, MemberProp, OptChainExpr, ParenExpr,
+};
+use swc_core::ecma::visit::VisitMut;
+
+use crate::utils::{create_require, match_str};
+use crate::Config;
+
+pub struct ConditionalImportsFallback<'a> {
+  pub config: &'a Config,
+  pub unresolved_mark: Mark,
+}
+
+impl<'a> VisitMut for ConditionalImportsFallback<'a> {
+  fn visit_mut_expr(&mut self, node: &mut Expr) {
+    match node {
+      Expr::Call(call) => match &call.callee {
+        swc_core::ecma::ast::Callee::Expr(expr) => match &**expr {
+          Expr::Ident(ident) if ident.sym.to_string().as_str() == "importCond" => {
+            match (match_str(&call.args[1].expr), match_str(&call.args[2].expr)) {
+              (Some((if_true, _if_true_span)), Some((if_false, _if_false_span))) => {
+                if !self.config.conditional_bundling {
+                  // Found importCond, if flag off replace an inline require import
+                  // importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
+                  // =>
+                  // (globalThis.__MOD_COND?.['CONDITION'] ? require('IF_TRUE') : require('IF_FALSE')).default;
+                  *node = Expr::Member(MemberExpr {
+                    obj: ParenExpr {
+                      expr: CondExpr {
+                        test: OptChainExpr {
+                          base: Box::new(
+                            MemberExpr {
+                              obj: Box::new(
+                                MemberExpr {
+                                  obj: Box::new(Expr::Ident("globalThis".into())),
+                                  prop: MemberProp::Ident("__MOD_COND".into()),
+                                  span: DUMMY_SP,
+                                }
+                                .into(),
+                              ),
+                              prop: MemberProp::Computed(ComputedPropName {
+                                expr: call.args[0].expr.clone(),
+                                span: DUMMY_SP,
+                              }),
+                              span: DUMMY_SP,
+                            }
+                            .into(),
+                          ),
+                          optional: true,
+                          span: DUMMY_SP,
+                        }
+                        .into(),
+                        cons: Box::new(create_require(if_true, self.unresolved_mark).into()),
+                        alt: Box::new(create_require(if_false, self.unresolved_mark).into()),
+                        span: DUMMY_SP,
+                      }
+                      .into(),
+                      span: DUMMY_SP,
+                    }
+                    .into(),
+                    prop: MemberProp::Ident("default".into()),
+                    span: DUMMY_SP,
+                  })
+                }
+              }
+              _ => {}
+            };
+          }
+          _ => {}
+        },
+        _ => {}
+      },
+      _ => {}
+    }
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::test_utils::{remove_code_whitespace, run_test_visit, RunContext, RunVisitResult};
+
+  fn make_conditional_imports<'a>(
+    context: RunContext,
+    config: &'a Config,
+  ) -> ConditionalImportsFallback<'a> {
+    ConditionalImportsFallback {
+      config,
+      unresolved_mark: context.unresolved_mark,
+    }
+  }
+
+  fn make_config() -> Config {
+    let mut config = Config::default();
+    config.is_browser = true;
+    config
+  }
+
+  #[test]
+  fn test_import_cond_disabled() {
+    let mut config = make_config();
+    config.conditional_bundling = false;
+    let input_code = r#"
+      const x = importCond('condition-1', 'a', 'b');
+      const y = importCond('condition-2', 'c', 'd');
+    "#;
+
+    let RunVisitResult { output_code, .. } = run_test_visit(input_code, |context| {
+      make_conditional_imports(context, &config)
+    });
+
+    let expected_code = r#"
+      const x = (globalThis.__MOD_COND?.['condition-1'] ? require("a") : require("b")).default;
+      const y = (globalThis.__MOD_COND?.['condition-2'] ? require("c") : require("d")).default;
+    "#;
+
+    assert_eq!(
+      remove_code_whitespace(output_code.as_str()),
+      remove_code_whitespace(expected_code)
+    );
+  }
+}

--- a/packages/transformers/js/core/src/conditional_imports_fallback.rs
+++ b/packages/transformers/js/core/src/conditional_imports_fallback.rs
@@ -1,9 +1,8 @@
-use swc_core::common::{Mark, Spanned};
-use swc_core::ecma::ast::{
-  BinExpr, BinaryOp, CallExpr, Callee, ComputedPropName, CondExpr, Expr, ExprOrSpread, Ident, Lit,
-  MemberExpr, MemberProp, ParenExpr, Str,
-};
+use swc_core::atoms::{atom, Atom};
+use swc_core::common::{Mark, Span, DUMMY_SP};
+use swc_core::ecma::ast::{CallExpr, Callee, Expr, ExprOrSpread, Ident, Lit, Str};
 use swc_core::ecma::visit::VisitMut;
+use swc_core::quote;
 
 use crate::utils::match_str;
 use crate::Config;
@@ -15,109 +14,68 @@ pub struct ConditionalImportsFallback<'a> {
 
 impl<'a> VisitMut for ConditionalImportsFallback<'a> {
   fn visit_mut_expr(&mut self, node: &mut Expr) {
-    match node {
-      Expr::Call(call) => match &call.callee {
-        Callee::Expr(expr) => match &**expr {
-          Expr::Ident(ident) if ident.sym.to_string().as_str() == "importCond" => {
-            match (match_str(&call.args[1].expr), match_str(&call.args[2].expr)) {
-              (Some((if_true, if_true_span)), Some((if_false, if_false_span))) => {
-                if !self.config.conditional_bundling {
-                  // Found importCond, if flag off replace an inline require import
-                  // importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
-                  // =>
-                  // (globalThis.__MOD_COND && globalThis.__MOD_COND['CONDITION'] ? require('IF_TRUE') : require('IF_FALSE')).default;
-                  *node = Expr::Member(MemberExpr {
-                    obj: ParenExpr {
-                      expr: CondExpr {
-                        test: Box::new(
-                          BinExpr {
-                            op: BinaryOp::LogicalAnd,
-                            left: MemberExpr {
-                              obj: Box::new(Expr::Ident("globalThis".into())),
-                              prop: MemberProp::Ident("__MOD_COND".into()),
-                              span: call.span(),
-                            }
-                            .into(),
-                            right: MemberExpr {
-                              obj: Box::new(
-                                MemberExpr {
-                                  obj: Box::new(Expr::Ident("globalThis".into())),
-                                  prop: MemberProp::Ident("__MOD_COND".into()),
-                                  span: call.span(),
-                                }
-                                .into(),
-                              ),
-                              prop: MemberProp::Computed(ComputedPropName {
-                                expr: call.args[0].expr.clone(),
-                                span: call.args[0].expr.span(),
-                              }),
-                              span: call.span(),
-                            }
-                            .into(),
-                            span: call.span(),
-                          }
-                          .into(),
-                        ),
-                        cons: Box::new(
-                          CallExpr {
-                            callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
-                              "require".into(),
-                              if_true_span.apply_mark(self.unresolved_mark),
-                            )))),
-                            args: vec![ExprOrSpread {
-                              expr: Box::new(Expr::Lit(Lit::Str(Str {
-                                value: if_true,
-                                // This span is important to avoid getting marked as a helper
-                                span: if_true_span,
-                                raw: None,
-                              }))),
-                              spread: None,
-                            }],
-                            span: if_true_span,
-                            type_args: None,
-                          }
-                          .into(),
-                        ),
-                        alt: Box::new(
-                          CallExpr {
-                            callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
-                              "require".into(),
-                              if_false_span.apply_mark(self.unresolved_mark),
-                            )))),
-                            args: vec![ExprOrSpread {
-                              expr: Box::new(Expr::Lit(Lit::Str(Str {
-                                value: if_false,
-                                // This span is important to avoid getting marked as a helper
-                                span: if_false_span,
-                                raw: None,
-                              }))),
-                              spread: None,
-                            }],
-                            span: if_false_span,
-                            type_args: None,
-                          }
-                          .into(),
-                        ),
-                        span: call.span(),
-                      }
-                      .into(),
-                      span: call.span(),
-                    }
-                    .into(),
-                    prop: MemberProp::Ident("default".into()),
-                    span: call.span(),
-                  })
-                }
-              }
-              _ => {}
-            };
-          }
-          _ => {}
-        },
-        _ => {}
-      },
-      _ => {}
+    // When flag is off, we want to replace the import
+    if self.config.conditional_bundling {
+      return;
     }
+
+    let Expr::Call(call) = node else {
+      return;
+    };
+
+    let Callee::Expr(callee_expr) = &call.callee else {
+      return;
+    };
+
+    let Expr::Ident(callee_ident) = &**callee_expr else {
+      return;
+    };
+
+    if callee_ident.sym != atom!("importCond") && call.args.len() != 3 {
+      return;
+    }
+
+    let (Some((cond, _cond_span)), Some((if_true, if_true_span)), Some((if_false, if_false_span))) = (
+      match_str(&call.args[0].expr),
+      match_str(&call.args[1].expr),
+      match_str(&call.args[2].expr),
+    ) else {
+      return;
+    };
+
+    let build_import = |atom: Atom, span: Span| -> Expr {
+      CallExpr {
+        callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
+          "require".into(),
+          // Required so that we resolve the new dependency
+          span.apply_mark(self.unresolved_mark),
+        )))),
+        args: vec![ExprOrSpread {
+          expr: Box::new(Expr::Lit(Lit::Str(Str {
+            value: atom,
+            // This span is important to avoid getting marked as a helper
+            span: span,
+            raw: None,
+          }))),
+          spread: None,
+        }],
+        span: DUMMY_SP,
+        type_args: None,
+      }
+      .into()
+    };
+
+    // importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
+    // =>
+    // (globalThis.__MOD_COND && globalThis.__MOD_COND['CONDITION'] ? require('IF_TRUE') : require('IF_FALSE')).default;
+    let new_node = quote!(
+      "(globalThis.__MOD_COND && globalThis.__MOD_COND[$cond] ? $if_true : $if_false).default" as Expr,
+      cond: Expr = Expr::Lit(Lit::Str(cond.into())),
+      if_true: Expr = build_import(if_true, if_true_span),
+      if_false: Expr = build_import(if_false, if_false_span)
+    );
+
+    *node = new_node;
   }
 }
 
@@ -156,8 +114,8 @@ mod tests {
     });
 
     let expected_code = r#"
-      const x = (globalThis.__MOD_COND && globalThis.__MOD_COND['condition-1'] ? require("a") : require("b")).default;
-      const y = (globalThis.__MOD_COND && globalThis.__MOD_COND['condition-2'] ? require("c") : require("d")).default;
+      const x = (globalThis.__MOD_COND && globalThis.__MOD_COND["condition-1"] ? require("a") : require("b")).default;
+      const y = (globalThis.__MOD_COND && globalThis.__MOD_COND["condition-2"] ? require("c") : require("d")).default;
     "#;
 
     assert_eq!(

--- a/packages/transformers/js/core/src/conditional_imports_fallback.rs
+++ b/packages/transformers/js/core/src/conditional_imports_fallback.rs
@@ -65,9 +65,9 @@ impl VisitMut for ConditionalImportsFallback {
 
     // importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
     // =>
-    // (globalThis.__MOD_COND && globalThis.__MOD_COND['CONDITION'] ? require('IF_TRUE') : require('IF_FALSE')).default;
+    // (globalThis.__MCOND && globalThis.__MCOND['CONDITION'] ? require('IF_TRUE') : require('IF_FALSE')).default;
     let new_node = quote!(
-      "(globalThis.__MOD_COND && globalThis.__MOD_COND[$cond] ? $if_true : $if_false).default" as Expr,
+      "globalThis.__MCOND && globalThis.__MCOND($cond) ? $if_true.default : $if_false.default" as Expr,
       cond: Expr = Expr::Lit(Lit::Str(cond.into())),
       if_true: Expr = build_import(if_true, if_true_span),
       if_false: Expr = build_import(if_false, if_false_span)
@@ -100,9 +100,9 @@ mod tests {
       run_test_visit(input_code, |context| make_conditional_imports(context));
 
     let expected_code = r#"
-      const x = (globalThis.__MOD_COND && globalThis.__MOD_COND["condition-1"] ? require("a") : require("b")).default;
-      const y = (globalThis.__MOD_COND && globalThis.__MOD_COND["condition-2"] ? require("c") : require("d")).default;
-      const z = (globalThis.__MOD_COND && globalThis.__MOD_COND["condition-2"] ? require("c") : require("d")).default;
+      const x = globalThis.__MCOND && globalThis.__MCOND("condition-1") ? require("a").default : require("b").default;
+      const y = globalThis.__MCOND && globalThis.__MCOND("condition-2") ? require("c").default : require("d").default;
+      const z = globalThis.__MCOND && globalThis.__MCOND("condition-2") ? require("c").default : require("d").default;
     "#;
 
     assert_eq!(

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -356,7 +356,7 @@ pub fn transform(
               }
 
               // Replace conditional imports with requires when flag is off
-              module.visit_mut_children_with(&mut ConditionalImportsFallback {
+              module.visit_mut_with(&mut ConditionalImportsFallback {
                 config: &config,
                 unresolved_mark,
               });

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -1,4 +1,5 @@
 mod collect;
+mod conditional_imports_fallback;
 mod constant_module;
 mod dependency_collector;
 mod env_replacer;
@@ -24,6 +25,7 @@ use atlaspack_macros::Macros;
 use collect::Collect;
 pub use collect::CollectImportedSymbol;
 use collect::CollectResult;
+use conditional_imports_fallback::ConditionalImportsFallback;
 use constant_module::ConstantModule;
 pub use dependency_collector::dependency_collector;
 pub use dependency_collector::DependencyDescriptor;
@@ -79,6 +81,7 @@ use swc_core::ecma::transforms::optimization::simplify::expr_simplifier;
 use swc_core::ecma::transforms::proposal::decorators;
 use swc_core::ecma::transforms::react;
 use swc_core::ecma::transforms::typescript;
+use swc_core::ecma::visit::VisitMutWith;
 use swc_core::ecma::visit::VisitWith;
 use swc_core::ecma::visit::{as_folder, FoldWith};
 use typeof_replacer::*;
@@ -351,6 +354,12 @@ pub fn transform(
                 module.visit_with(&mut constant_module);
                 result.is_constant_module = constant_module.is_constant_module;
               }
+
+              // Replace conditional imports with requires when flag is off
+              module.visit_mut_children_with(&mut ConditionalImportsFallback {
+                config: &config,
+                unresolved_mark,
+              });
 
               let module = {
                 let mut passes = chain!(

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -356,10 +356,9 @@ pub fn transform(
               }
 
               // Replace conditional imports with requires when flag is off
-              module.visit_mut_with(&mut ConditionalImportsFallback {
-                config: &config,
-                unresolved_mark,
-              });
+              if !config.conditional_bundling {
+                module.visit_mut_with(&mut ConditionalImportsFallback { unresolved_mark });
+              }
 
               let module = {
                 let mut passes = chain!(

--- a/packages/transformers/js/core/src/test_utils.rs
+++ b/packages/transformers/js/core/src/test_utils.rs
@@ -1,3 +1,4 @@
+use regex::Regex;
 use swc_core::ecma::visit::{Fold, VisitMut};
 
 use crate::runner::{run_fold, run_visit};
@@ -26,4 +27,11 @@ pub fn run_test_fold<V: Fold>(
   make_fold: impl FnOnce(RunTestContext) -> V,
 ) -> RunVisitResult<V> {
   run_fold(code, make_fold).unwrap()
+}
+
+/// Remove whitespace from line starts and ends
+#[allow(unused)]
+pub fn remove_code_whitespace(code: &str) -> String {
+  let re = Regex::new(r"\s*\n\s*").unwrap();
+  re.replace_all(code, "\n").trim().to_string()
 }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Allows usage of importCond in jira with support for a condition. This allows us to actually use `importCond` functionally in production, without the bundling implementation.

## Changes

- New module `ConditionalImportsFallback` to visit earlier than the dependency collector

