### PR TITLE
Partially wire-up cache invalidation forwarding

### DIFF
--- a/crates/atlaspack/src/request_tracker/request_graph.rs
+++ b/crates/atlaspack/src/request_tracker/request_graph.rs
@@ -1,15 +1,15 @@
 use petgraph::stable_graph::StableDiGraph;
 
-use crate::request_tracker::RunRequestError;
+use crate::request_tracker::{ResultAndInvalidations, RunRequestError};
 
-pub type RequestGraph<T> = StableDiGraph<RequestNode<T>, RequestEdgeType>;
+pub type RequestGraph = StableDiGraph<RequestNode, RequestEdgeType>;
 
 #[derive(Debug)]
-pub enum RequestNode<T> {
+pub enum RequestNode {
   Error(RunRequestError),
   Root,
   Incomplete,
-  Valid(T),
+  Valid(ResultAndInvalidations),
 }
 
 #[derive(Debug)]

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -6,10 +6,10 @@ use atlaspack_core::plugin::AssetBuildEvent;
 use atlaspack_core::plugin::BuildProgressEvent;
 use atlaspack_core::plugin::ReporterEvent;
 use atlaspack_core::plugin::TransformResult;
-use atlaspack_core::types::Asset;
 use atlaspack_core::types::AssetStats;
 use atlaspack_core::types::Dependency;
 use atlaspack_core::types::Environment;
+use atlaspack_core::types::{Asset, Invalidation};
 
 use crate::plugins::PluginsRef;
 use crate::plugins::TransformerPipeline;
@@ -77,8 +77,11 @@ impl Request for AssetRequest {
         },
         dependencies: result.dependencies,
       }),
-      // TODO: Support invalidations
-      invalidations: vec![],
+      invalidations: result
+        .invalidate_on_file_change
+        .into_iter()
+        .map(|path| Invalidation::FileChange(path))
+        .collect(),
     })
   }
 }

--- a/crates/atlaspack_core/src/types/invalidation.rs
+++ b/crates/atlaspack_core/src/types/invalidation.rs
@@ -1,2 +1,6 @@
+use std::path::PathBuf;
+
 #[derive(Debug, PartialEq, Clone)]
-pub enum Invalidation {}
+pub enum Invalidation {
+  FileChange(PathBuf),
+}


### PR DESCRIPTION
This change wires-up passing cache invalidation data from the asset request into the request tracker.

It also removes one seemingly unnecessary generic type we had around request graph nodes. 