### PR TITLE
Change transformers to allow multiple assets in result

### DIFF
--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -1,5 +1,3 @@
-use std::hash::Hash;
-use std::hash::Hasher;
 use std::path::Path;
 use std::sync::Arc;
 

--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -197,11 +197,7 @@ impl Plugins for ConfigPlugins {
       use_fallback: false,
     });
 
-    let mut hasher = atlaspack_core::hash::IdentifierHasher::default();
-
     for transformer in self.config.transformers.get(path, named_pattern).iter() {
-      transformer.hash(&mut hasher);
-
       let transformer: Box<dyn TransformerPlugin> = match transformer.package_name.as_str() {
         // Currently JS plugins don't work and it's easier to just skip these.
         // We also will probably remove babel from the defaults and support react refresh in Rust
@@ -241,10 +237,7 @@ impl Plugins for ConfigPlugins {
       };
     }
 
-    Ok(TransformerPipeline {
-      transformers,
-      hash: hasher.finish(),
-    })
+    Ok(TransformerPipeline::new(transformers))
   }
 
   #[allow(unused)]
@@ -342,12 +335,9 @@ mod tests {
       format!("{:?}", pipeline),
       format!(
         "{:?}",
-        TransformerPipeline {
-          transformers: vec![Box::new(
-            AtlaspackJsTransformerPlugin::new(&make_test_plugin_context()).unwrap()
-          )],
-          hash: 1
-        }
+        TransformerPipeline::new(vec![Box::new(
+          AtlaspackJsTransformerPlugin::new(&make_test_plugin_context()).unwrap()
+        )]),
       )
     );
   }

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -235,6 +235,11 @@ impl AssetGraphBuilder {
     // Connect the incoming DependencyNode to the new AssetNode
     let asset_node_index = self.graph.add_asset(incoming_dep_node_index, asset.clone());
 
+    // TODO: Stitch discovered assets to the AssetGraph
+    // for asset in discovered_assets {
+    //   self.graph.add_asset(asset_node_index, asset);
+    // }
+
     self
       .asset_request_to_asset
       .insert(request_id, asset_node_index);

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -224,6 +224,7 @@ impl AssetGraphBuilder {
   fn handle_asset_result(&mut self, result: AssetRequestOutput, request_id: u64) {
     let AssetRequestOutput {
       asset,
+      discovered_assets: _,
       dependencies,
     } = result;
     let incoming_dep_node_index = *self

--- a/crates/atlaspack_core/src/plugin/transformer_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/transformer_plugin.rs
@@ -18,6 +18,7 @@ pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, an
 #[derive(Debug, Serialize, PartialEq)]
 pub struct TransformResult {
   pub asset: Asset,
+  pub discovered_assets: Vec<Asset>,
   pub dependencies: Vec<Dependency>,
   /// The transformer signals through this field that its result should be invalidated
   /// if these paths change.

--- a/crates/atlaspack_core/src/plugin/transformer_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/transformer_plugin.rs
@@ -1,9 +1,11 @@
-use std::fmt::Debug;
-use std::path::PathBuf;
-
-use serde::Serialize;
-
+use crate::hash::IdentifierHasher;
 use crate::types::{Asset, Dependency, SpecifierType};
+use mockall::automock;
+use serde::Serialize;
+use std::any::Any;
+use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
+use std::path::PathBuf;
 
 pub struct ResolveOptions {
   /// A list of custom conditions to use when resolving package.json "exports" and "imports"
@@ -30,7 +32,14 @@ pub struct TransformResult {
 /// Many transformers are wrappers around other tools such as compilers and preprocessors, and are
 /// designed to integrate with Atlaspack.
 ///
-pub trait TransformerPlugin: Debug + Send + Sync {
+#[automock]
+pub trait TransformerPlugin: Any + Debug + Send + Sync {
+  /// Unique ID for this transformer
+  fn id(&self) -> u64 {
+    let mut hasher = IdentifierHasher::new();
+    self.type_id().hash(&mut hasher);
+    hasher.finish()
+  }
   /// Transform the asset and/or add new assets
   fn transform(&mut self, input: Asset) -> Result<TransformResult, anyhow::Error>;
 }

--- a/crates/atlaspack_core/src/plugin/transformer_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/transformer_plugin.rs
@@ -15,7 +15,7 @@ pub struct ResolveOptions {
 /// A function that enables transformers to resolve a dependency specifier
 pub type Resolve = dyn Fn(PathBuf, String, ResolveOptions) -> Result<PathBuf, anyhow::Error>;
 
-#[derive(Debug, Serialize, PartialEq)]
+#[derive(Debug, Serialize, PartialEq, Default)]
 pub struct TransformResult {
   pub asset: Asset,
   pub discovered_assets: Vec<Asset>,

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use anyhow::Error;
 
 use atlaspack_config::PluginNode;
+use atlaspack_core::hash::IdentifierHasher;
 use atlaspack_core::plugin::PluginContext;
 use atlaspack_core::plugin::TransformResult;
 use atlaspack_core::plugin::TransformerPlugin;
@@ -45,6 +46,12 @@ impl RpcTransformerPlugin {
 }
 
 impl TransformerPlugin for RpcTransformerPlugin {
+  fn id(&self) -> u64 {
+    let mut hasher = IdentifierHasher::new();
+    self.plugin.hash(&mut hasher);
+    hasher.finish()
+  }
+
   fn transform(&mut self, asset: Asset) -> Result<TransformResult, Error> {
     let asset_env = asset.env.clone();
     let stats = asset.stats.clone();

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -82,6 +82,7 @@ impl TransformerPlugin for RpcTransformerPlugin {
     Ok(TransformResult {
       asset: transformed_asset,
       // Adding dependencies from Node plugins isn't yet supported
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       // TODO: Handle invalidations
       invalidate_on_file_change: Vec::new(),

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -80,12 +80,10 @@ impl TransformerPlugin for RpcTransformerPlugin {
     };
 
     Ok(TransformResult {
-      asset: transformed_asset,
       // Adding dependencies from Node plugins isn't yet supported
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
       // TODO: Handle invalidations
-      invalidate_on_file_change: Vec::new(),
+      asset: transformed_asset,
+      ..Default::default()
     })
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fmt::Debug;
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use anyhow::Error;

--- a/crates/atlaspack_plugin_transformer_html/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/lib.rs
@@ -37,6 +37,7 @@ impl TransformerPlugin for AtlaspackHtmlTransformerPlugin {
 
     Ok(TransformResult {
       asset,
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       invalidate_on_file_change: Vec::new(),
     })

--- a/crates/atlaspack_plugin_transformer_html/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/lib.rs
@@ -37,9 +37,7 @@ impl TransformerPlugin for AtlaspackHtmlTransformerPlugin {
 
     Ok(TransformResult {
       asset,
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
-      invalidate_on_file_change: Vec::new(),
+      ..Default::default()
     })
   }
 }

--- a/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
@@ -72,9 +72,7 @@ impl TransformerPlugin for AtlaspackImageTransformerPlugin {
 
     Ok(TransformResult {
       asset,
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
-      invalidate_on_file_change: Vec::new(),
+      ..Default::default()
     })
   }
 }
@@ -130,8 +128,7 @@ mod tests {
           bundle_behavior: BundleBehavior::Isolated,
           ..Asset::default()
         },
-        dependencies: Vec::new(),
-        invalidate_on_file_change: Vec::new()
+        ..Default::default()
       })
     );
   }

--- a/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
@@ -72,6 +72,7 @@ impl TransformerPlugin for AtlaspackImageTransformerPlugin {
 
     Ok(TransformResult {
       asset,
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       invalidate_on_file_change: Vec::new(),
     })

--- a/crates/atlaspack_plugin_transformer_inline/src/inline_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline/src/inline_transformer.rs
@@ -21,9 +21,7 @@ impl TransformerPlugin for AtlaspackInlineTransformerPlugin {
 
     Ok(TransformResult {
       asset,
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
-      invalidate_on_file_change: Vec::new(),
+      ..Default::default()
     })
   }
 }
@@ -64,8 +62,7 @@ mod tests {
           bundle_behavior: BundleBehavior::Inline,
           ..Asset::default()
         },
-        dependencies: Vec::new(),
-        invalidate_on_file_change: Vec::new()
+        ..Default::default()
       })
     );
   }

--- a/crates/atlaspack_plugin_transformer_inline/src/inline_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline/src/inline_transformer.rs
@@ -21,6 +21,7 @@ impl TransformerPlugin for AtlaspackInlineTransformerPlugin {
 
     Ok(TransformResult {
       asset,
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       invalidate_on_file_change: Vec::new(),
     })

--- a/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
@@ -22,9 +22,7 @@ impl TransformerPlugin for AtlaspackInlineStringTransformerPlugin {
 
     Ok(TransformResult {
       asset,
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
-      invalidate_on_file_change: Vec::new(),
+      ..Default::default()
     })
   }
 }
@@ -67,8 +65,7 @@ mod tests {
           meta: JSONObject::from_iter([(String::from("inlineType"), "string".into())]),
           ..Asset::default()
         },
-        dependencies: Vec::new(),
-        invalidate_on_file_change: Vec::new()
+        ..Default::default()
       })
     );
   }

--- a/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
@@ -22,6 +22,7 @@ impl TransformerPlugin for AtlaspackInlineStringTransformerPlugin {
 
     Ok(TransformResult {
       asset,
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       invalidate_on_file_change: Vec::new(),
     })

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -373,6 +373,7 @@ mod tests {
           unique_key: Some(target_asset.id.clone()),
           ..target_asset
         },
+        discovered_assets: vec![],
         dependencies: vec![],
         invalidate_on_file_change: vec![]
       }
@@ -464,6 +465,7 @@ exports.hello = function() {};
           unique_key: Some(asset_id),
           ..empty_asset()
         },
