### PR TITLE
Resolve serde error when reading package json browser fields

### DIFF
--- a/crates/atlaspack/src/requests/target_request.rs
+++ b/crates/atlaspack/src/requests/target_request.rs
@@ -96,7 +96,10 @@ impl TargetRequest {
       dist: dist.and_then(|browser| match browser {
         BrowserField::EntryPoint(entrypoint) => Some(entrypoint.clone()),
         BrowserField::ReplacementBySpecifier(replacements) => {
-          name.and_then(|name| replacements.get(&name).map(|v| v.into()))
+          let name = name?;
+          let replacements = replacements.get(&name)?;
+          let path = replacements.as_str()?;
+          Some(path.into())
         }
       }),
       name: "browser",

--- a/crates/atlaspack/src/requests/target_request/package_json.rs
+++ b/crates/atlaspack/src/requests/target_request/package_json.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde::Deserializer;
 use serde_json::Value;
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum BrowserField {
   EntryPoint(PathBuf),
@@ -20,7 +20,7 @@ pub enum BrowserField {
   ReplacementBySpecifier(HashMap<String, serde_json::Value>),
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum BrowsersList {
   Browser(String),
@@ -28,14 +28,14 @@ pub enum BrowsersList {
   BrowsersByEnv(HashMap<String, Vec<String>>),
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(untagged)]
 pub enum BuiltInTargetDescriptor {
   Disabled(serde_bool::False),
   TargetDescriptor(TargetDescriptor),
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, PartialEq)]
 #[serde(default, rename_all = "camelCase")]
 pub struct TargetDescriptor {
   pub context: Option<EnvironmentContext>,
@@ -52,7 +52,7 @@ pub struct TargetDescriptor {
   pub source_map: Option<SourceMapField>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum ModuleFormat {
   CommonJS,
@@ -68,7 +68,7 @@ impl Display for ModuleFormat {
   }
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct PackageJson {
   pub name: Option<String>,
 
@@ -99,7 +99,7 @@ pub struct PackageJson {
   pub fields: HashMap<String, serde_json::Value>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub enum SourceField {
   #[allow(unused)]
   Source(String),
@@ -107,7 +107,7 @@ pub enum SourceField {
   Sources(Vec<String>),
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
 pub enum SourceMapField {
   Bool(bool),
   Options(TargetSourceMapOptions),
@@ -140,7 +140,7 @@ where
   Ok(browser)
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, PartialEq)]
 pub struct TargetsField {
   #[serde(default, deserialize_with = "browser_target")]
   pub browser: Option<BuiltInTargetDescriptor>,
@@ -309,4 +309,56 @@ where
   }
 
   Ok(())
+}
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn test_parse_package_json() {
+    let raw_package_json = r#"
+{
+  "name": "example-package",
+  "type": "module",
+  "browser": {
+    "main": "./browser-main.js",
+    "module": "./browser-module.js"
+  },
+  "main": "./index.js",
+  "module": "./index.mjs",
+  "types": "./index.d.ts",
+  "engines": {
+     "npm": ">=6.0.0"
+  },
+  "browserslist": [
+    "> 1%"
+  ]
+}"#;
+    let package_json: PackageJson = serde_json::from_str(raw_package_json).unwrap();
+
+    assert_eq!(
+      package_json,
+      PackageJson {
+        name: Some(String::from("example-package"),),
+        module_format: Some(ModuleFormat::Module),
+        browser: Some(BrowserField::ReplacementBySpecifier(HashMap::from([
+          (String::from("main"), Value::from("./browser-main.js")),
+          (String::from("module"), Value::from("./browser-module.js")),
+        ])),),
+        main: Some(PathBuf::from("./index.js"),),
+        module: Some(PathBuf::from("./index.mjs"),),
+        types: Some(PathBuf::from("./index.d.ts"),),
+        engines: Some(Engines {
+          atlaspack: None,
+          browsers: Default::default(),
+          electron: None,
+          node: None,
+        },),
+        browserslist: Some(BrowsersList::Browsers(vec![String::from("> 1%")],),),
+        targets: TargetsField::default(),
+        ..Default::default()
+      }
+    )
+  }
 }

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1907,42 +1907,33 @@ describe('javascript', function () {
     assert.equal(output.test(), 'pkg-browser');
   });
 
-  it.v2(
-    'should exclude resolving specifiers that map to false in the browser field in browser builds',
-    async () => {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/resolve-entries/pkg-ignore-browser/index.js',
-        ),
-        {
-          targets: ['browsers'],
-        },
-      );
+  it.only('should exclude resolving specifiers that map to false in the browser field in browser builds', async () => {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/resolve-entries/pkg-ignore-browser/index.js',
+      ),
+      {
+        targets: ['browsers'],
+      },
+    );
 
-      assert.deepEqual(await run(b), {});
-    },
-  );
+    assert.deepEqual(await run(b), {});
+  });
 
-  it.v2(
-    'should not exclude resolving specifiers that map to false in the browser field in node builds',
-    async () => {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/resolve-entries/pkg-ignore-browser/index.js',
-        ),
-        {
-          targets: ['node'],
-        },
-      );
+  it.only('should not exclude resolving specifiers that map to false in the browser field in node builds', async () => {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        '/integration/resolve-entries/pkg-ignore-browser/index.js',
+      ),
+      {
+        targets: ['node'],
+      },
+    );
 
-      assert.equal(
-        await run(b),
-        'this should only exist in non-browser builds',
-      );
-    },
-  );
+    assert.equal(await run(b), 'this should only exist in non-browser builds');
+  });
 
   it.skip('should not resolve the browser field for --target=node', async function () {
     let b = await bundle(

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1907,33 +1907,42 @@ describe('javascript', function () {
     assert.equal(output.test(), 'pkg-browser');
   });
 
-  it.only('should exclude resolving specifiers that map to false in the browser field in browser builds', async () => {
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/resolve-entries/pkg-ignore-browser/index.js',
-      ),
-      {
-        targets: ['browsers'],
-      },
-    );
+  it.v2(
+    'should exclude resolving specifiers that map to false in the browser field in browser builds',
+    async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/resolve-entries/pkg-ignore-browser/index.js',
+        ),
+        {
+          targets: ['browsers'],
+        },
+      );
 
-    assert.deepEqual(await run(b), {});
-  });
+      assert.deepEqual(await run(b), {});
+    },
+  );
 
-  it.only('should not exclude resolving specifiers that map to false in the browser field in node builds', async () => {
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/resolve-entries/pkg-ignore-browser/index.js',
-      ),
-      {
-        targets: ['node'],
-      },
-    );
+  it.v2(
+    'should not exclude resolving specifiers that map to false in the browser field in node builds',
+    async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/resolve-entries/pkg-ignore-browser/index.js',
+        ),
+        {
+          targets: ['node'],
+        },
+      );
 
-    assert.equal(await run(b), 'this should only exist in non-browser builds');
-  });
+      assert.equal(
+        await run(b),
+        'this should only exist in non-browser builds',
+      );
+    },
+  );
 
   it.skip('should not resolve the browser field for --target=node', async function () {
     let b = await bundle(


### PR DESCRIPTION
The original error was a parsing issue due to type mismatching in `package.json`. This code resolves it and reveals an issue with the asset graph being incorrectly built in case multiple targets are stated. The tests now fail with the error "Bundles must have unique name. Conflicting names:". This will be fixed in a separate PR.