### PR TITLE
Start work on Rust HTML transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,6 +416,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "atlaspack_plugin_transformer_html"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atlaspack_core",
+ "atlaspack_filesystem",
+ "html5ever",
+ "markup5ever",
+ "markup5ever_rcdom",
+]
+
+[[package]]
 name = "atlaspack_plugin_transformer_image"
 version = "0.1.0"
 dependencies = [
@@ -1381,6 +1393,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
+name = "futf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
+dependencies = [
+ "mac",
+ "new_debug_unreachable",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1652,19 @@ dependencies = [
  "phf",
  "rustc-hash",
  "triomphe",
+]
+
+[[package]]
+name = "html5ever"
+version = "0.29.0"
+source = "git+https://github.com/servo/html5ever?rev=a831e82fcee980d80f53699dc14bdfc39a17dc5f#a831e82fcee980d80f53699dc14bdfc39a17dc5f"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2182,12 +2217,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "mac"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
 name = "mach2"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "markup5ever"
+version = "0.14.0"
+source = "git+https://github.com/servo/html5ever?rev=a831e82fcee980d80f53699dc14bdfc39a17dc5f#a831e82fcee980d80f53699dc14bdfc39a17dc5f"
+dependencies = [
+ "log",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+ "tendril",
+]
+
+[[package]]
+name = "markup5ever_rcdom"
+version = "0.3.0"
+source = "git+https://github.com/servo/html5ever?rev=a831e82fcee980d80f53699dc14bdfc39a17dc5f#a831e82fcee980d80f53699dc14bdfc39a17dc5f"
+dependencies = [
+ "html5ever",
+ "markup5ever",
+ "tendril",
+ "xml5ever",
 ]
 
 [[package]]
@@ -2850,7 +2915,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+dependencies = [
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2859,7 +2944,7 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.2",
  "rand 0.8.5",
 ]
 
@@ -2869,11 +2954,20 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.2",
+ "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -2996,6 +3090,12 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "precomputed-hash"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
@@ -4062,6 +4162,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "parking_lot",
+ "phf_shared 0.10.0",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "string_enum"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4834,6 +4960,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tendril"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
+dependencies = [
+ "futf",
+ "mac",
+ "utf-8",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5271,6 +5408,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4b5120022ae7548d0005c9e99f9a695a33bcd732deffb578f7e85516dbb7a6"
 
 [[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
 name = "uuid"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5689,6 +5832,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xml5ever"
+version = "0.20.0"
+source = "git+https://github.com/servo/html5ever?rev=a831e82fcee980d80f53699dc14bdfc39a17dc5f#a831e82fcee980d80f53699dc14bdfc39a17dc5f"
+dependencies = [
+ "log",
+ "mac",
+ "markup5ever",
 ]
 
 [[package]]

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -15,10 +15,13 @@ use super::file_type::FileType;
 use super::json::JSONObject;
 use super::symbol::Symbol;
 
-#[derive(PartialEq, Hash, Clone, Copy, Debug)]
+#[derive(PartialEq, Hash, Clone, Copy, Debug, Serialize, Deserialize)]
 pub struct AssetId(pub NonZeroU32);
 
 /// The source code for an asset.
+///
+/// TODO: This should be called contents now that it's bytes
+/// TODO: This should be an enum and represent cases where the bytes are on disk
 #[derive(PartialEq, Default, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", transparent)]
 pub struct Code {

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -1,13 +1,13 @@
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
-use std::num::NonZeroU32;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::u64;
 
-use atlaspack_filesystem::FileSystemRef;
 use serde::Deserialize;
 use serde::Serialize;
+
+use atlaspack_filesystem::FileSystemRef;
 
 use super::bundle::BundleBehavior;
 use super::environment::Environment;
@@ -15,8 +15,7 @@ use super::file_type::FileType;
 use super::json::JSONObject;
 use super::symbol::Symbol;
 
-#[derive(PartialEq, Hash, Clone, Copy, Debug, Serialize, Deserialize)]
-pub struct AssetId(pub NonZeroU32);
+pub type AssetId = String;
 
 /// The source code for an asset.
 ///
@@ -84,7 +83,7 @@ fn create_asset_id(
 pub struct Asset {
   /// The main identify hash for the asset. It is consistent for the entire
   /// build and between builds.
-  pub id: String,
+  pub id: AssetId,
 
   /// Controls which bundle the asset is placed into
   pub bundle_behavior: BundleBehavior,

--- a/crates/atlaspack_core/src/types/dependency.rs
+++ b/crates/atlaspack_core/src/types/dependency.rs
@@ -9,7 +9,7 @@ use serde::Serialize;
 use serde_repr::Deserialize_repr;
 use serde_repr::Serialize_repr;
 
-use crate::types::ExportsCondition;
+use crate::types::{AssetId, ExportsCondition};
 
 use super::bundle::BundleBehavior;
 use super::environment::Environment;
@@ -63,7 +63,7 @@ pub struct Dependency {
   pub resolve_from: Option<PathBuf>,
 
   /// The id of the asset with this dependency
-  pub source_asset_id: Option<String>,
+  pub source_asset_id: Option<AssetId>,
 
   /// The file path of the asset with this dependency
   pub source_path: Option<PathBuf>,

--- a/crates/atlaspack_plugin_transformer_html/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_html/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "atlaspack_plugin_transformer_html"
+version = "0.1.0"
+authors = ["Pedro Tacla Yamada <tacla.yamada@gmail.com>"]
+edition = "2021"
+description = "HTML transformer plugin for the Atlaspack Bundler"
+
+[dependencies]
+atlaspack_core = { path = "../atlaspack_core" }
+anyhow = "1"
+# Using git version because on crates.io the packages have quite stale and incompatible versions
+html5ever = { git = "https://github.com/servo/html5ever", rev = "a831e82fcee980d80f53699dc14bdfc39a17dc5f" }
+markup5ever = { git = "https://github.com/servo/html5ever", rev = "a831e82fcee980d80f53699dc14bdfc39a17dc5f" }
+markup5ever_rcdom = { git = "https://github.com/servo/html5ever", rev = "a831e82fcee980d80f53699dc14bdfc39a17dc5f" }
+
+[dev-dependencies]
+atlaspack_filesystem = { path = "../atlaspack_filesystem" }

--- a/crates/atlaspack_plugin_transformer_html/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/lib.rs
@@ -1,0 +1,240 @@
+use std::cell::RefMut;
+use std::io::BufReader;
+use std::ops::{Deref, DerefMut};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use anyhow::Error;
+use html5ever::serialize::SerializeOpts;
+use html5ever::tendril::fmt::UTF8;
+use html5ever::tendril::TendrilSink;
+use html5ever::{serialize, ParseOpts};
+use markup5ever::interface::ElemName;
+use markup5ever::tendril::Tendril;
+use markup5ever::{
+  expanded_name, local_name, namespace_url, ns, Attribute, ExpandedName, QualName,
+};
+use markup5ever_rcdom::{Node, NodeData, RcDom, SerializableHandle};
+
+use atlaspack_core::plugin::{TransformResult, TransformerPlugin};
+use atlaspack_core::types::{
+  Asset, AssetId, BundleBehavior, Code, Dependency, Environment, OutputFormat, Priority,
+  SourceType, SpecifierType,
+};
+
+#[derive(Debug)]
+struct AtlaspackHtmlTransformerPlugin {}
+
+impl TransformerPlugin for AtlaspackHtmlTransformerPlugin {
+  fn transform(&mut self, input: Asset) -> Result<TransformResult, Error> {
+    let bytes: &[u8] = input.code.bytes();
+    let mut dom = parse_html(bytes)?;
+    extract_dependencies(&mut dom);
+    let output_bytes = serialize_html(dom)?;
+
+    let mut asset = input;
+    asset.code = Arc::new(Code::new(output_bytes));
+
+    Ok(TransformResult {
+      asset,
+      dependencies: Vec::new(),
+      invalidate_on_file_change: Vec::new(),
+    })
+  }
+}
+
+fn serialize_html(dom: RcDom) -> Result<Vec<u8>, Error> {
+  let document: SerializableHandle = dom.document.clone().into();
+  let mut output_bytes = vec![];
+  let mut options = SerializeOpts::default();
+  serialize(&mut output_bytes, &document, options)?;
+  Ok(output_bytes)
+}
+
+fn parse_html(bytes: &[u8]) -> Result<RcDom, Error> {
+  let mut bytes = BufReader::new(bytes);
+  let options = ParseOpts::default();
+  let dom = RcDom::default();
+  let dom = html5ever::parse_document(dom, options)
+    .from_utf8()
+    .read_from(&mut bytes)?;
+  Ok(dom)
+}
+
+trait DomVisitor {
+  fn visit_node(&mut self, node: &Node);
+}
+
+fn walk(node: Rc<Node>, visitor: &mut impl DomVisitor) {
+  let mut queue = vec![node.clone()];
+  while let Some(node) = queue.pop() {
+    visitor.visit_node(&node);
+    let borrow = node.children.borrow();
+    for child in borrow.iter() {
+      queue.push(child.clone());
+    }
+  }
+}
+
+struct AttrWrapper<'a> {
+  attributes: RefMut<'a, Vec<Attribute>>,
+}
+
+impl<'a> AttrWrapper<'a> {
+  pub fn new(attributes: RefMut<'a, Vec<Attribute>>) -> Self {
+    Self { attributes }
+  }
+
+  pub fn get(&self, name: ExpandedName) -> Option<&Tendril<UTF8>> {
+    self
+      .attributes
+      .iter()
+      .find(|attr| attr.name.expanded() == name)
+      .map(|attr| &attr.value)
+  }
+
+  pub fn delete(&mut self, name: ExpandedName) {
+    let attributes = self.attributes.deref_mut();
+    *attributes = attributes
+      .iter()
+      .filter(|attr| attr.name.expanded() != name)
+      .cloned()
+      .collect();
+  }
+
+  fn set(&mut self, name: ExpandedName, value: &str) {
+    if let Some(attribute) = self
+      .attributes
+      .iter_mut()
+      .find(|attr| attr.name.expanded() == name)
+    {
+      attribute.value = value.into();
+    } else {
+      let attributes = self.attributes.deref_mut();
+      attributes.push(Attribute {
+        name: QualName::new(None, name.ns.clone(), name.local.clone()),
+        value: value.into(),
+      });
+    }
+  }
+}
+
+#[derive(Default)]
+struct ExtractDependencies {
+  should_scope_hoist: bool,
+  dependencies: Vec<Dependency>,
+  source_asset_id: Option<AssetId>,
+  env: Arc<Environment>,
+}
+
+impl DomVisitor for ExtractDependencies {
+  fn visit_node(&mut self, node: &Node) {
+    match &node.data {
+      NodeData::Document => {}
+      NodeData::Doctype { .. } => {}
+      NodeData::Text { .. } => {}
+      NodeData::Comment { .. } => {}
+      NodeData::Element { name, attrs, .. } => match name.expanded() {
+        // TODO: Handle meta
+        expanded_name!(html "meta") => {}
+        // TODO: Handle link
+        expanded_name!(html "link") => {}
+        expanded_name!(html "script") => {
+          let attrs = attrs.borrow_mut();
+          let mut attrs = AttrWrapper::new(attrs);
+          if let Some(src_value) = attrs.get(expanded_name!("", "src")) {
+            let src_string = src_value.to_string();
+            let source_type = if attrs.get(expanded_name!("", "type")) == Some(&"module".into()) {
+              SourceType::Module
+            } else {
+              SourceType::Script
+            };
+
+            let mut output_format = OutputFormat::Global;
+            if self.should_scope_hoist {
+              output_format = OutputFormat::EsModule;
+            } else {
+              if source_type == SourceType::Module {
+                attrs.set(expanded_name!("", "defer"), "");
+              }
+              attrs.delete(expanded_name!("", "type"));
+            }
+
+            // TODO: Support non-ESM browsers
+
+            let dependency = Dependency {
+              specifier: src_string,
+              specifier_type: SpecifierType::Url,
+              priority: Priority::Parallel,
+              source_asset_id: self.source_asset_id.clone(),
+              env: self.env.clone(),
+              // TODO: Set this
+              source_path: None,
+              bundle_behavior: if source_type == SourceType::Script
+                && attrs.get(expanded_name!("", "async")).is_some()
+              {
+                BundleBehavior::Isolated
+              } else {
+                BundleBehavior::None
+              },
+              ..Default::default()
+            };
+            let dependency_id = dependency.id();
+            self.dependencies.push(dependency);
+            attrs.set(expanded_name!("", "src"), &dependency_id);
+          }
+        }
+        _ => {}
+      },
+      NodeData::ProcessingInstruction { .. } => {}
+    }
+  }
+}
+
+fn extract_dependencies(dom: &mut RcDom) {
+  let node = dom.document.clone();
+  let mut visitor = ExtractDependencies::default();
+  walk(node, &mut visitor);
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn test_transform_simple_script_tag() {
+    let bytes = r#"
+<html>
+  <body>
+    <script src="input.js"></script>
+  </body>
+</html>
+    "#
+    .trim();
+    let mut dom = parse_html(bytes.as_bytes()).unwrap();
+    extract_dependencies(&mut dom);
+    let html = String::from_utf8(serialize_html(dom).unwrap()).unwrap();
+    assert_eq!(
+      &normalize_html(&html),
+      &normalize_html(
+        r#"
+<html>
+  <body>
+    <script src="4d82d7c15de63fc0"></script>
+  </body>
+</html>
+    "#
+      )
+    );
+  }
+
+  fn normalize_html(html: &str) -> String {
+    let html = parse_html(html.as_bytes()).unwrap();
+    let output = String::from_utf8(serialize_html(html).unwrap()).unwrap();
+    output
+      .lines()
+      .map(|line| line.trim())
+      .filter(|line| !line.is_empty())
+      .collect()
+  }
+}

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -5,6 +5,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "scripts": {
+    "test": "mocha"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"
@@ -25,5 +28,8 @@
     "posthtml-render": "^3.0.0",
     "semver": "^7.5.2",
     "srcset": "4"
+  },
+  "devDependencies": {
+    "@atlaspack/core": "2.12.0"
   }
 }

--- a/packages/transformers/html/test/HTMLTransformer.test.js
+++ b/packages/transformers/html/test/HTMLTransformer.test.js
@@ -1,0 +1,253 @@
+// @flow strict-local
+
+import {type PostHTMLNode, render} from 'posthtml-render';
+import {parseHTML, transformerOpts} from '../src/HTMLTransformer';
+import assert from 'assert';
+
+function normalizeHTML(code: string): string {
+  const ast = parseHTML(code, true);
+  // $FlowFixMe
+  const result = renderHTML(ast);
+  const lines = result
+    .split('\n')
+    .map(line => line.trim())
+    .filter(line => line);
+  return lines.join('');
+}
+
+function renderHTML(newAST: {|program: PostHTMLNode|}): string {
+  return render(newAST.program, {
+    closingSingleTag: 'slash',
+  });
+}
+
+async function runTestTransform(
+  code: string,
+  options: {|shouldScopeHoist: boolean, supportsEsmodules: boolean|} = {
+    shouldScopeHoist: true,
+    supportsEsmodules: true,
+  },
+) {
+  const dependencies = [];
+  let newAST = null;
+  const asset = {
+    getAST: () => parseHTML(code, true),
+    setAST: n => {
+      newAST = n;
+    },
+    addURLDependency(url, opts) {
+      dependencies.push({url, opts});
+      return 'dependency-id';
+    },
+    env: {
+      shouldScopeHoist: options.shouldScopeHoist,
+      supports(tag: string, defaultValue: boolean) {
+        assert.equal(tag, 'esmodules');
+        assert.equal(defaultValue, true);
+        return options.supportsEsmodules;
+      },
+    },
+  };
+
+  const transformInput = {
+    asset,
+    options: {},
+  };
+  // $FlowFixMe
+  const transformResult = await transformerOpts.transform(transformInput);
+
+  // $FlowFixMe
+  const outputCode = renderHTML(newAST);
+
+  return {dependencies, newAST, outputCode, transformResult, inputAsset: asset};
+}
+
+function normalizeDependencies(dependencies) {
+  return dependencies.map(dependency => ({
+    ...dependency,
+    opts: {
+      ...dependency.opts,
+      env: {
+        ...dependency.opts.env,
+        loc: null,
+      },
+    },
+  }));
+}
+
+describe('HTMLTransformer', () => {
+  it('transform simple script tag', async () => {
+    const code = `
+<html>
+  <body>
+    <script src="input.js"></script>
+  </body>
+</html>
+    `;
+    const {dependencies, outputCode, transformResult, inputAsset} =
+      await runTestTransform(code);
+    assert.equal(
+      outputCode,
+      `
+<html>
+  <body>
+    <script src="dependency-id"></script>
+  </body>
+</html>
+    `,
+    );
+    assert.deepEqual(normalizeDependencies(dependencies), [
+      {
+        url: 'input.js',
+        opts: {
+          bundleBehavior: 'isolated',
+          env: {
+            loc: null,
+            outputFormat: 'global',
+            sourceType: 'script',
+          },
+          priority: 'parallel',
+        },
+      },
+    ]);
+
+    assert.deepEqual(transformResult, [inputAsset]);
+  });
+
+  it('we will get one dependency per asset', async () => {
+    const code = `
+<html>
+  <body>
+    <script src="input1.js"></script>
+    <script src="input2.js"></script>
+  </body>
+</html>
+    `;
+    const {dependencies, outputCode, transformResult, inputAsset} =
+      await runTestTransform(code);
+    assert.equal(
+      outputCode,
+      `
+<html>
+  <body>
+    <script src="dependency-id"></script>
+    <script src="dependency-id"></script>
+  </body>
+</html>
+    `,
+    );
+    const opts = {
+      bundleBehavior: 'isolated',
+      env: {
+        loc: null,
+        outputFormat: 'global',
+        sourceType: 'script',
+      },
+      priority: 'parallel',
+    };
+    assert.deepEqual(normalizeDependencies(dependencies), [
+      {
+        url: 'input1.js',
+        opts,
+      },
+      {
+        url: 'input2.js',
+        opts,
+      },
+    ]);
+
+    assert.deepEqual(transformResult, [inputAsset]);
+  });
+
+  it('transform simple module tag', async () => {
+    const code = `
+<html>
+  <body>
+    <script src="input.js" type="module"></script>
+  </body>
+</html>
+    `;
+    const {dependencies, outputCode, transformResult, inputAsset} =
+      await runTestTransform(code);
+    assert.equal(
+      outputCode,
+      `
+<html>
+  <body>
+    <script src="dependency-id" type="module"></script>
+  </body>
+</html>
+    `,
+    );
+    assert.deepEqual(normalizeDependencies(dependencies), [
+      {
+        url: 'input.js',
+        opts: {
+          bundleBehavior: undefined,
+          env: {
+            loc: null,
+            outputFormat: 'esmodule',
+            sourceType: 'module',
+          },
+          priority: 'parallel',
+        },
+      },
+    ]);
+
+    assert.deepEqual(transformResult, [inputAsset]);
+  });
+
+  it('transform simple module tag if there is no support for esmodules', async () => {
+    const code = `
+<html>
+  <body>
+    <script src="input.js" type="module"></script>
+  </body>
+</html>
+    `;
+    const {dependencies, outputCode, transformResult, inputAsset} =
+      await runTestTransform(code, {
+        shouldScopeHoist: true,
+        supportsEsmodules: false,
+      });
+    assert.equal(
+      normalizeHTML(outputCode),
+      normalizeHTML(`
+<html>
+  <body>
+    <script src="dependency-id" type="module"></script>
+    <script src="dependency-id" nomodule="" defer=""></script>
+  </body>
+</html>
+    `),
+    );
+    assert.deepEqual(normalizeDependencies(dependencies), [
+      {
+        url: 'input.js',
+        opts: {
+          bundleBehavior: undefined,
+          env: {
+            loc: null,
+            outputFormat: 'global',
+            sourceType: 'module',
+          },
+          priority: 'parallel',
+        },
+      },
+      {
+        url: 'input.js',
+        opts: {
+          bundleBehavior: undefined,
+          env: {
+            loc: null,
+            outputFormat: 'esmodule',
+            sourceType: 'module',
+          },
+          priority: 'parallel',
+        },
+      },
+    ]);
+
+    assert.deepEqual(transformResult, [inputAsset]);
+  });
+});


### PR DESCRIPTION
There are 2 changes:

* Add rust HTML transformer and start to write test-suite for JavaScript HTML transformer
* Fix asset ID alias

HTML transformer implementation is not complete. I chose to use Servo's HTML parser. There's just a very barebones set-up at the moment.

Please see the commit messages for justifications. I'm removing the "non zero u32" alias because it's unused and incompatible with the current code. So I'd rather alias to string until we port all code to use u32.

We shouldn't have an alias that can't be used on the current code. A change to make the IDs u32 should be applied globally to everything.