+        discovered_assets: vec![],
         dependencies: expected_dependencies,
         invalidate_on_file_change: vec![]
       }

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -302,6 +302,7 @@ pub(crate) fn convert_result(
 
   Ok(TransformResult {
     asset,
+    discovered_assets: Vec::new(),
     dependencies: dependency_by_specifier.into_values().collect(),
     // map: result.map,
     // shebang: result.shebang,

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -302,7 +302,6 @@ pub(crate) fn convert_result(
 
   Ok(TransformResult {
     asset,
-    discovered_assets: Vec::new(),
     dependencies: dependency_by_specifier.into_values().collect(),
     // map: result.map,
     // shebang: result.shebang,
@@ -310,6 +309,7 @@ pub(crate) fn convert_result(
     // diagnostics: result.diagnostics,
     // used_env: result.used_env.into_iter().map(|v| v.to_string()).collect(),
     invalidate_on_file_change,
+    ..Default::default()
   })
 }
 

--- a/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
@@ -28,9 +28,7 @@ impl TransformerPlugin for AtlaspackJsonTransformerPlugin {
 
     Ok(TransformResult {
       asset,
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
-      invalidate_on_file_change: Vec::new(),
+      ..Default::default()
     })
   }
 }
@@ -94,9 +92,7 @@ mod tests {
           file_type: FileType::Js,
           ..Asset::default()
         },
-        discovered_assets: Vec::new(),
-        dependencies: Vec::new(),
-        invalidate_on_file_change: Vec::new()
+        ..Default::default()
       })
     );
   }
