### PR TITLE
Always run all V2 tests

### DIFF
--- a/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
+++ b/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
@@ -361,7 +361,9 @@ impl ResolverPlugin for AtlaspackResolver {
       (atlaspack_resolver::Resolution::External, _query) => {
         if let Some(_source_path) = &ctx.dependency.source_path {
           if ctx.dependency.env.is_library && ctx.dependency.specifier_type != SpecifierType::Url {
-            todo!("check excluded dependency for libraries");
+            return Err(anyhow::anyhow!(
+              "Not implemented: We need to check excluded dependency for libraries"
+            ));
           }
         }
 

--- a/crates/atlaspack_plugin_rpc/src/plugin/resolver.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/resolver.rs
@@ -1,11 +1,11 @@
-use std::fmt;
-use std::fmt::Debug;
-
+use anyhow::anyhow;
 use atlaspack_config::PluginNode;
 use atlaspack_core::plugin::PluginContext;
 use atlaspack_core::plugin::ResolveContext;
 use atlaspack_core::plugin::Resolved;
 use atlaspack_core::plugin::ResolverPlugin;
+use std::fmt;
+use std::fmt::Debug;
 
 #[derive(Hash)]
 pub struct RpcResolverPlugin {}
@@ -24,6 +24,6 @@ impl RpcResolverPlugin {
 
 impl ResolverPlugin for RpcResolverPlugin {
   fn resolve(&self, _ctx: ResolveContext) -> Result<Resolved, anyhow::Error> {
-    todo!()
+    Err(anyhow!("Not implemented"))
   }
 }

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -114,7 +114,9 @@ export default function createBundleGraphRequest(
       let {assetGraph, changedAssets, assetRequests} = await api.runRequest(
         request,
         {
-          force: options.shouldBuildLazily && requestedAssetIds.size > 0,
+          force:
+            Boolean(input.rustAtlaspack) ||
+            (options.shouldBuildLazily && requestedAssetIds.size > 0),
         },
       );
 

--- a/packages/core/integration-tests/test/BundleGraph.js
+++ b/packages/core/integration-tests/test/BundleGraph.js
@@ -11,7 +11,7 @@ import {
 } from '@atlaspack/test-utils';
 import type {BundleGraph, BundleGroup, PackagedBundle} from '@atlaspack/types';
 
-describe.v2('BundleGraph', () => {
+describe('BundleGraph', () => {
   it('can traverse assets across bundles and contexts', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/worker-shared/index.js'),
@@ -85,7 +85,7 @@ describe.v2('BundleGraph', () => {
     ]);
   });
 
-  describe('getBundlesInBundleGroup', () => {
+  describe.v2('getBundlesInBundleGroup', () => {
     let bundleGraph: BundleGraph<PackagedBundle>;
     let bundleGroup: BundleGroup;
     let dir = path.join(__dirname, 'get-bundles-in-bundle-group');

--- a/packages/core/integration-tests/test/BundleGraph.js
+++ b/packages/core/integration-tests/test/BundleGraph.js
@@ -86,11 +86,12 @@ describe('BundleGraph', () => {
   });
 
   describe.v2('getBundlesInBundleGroup', () => {
-    let bundleGraph: BundleGraph<PackagedBundle>;
-    let bundleGroup: BundleGroup;
     let dir = path.join(__dirname, 'get-bundles-in-bundle-group');
 
-    before(async () => {
+    async function setupTest(): Promise<{
+      bundleGraph: BundleGraph<PackagedBundle>,
+      bundleGroup: BundleGroup,
+    }> {
       await overlayFS.mkdirp(dir);
 
       await fsFixture(overlayFS, dir)`
@@ -103,20 +104,21 @@ describe('BundleGraph', () => {
         yarn.lock: {}
       `;
 
-      bundleGraph = await bundle(path.join(dir, 'index.jsx'), {
+      const bundleGraph = await bundle(path.join(dir, 'index.jsx'), {
         inputFS: overlayFS,
       });
-
-      bundleGroup = bundleGraph.getBundleGroupsContainingBundle(
+      const bundleGroup = bundleGraph.getBundleGroupsContainingBundle(
         bundleGraph.getBundles({includeInline: true})[0],
       )[0];
-    });
+      return {bundleGraph, bundleGroup};
+    }
 
     after(async () => {
       await overlayFS.rimraf(dir);
     });
 
-    it('does not return inlineAssets by default', () => {
+    it('does not return inlineAssets by default', async () => {
+      const {bundleGraph, bundleGroup} = await setupTest();
       const bundles = bundleGraph.getBundlesInBundleGroup(bundleGroup);
 
       assert.deepEqual(
@@ -125,7 +127,8 @@ describe('BundleGraph', () => {
       );
     });
 
-    it('does not return inlineAssets when requested', () => {
+    it('does not return inlineAssets when requested', async () => {
+      const {bundleGraph, bundleGroup} = await setupTest();
       const bundles = bundleGraph.getBundlesInBundleGroup(bundleGroup, {
         includeInline: false,
       });
@@ -136,7 +139,8 @@ describe('BundleGraph', () => {
       );
     });
 
-    it('returns inlineAssets when requested', () => {
+    it('returns inlineAssets when requested', async () => {
+      const {bundleGraph, bundleGroup} = await setupTest();
       const bundles = bundleGraph.getBundlesInBundleGroup(bundleGroup, {
         includeInline: true,
       });

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -14,8 +14,8 @@ import {
 
 import {ATLASPACK_VERSION} from '../../core/src/constants';
 
-describe.v2('JS API', function () {
-  it('should respect distEntry', async function () {
+describe('JS API', function () {
+  it.v2('should respect distEntry', async function () {
     const NAME = 'custom-name.js';
 
     let b = await bundle(

--- a/packages/core/integration-tests/test/contentHashing.js
+++ b/packages/core/integration-tests/test/contentHashing.js
@@ -21,12 +21,12 @@ function bundle(path) {
   });
 }
 
-describe.v2('content hashing', function () {
+describe('content hashing', function () {
   beforeEach(async () => {
     await outputFS.rimraf(path.join(__dirname, '/input'));
   });
 
-  it('should update content hash when content changes', async function () {
+  it.v2('should update content hash when content changes', async function () {
     await ncp(
       path.join(__dirname, '/integration/html-css'),
       path.join(__dirname, '/input'),
@@ -59,7 +59,7 @@ describe.v2('content hashing', function () {
     assert.notEqual(filename, newFilename);
   });
 
-  it('should update content hash when raw asset changes', async function () {
+  it.v2('should update content hash when raw asset changes', async function () {
     await ncp(
       path.join(__dirname, '/integration/import-raw'),
       path.join(__dirname, '/input'),
@@ -94,25 +94,28 @@ describe.v2('content hashing', function () {
     );
   });
 
-  it('should generate the same hash for the same distDir inside separate projects', async () => {
-    let a = await _bundle(
-      path.join(__dirname, 'integration/hash-distDir/a/index.html'),
-      {sourceMaps: true},
-    );
-    let b = await _bundle(
-      path.join(__dirname, 'integration/hash-distDir/b/index.html'),
-      {sourceMaps: true},
-    );
+  it.v2(
+    'should generate the same hash for the same distDir inside separate projects',
+    async () => {
+      let a = await _bundle(
+        path.join(__dirname, 'integration/hash-distDir/a/index.html'),
+        {sourceMaps: true},
+      );
+      let b = await _bundle(
+        path.join(__dirname, 'integration/hash-distDir/b/index.html'),
+        {sourceMaps: true},
+      );
 
-    let aBundles = a.getBundles();
-    let bBundles = b.getBundles();
+      let aBundles = a.getBundles();
+      let bBundles = b.getBundles();
 
-    assert.equal(aBundles.length, 2);
-    assert.equal(bBundles.length, 2);
+      assert.equal(aBundles.length, 2);
+      assert.equal(bBundles.length, 2);
 
-    let aJS = aBundles.find(bundle => bundle.type === 'js');
-    let bJS = bBundles.find(bundle => bundle.type === 'js');
-    assert(/index\.[a-f0-9]*\.js/.test(path.basename(aJS.filePath)));
-    assert.equal(aJS.name, bJS.name);
-  });
+      let aJS = aBundles.find(bundle => bundle.type === 'js');
+      let bJS = bBundles.find(bundle => bundle.type === 'js');
+      assert(/index\.[a-f0-9]*\.js/.test(path.basename(aJS.filePath)));
+      assert.equal(aJS.name, bJS.name);
+    },
+  );
 });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1323,7 +1323,6 @@ function itImpl(
   ...args: mixed[]
 ) {
   const fn = only ? origIt.only : origIt;
-  console.log({testVersionContext, isAtlaspackV3, only, title});
   if (
     testVersionContext == null ||
     (testVersionContext === 'v2' && !isAtlaspackV3) ||

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1335,9 +1335,9 @@ function itImpl(
       this,
       title,
       async function () {
-        // Timeout mocha after 3s when running V2 tests over V3, but also self
-        // timeout after 2s to avoid hanging the test suite.
-        this.timeout(3000);
+        // Timeout mocha after 10s when running V2 tests over V3, but also self
+        // timeout after 9s to avoid hanging the test suite.
+        this.timeout(10000);
         this.retries(0);
 
         try {
@@ -1346,7 +1346,7 @@ function itImpl(
             new Promise((_, reject) => {
               setTimeout(() => {
                 reject(new Error('TEST: Timeout'));
-              }, 2000);
+              }, 9000);
             }),
           ]);
         } catch (err) {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1335,8 +1335,20 @@ function itImpl(
       this,
       title,
       async function () {
+        // Timeout mocha after 3s when running V2 tests over V3, but also self
+        // timeout after 2s to avoid hanging the test suite.
+        this.timeout(3000);
+        this.retries(0);
+
         try {
-          await builder.call(this);
+          await Promise.race([
+            builder.call(this),
+            new Promise((_, reject) => {
+              setTimeout(() => {
+                reject(new Error('TEST: Timeout'));
+              }, 2000);
+            }),
+          ]);
         } catch (err) {
           // eslint-disable-next-line no-console
           console.error(`TEST: ${title} failed for V3`, err);

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1338,9 +1338,11 @@ function itImpl(
         try {
           await builder.call(this);
         } catch (err) {
+          // eslint-disable-next-line no-console
           console.error(`TEST: ${title} failed for V3`, err);
           return;
         }
+        // eslint-disable-next-line no-console
         console.error(`TEST: ${title} is green for V3 but skipped`);
       },
       args,


### PR DESCRIPTION
This commit modifies the integration testing rig so that we run all V2 tests on the V3 integration suite, even if they are currently marked as failures.

The purpose of doing this is to:

* Quickly understand what failures are happening from CI build logs
* Be able to build tooling that automatically tries to diagnose current gaps
* Identify tests that are not failing but are currently skipped

This diff adds a few other changes outside of test-utils:

* The rust 'RPC' resolver code, which is meant for plugin support is changed so that it will not panic and crash a thread, since that will otherwise stall the test-suite
* A few tests that should be passing on V3 are re-enabled
* I reckon we should force the asset graph to be built always on the V3 implementation for now. So this adds `force: true` on the runs that are using the rust back-end. This is temporary until we have cache invalidation