### PR TITLE
Limit number of rust threads on tests to 2

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -130,6 +130,7 @@ export default class Atlaspack {
       rustAtlaspack = new AtlaspackV3({
         ...options,
         corePath: path.join(__dirname, '..'),
+        threads: process.env.NODE_ENV === 'test' ? 2 : undefined,
         entries: Array.isArray(entries)
           ? entries
           : entries == null


### PR DESCRIPTION
This improves runtime of running integration tests at the moment.

A better fix is to pre-compile these tests.
