### PR TITLE
Sort the connections back into topological order after traversing runtimes

### DIFF
--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -61,6 +61,35 @@ function nameRuntimeBundle(
   bundle.displayName = name.replace(hashReference, '[hash]');
 }
 
+/**
+ * The applyRuntimes function is responsible for generating all the runtimes
+ * (assets created during the build that don't actually exist on disk) and then
+ * linking them into the bundle graph.
+ *
+ * Usually, the assets returned from a runtime will go in the same bundle. It is
+ * possible though, for a runtime to return an asset with a `parallel` priority,
+ * which allows it to be moved to a separate bundle. In practice, this is
+ * usually used to generate application manifest files.
+ *
+ * When adding a manifest bundle (a whole new separate bundle) during a runtime,
+ * it needs to be added to a bundle group which will be potentially referenced
+ * by another bundle group. To avoid trying to reference a manifest entry which
+ * hasn't been created yet, we process the bundles from the bottom up, so that
+ * children will always be available when parents try to reference them.
+ *
+ * However, when merging those connections in to the bundle graph, the reversed
+ * order can create a situation where the child bundles thought they were coming
+ * first and so take responsibility for loading in shared bundles. When the
+ * parents actually load first, they're expecting bundles to be loaded which
+ * aren't yet, creating module not found errors.
+ *
+ * To fix that, we restore the forward topological order once all the
+ * connections are created.
+ *
+ * Introduction of manifest bundles: https://github.com/parcel-bundler/parcel/pull/8837
+ * Introduction of reverse topology: https://github.com/parcel-bundler/parcel/pull/8981
+ */
+
 export default async function applyRuntimes<TResult: RequestResult>({
   bundleGraph,
   config,
@@ -84,9 +113,7 @@ export default async function applyRuntimes<TResult: RequestResult>({
 |}): Promise<Map<string, Asset>> {
   let runtimes = await config.getRuntimes();
 
-  // As manifest bundles may be added during runtimes we process them in reverse topological
-  // sort order. This allows bundles to be added to their bundle groups before they are referenced
-  // by other bundle groups by loader runtimes
+  // Sort bundles into reverse topological order
   let bundles = [];
   bundleGraph.traverseBundles({
     exit(bundle) {
@@ -194,7 +221,7 @@ export default async function applyRuntimes<TResult: RequestResult>({
     }
   }
 
-  // Correct connection order after generating runtimes in reverse topological order
+  // Sort the bundles back into forward topological order
   let connections: Array<RuntimeConnection> = [];
 
   bundleGraph.traverseBundles({

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -870,7 +870,12 @@ describe.v2('bundler', function () {
         assets: ['b.html'],
       },
       {
-        assets: ['a.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'a.js',
+          'bundle-manifest.js',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['bundle-manifest.js', 'bundle-url.js'], // manifest bundle
@@ -881,6 +886,7 @@ describe.v2('bundler', function () {
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
+          'bundle-manifest.js',
         ],
       },
       {

--- a/packages/core/integration-tests/test/workers.js
+++ b/packages/core/integration-tests/test/workers.js
@@ -1254,6 +1254,7 @@ describe('atlaspack', function () {
             'get-worker-url.js',
             'lodash.js',
             'esmodule-helpers.js',
+            'bundle-url.js',
           ],
         },
         {


### PR DESCRIPTION
A while back in Parcel, we [reversed the order](https://github.com/parcel-bundler/parcel/pull/8837) that runtimes were processed in, so that child runtimes could be processed before parent bundles who would need to know about them. That didn't quite cut it, so we moved to [reverse topological order](https://github.com/parcel-bundler/parcel/pull/8981).

This works fine for Jira, but in Confluence it causes an issue where a bundle gets loaded thinking that some of its dependencies are already loaded when they aren't.

We thought we'd fixed this with `connections.reverse()`, but that doesn't _actually_ restore topological order, and it seems that Confluence has found the edge case.

The fix here is to actually restore topological order, by processing the bundles in reverse, and then re-traversing and building up the connection list that way.
