### PR TITLE
Skip project root relativisation of paths if they're already relative

### DIFF
--- a/packages/core/core/src/projectPath.js
+++ b/packages/core/core/src/projectPath.js
@@ -9,9 +9,9 @@ import {relativePath, normalizeSeparators} from '@atlaspack/utils';
 export opaque type ProjectPath = string;
 
 function toProjectPath_(projectRoot: FilePath, p: FilePath): ProjectPath {
-  // If the file path is not provided, is already relative, or already absolute,
-  // then there's no work to do
-  if (p == null && p?.[0] !== '.' && p?.[0] !== '/') {
+  // If the file path is not provided, or is not relative or absolute, then we
+  // treat it as though it's from the project root already
+  if (p == null || !(p?.[0] === '.' || path.isAbsolute(p))) {
     return p;
   }
 

--- a/packages/core/core/src/projectPath.js
+++ b/packages/core/core/src/projectPath.js
@@ -9,10 +9,9 @@ import {relativePath, normalizeSeparators} from '@atlaspack/utils';
 export opaque type ProjectPath = string;
 
 function toProjectPath_(projectRoot: FilePath, p: FilePath): ProjectPath {
-  let firstChar = p[0];
   // If the file path is not provided, is already relative, or already absolute,
   // then there's no work to do
-  if (p == null && firstChar !== '.' && firstChar !== '/') {
+  if (p == null && p[0] !== '.' && p[0] !== '/') {
     return p;
   }
 

--- a/packages/core/core/src/projectPath.js
+++ b/packages/core/core/src/projectPath.js
@@ -11,7 +11,7 @@ export opaque type ProjectPath = string;
 function toProjectPath_(projectRoot: FilePath, p: FilePath): ProjectPath {
   // If the file path is not provided, is already relative, or already absolute,
   // then there's no work to do
-  if (p == null && p[0] !== '.' && p[0] !== '/') {
+  if (p == null && p?.[0] !== '.' && p?.[0] !== '/') {
     return p;
   }
 

--- a/packages/core/core/src/projectPath.js
+++ b/packages/core/core/src/projectPath.js
@@ -11,7 +11,11 @@ export opaque type ProjectPath = string;
 function toProjectPath_(projectRoot: FilePath, p: FilePath): ProjectPath {
   // If the file path is not provided, or is not relative or absolute, then we
   // treat it as though it's from the project root already
-  if (p == null || !(p?.[0] === '.' || path.isAbsolute(p))) {
+  if (p == null) {
+    return p;
+  }
+
+  if (p?.[0] !== '.' && path.isAbsolute(p)) {
     return p;
   }
 

--- a/packages/core/core/src/projectPath.js
+++ b/packages/core/core/src/projectPath.js
@@ -9,7 +9,10 @@ import {relativePath, normalizeSeparators} from '@atlaspack/utils';
 export opaque type ProjectPath = string;
 
 function toProjectPath_(projectRoot: FilePath, p: FilePath): ProjectPath {
-  if (p == null) {
+  let firstChar = p[0];
+  // If the file path is not provided, is already relative, or already absolute,
+  // then there's no work to do
+  if (p == null && firstChar !== '.' && firstChar !== '/') {
     return p;
   }
 

--- a/packages/core/core/test/requests/ConfigRequest.test.js
+++ b/packages/core/core/test/requests/ConfigRequest.test.js
@@ -229,10 +229,7 @@ describe('ConfigRequest tests', () => {
       invalidateOnConfigKeyChange: [
         {
           configKey: 'key1',
-          filePath: toProjectPath(
-            projectRoot,
-            path.join('project_root', 'config.json'),
-          ),
+          filePath: toProjectPath(projectRoot, 'config.json'),
         },
       ],
     });


### PR DESCRIPTION
In most usages of Parcel/Atlaspack, the CWD that the command has been run from and the project root have been the same.

In the setup for Confluence, however, they aren't. The `parcel:build` commands run from the top level, but actually call the build/start commands in a workspace package a few layers deep.

This caused issues with the gap between CWD and project root being added to the path twice, e.g. `afm/confluence/packages/confluence-frontend-server/packages/confluence-frontend-server/package.json`, due to the fact that it's not _really_ relative, and the node path relativisation algorithm works in kind of a funny way.

Luckily, the point of the `toProjectPath` function is just to make sure that paths that exist outside of the project root are properly set up as either relative to the project root or absolute from the get go, so that those files can be properly located. This means that if the path is already relative or already absolute, we shouldn't do anything with it.