### PR TITLE
Add test for html transformer in case of an inline script

### DIFF
--- a/packages/transformers/html/test/HTMLTransformer.test.js
+++ b/packages/transformers/html/test/HTMLTransformer.test.js
@@ -72,6 +72,7 @@ function normalizeDependencies(dependencies) {
     opts: {
       ...dependency.opts,
       env: {
+        // $FlowFixMe
         ...dependency.opts.env,
         loc: null,
       },
@@ -81,8 +82,8 @@ function normalizeDependencies(dependencies) {
 
 function normalizeAssets(assets) {
   return assets.map(asset => {
+    // $FlowFixMe
     return {
-      // $FlowFixMe
       ...asset,
       env: null,
       meta: null,

--- a/packages/transformers/html/test/HTMLTransformer.test.js
+++ b/packages/transformers/html/test/HTMLTransformer.test.js
@@ -128,7 +128,7 @@ describe('HTMLTransformer', () => {
     assert.deepEqual(transformResult, [inputAsset]);
   });
 
-  it.only('transforms simple inline script', async () => {
+  it('transforms simple inline script', async () => {
     const code = `
 <html>
   <body>

--- a/packages/transformers/html/test/HTMLTransformer.test.js
+++ b/packages/transformers/html/test/HTMLTransformer.test.js
@@ -82,6 +82,7 @@ function normalizeDependencies(dependencies) {
 function normalizeAssets(assets) {
   return assets.map(asset => {
     return {
+      // $FlowFixMe
       ...asset,
       env: null,
       meta: null,


### PR DESCRIPTION
We didn't test for inline scripts before and it will help to have a test for both the v2 and v3 transformer, the v3 test will be written in a separate PR.