@@ -137,8 +133,7 @@ mod tests {
           file_type: FileType::Js,
           ..Asset::default()
         },
-        dependencies: Vec::new(),
-        invalidate_on_file_change: Vec::new()
+        ..Default::default()
       })
     );
   }

--- a/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
@@ -28,6 +28,7 @@ impl TransformerPlugin for AtlaspackJsonTransformerPlugin {
 
     Ok(TransformResult {
       asset,
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       invalidate_on_file_change: Vec::new(),
     })

--- a/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
@@ -94,6 +94,7 @@ mod tests {
           file_type: FileType::Js,
           ..Asset::default()
         },
+        discovered_assets: Vec::new(),
         dependencies: Vec::new(),
         invalidate_on_file_change: Vec::new()
       })

--- a/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
@@ -63,6 +63,7 @@ mod tests {
           bundle_behavior: BundleBehavior::Isolated,
           ..Asset::default()
         },
+        discovered_assets: Vec::new(),
         dependencies: Vec::new(),
         invalidate_on_file_change: Vec::new()
       })

--- a/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
@@ -20,9 +20,7 @@ impl TransformerPlugin for AtlaspackRawTransformerPlugin {
 
     Ok(TransformResult {
       asset,
-      discovered_assets: Vec::new(),
-      dependencies: Vec::new(),
-      invalidate_on_file_change: Vec::new(),
+      ..Default::default()
     })
   }
 }
@@ -63,9 +61,7 @@ mod tests {
           bundle_behavior: BundleBehavior::Isolated,
           ..Asset::default()
         },
-        discovered_assets: Vec::new(),
-        dependencies: Vec::new(),
-        invalidate_on_file_change: Vec::new()
+        ..Default::default()
       })
     );
   }

--- a/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
@@ -20,6 +20,7 @@ impl TransformerPlugin for AtlaspackRawTransformerPlugin {
 
     Ok(TransformResult {
       asset,
+      discovered_assets: Vec::new(),
       dependencies: Vec::new(),
       invalidate_on_file_change: Vec::new(),
     })


### PR DESCRIPTION
The PR achieves the following:
* implements logic to discover and process new assets with a queue
* adds unit tests for new functionality
* changes the transformers and pipeline APIs to allow for easier mocking and to no longer use hash keyword to avoid colliding with the standard library

The remaining work is to model the `AssetRequestOutput` and related function to update the new assets.