### PR TITLE
Add basic Node JS plugin support

### DIFF
--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conns_nodejs.rs
@@ -1,10 +1,8 @@
-use std::path::Path;
-
 use parking_lot::Mutex;
 
 use super::NodejsWorker;
 
-use crate::RpcWorker;
+use crate::{RpcTransformerOpts, RpcTransformerResult, RpcWorker};
 
 /// Connection to multiple Nodejs Workers
 /// Implements round robin messaging
@@ -41,10 +39,8 @@ impl RpcWorker for NodejsWorkerFarm {
     Ok(())
   }
 
-  fn register_transformer(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()> {
-    for worker in &self.workers {
-      worker.register_transformer(resolve_from, specifier)?;
-    }
-    Ok(())
+  fn run_transformer(&self, opts: RpcTransformerOpts) -> anyhow::Result<RpcTransformerResult> {
+    let worker = &self.workers[self.next_index()];
+    worker.run_transformer(opts)
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -75,7 +75,7 @@ impl TransformerPlugin for RpcTransformerPlugin {
       side_effects: result.asset.side_effects,
       is_bundle_splittable: result.asset.is_bundle_splittable,
       is_source: result.asset.is_source,
-      // TODO: Fix or remove the duplicate meta fields. I vote we remove these fields as they're just duplicates of meta
+      // TODO: Fix or remove the duplicate meta fields.
       ..Default::default()
     };
 

--- a/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/transformer.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::fmt::Debug;
+use std::sync::Arc;
 
 use anyhow::Error;
 
@@ -9,40 +10,81 @@ use atlaspack_core::plugin::TransformResult;
 use atlaspack_core::plugin::TransformerPlugin;
 use atlaspack_core::types::Asset;
 
+use crate::RpcPluginOptions;
+use crate::RpcTransformerOpts;
 use crate::RpcWorkerRef;
 
 pub struct RpcTransformerPlugin {
-  _rpc_worker: RpcWorkerRef,
-  name: String,
+  rpc_worker: RpcWorkerRef,
+  plugin: PluginNode,
+  plugin_options: RpcPluginOptions,
 }
 
 impl Debug for RpcTransformerPlugin {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "RpcTransformerPlugin({})", self.name)
+    write!(f, "RpcTransformerPlugin({})", self.plugin.package_name)
   }
 }
 
 impl RpcTransformerPlugin {
   pub fn new(
     rpc_worker: RpcWorkerRef,
-    _ctx: &PluginContext,
+    ctx: &PluginContext,
     plugin: &PluginNode,
   ) -> Result<Self, anyhow::Error> {
-    rpc_worker.register_transformer(&plugin.resolve_from, &plugin.package_name)?;
-
+    let plugin_options = RpcPluginOptions {
+      hmr_options: None,
+      project_root: ctx.options.project_root.clone(),
+    };
     Ok(RpcTransformerPlugin {
-      _rpc_worker: rpc_worker,
-      name: plugin.package_name.clone(),
+      rpc_worker,
+      plugin: plugin.clone(),
+      plugin_options,
     })
   }
 }
 
 impl TransformerPlugin for RpcTransformerPlugin {
   fn transform(&mut self, asset: Asset) -> Result<TransformResult, Error> {
-    Ok(TransformResult {
+    let asset_env = asset.env.clone();
+    let stats = asset.stats.clone();
+    let run_transformer_opts = RpcTransformerOpts {
+      // TODO: Make this not bad
+      resolve_from: self.plugin.resolve_from.to_str().unwrap().to_string(),
+      specifier: self.plugin.package_name.clone(),
+      // TODO: Pass this just once to each worker
+      options: self.plugin_options.clone(),
       asset,
-      dependencies: vec![],
-      invalidate_on_file_change: vec![],
+    };
+
+    let result = self.rpc_worker.run_transformer(run_transformer_opts)?;
+
+    let transformed_asset = Asset {
+      id: result.asset.id,
+      code: Arc::new(result.asset.code),
+      bundle_behavior: result.asset.bundle_behavior,
+      env: asset_env.clone(),
+      file_path: result.asset.file_path,
+      file_type: result.asset.file_type,
+      meta: result.asset.meta,
+      pipeline: result.asset.pipeline,
+      query: result.asset.query,
+      stats,
+      symbols: result.asset.symbols,
+      unique_key: result.asset.unique_key,
+      side_effects: result.asset.side_effects,
+      is_bundle_splittable: result.asset.is_bundle_splittable,
+      is_source: result.asset.is_source,
+      // TODO: Fix or remove the duplicate meta fields. I vote we remove these fields as they're just duplicates of meta
+      ..Default::default()
+    };
+
+    Ok(TransformResult {
+      asset: transformed_asset,
+      // Adding dependencies from Node plugins isn't yet supported
+      dependencies: Vec::new(),
+      // TODO: Handle invalidations
+      invalidate_on_file_change: Vec::new(),
     })
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/rpc_host.rs
+++ b/crates/atlaspack_plugin_rpc/src/rpc_host.rs
@@ -1,9 +1,8 @@
 use std::{path::PathBuf, sync::Arc};
 
 use atlaspack_core::types::{
-  engines::Engines, Asset, BundleBehavior, Code, EnvironmentContext, ExportsCondition, FileType,
-  IncludeNodeModules, JSONObject, OutputFormat, Priority, SourceLocation, SourceType,
-  SpecifierType, Symbol,
+  engines::Engines, Asset, BundleBehavior, Code, EnvironmentContext, FileType, IncludeNodeModules,
+  JSONObject, OutputFormat, SourceLocation, SourceType, Symbol,
 };
 use serde::{Deserialize, Serialize};
 
@@ -66,33 +65,6 @@ pub struct RpcEnvironmentResult {
   pub source_type: Option<SourceType>,
 }
 
-/// This Dependency mostly replicates the core Dependency type however it only features
-/// fields that can be modified by transformers and some properties are
-/// optional as they will be merged into the Asset later
-/// Similar to packages/core/types-internal/src/index.js#DependencyOptions
-#[derive(Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcDependencyResult {
-  pub id: String,
-  pub bundle_behavior: Option<BundleBehavior>,
-  pub env: Option<RpcEnvironmentResult>,
-  #[serde(default)]
-  pub loc: Option<SourceLocation>,
-  #[serde(default)]
-  pub meta: JSONObject,
-  #[serde(default)]
-  pub package_conditions: Option<ExportsCondition>,
-  #[serde(default)]
-  pub pipeline: Option<String>,
-  pub priority: Option<Priority>,
-  pub range: Option<String>,
-  pub resolve_from: Option<PathBuf>,
-  pub specifier: String,
-  pub specifier_type: SpecifierType,
-  #[serde(default)]
-  pub symbols: Option<Vec<Symbol>>,
-}
-
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransformerOpts {
@@ -106,7 +78,6 @@ pub struct RpcTransformerOpts {
 #[serde(rename_all = "camelCase")]
 pub struct RpcTransformerResult {
   pub asset: RpcAssetResult,
-  pub dependencies: Vec<RpcDependencyResult>,
 }
 
 pub trait RpcWorker: Send + Sync {

--- a/crates/atlaspack_plugin_rpc/src/rpc_host.rs
+++ b/crates/atlaspack_plugin_rpc/src/rpc_host.rs
@@ -1,5 +1,11 @@
-use std::path::Path;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
+
+use atlaspack_core::types::{
+  engines::Engines, Asset, BundleBehavior, Code, EnvironmentContext, ExportsCondition, FileType,
+  IncludeNodeModules, JSONObject, OutputFormat, Priority, SourceLocation, SourceType,
+  SpecifierType, Symbol,
+};
+use serde::{Deserialize, Serialize};
 
 pub type RpcHostRef = Arc<dyn RpcHost>;
 pub type RpcWorkerRef = Arc<dyn RpcWorker>;
@@ -8,7 +14,102 @@ pub trait RpcHost: Send + Sync {
   fn start(&self) -> anyhow::Result<RpcWorkerRef>;
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHmrOptions {
+  pub port: Option<u16>,
+  pub host: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcPluginOptions {
+  pub hmr_options: Option<RpcHmrOptions>,
+  pub project_root: PathBuf,
+}
+
+/// This Asset mostly replicates the core Asset type however it only features
+/// fields that can be modified by transformers to save on desialization
+#[derive(Default, PartialEq, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcAssetResult {
+  pub id: String,
+  pub bundle_behavior: BundleBehavior,
+  pub file_path: PathBuf,
+  #[serde(rename = "type")]
+  pub file_type: FileType,
+  pub code: Code,
+  pub meta: JSONObject,
+  pub pipeline: Option<String>,
+  pub query: Option<String>,
+  pub symbols: Option<Vec<Symbol>>,
+  pub unique_key: Option<String>,
+  pub side_effects: bool,
+  pub is_bundle_splittable: bool,
+  pub is_source: bool,
+}
+
+// This Environment mostly replicates the core Environment but makes everything
+// optional as it is merged into the Asset Environment later.
+// Similar to packages/core/types-internal/src/index.js#EnvironmnetOptions
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcEnvironmentResult {
+  pub context: Option<EnvironmentContext>,
+  pub engines: Option<Engines>,
+  pub include_node_modules: Option<IncludeNodeModules>,
+  pub is_library: Option<bool>,
+  pub loc: Option<SourceLocation>,
+  pub output_format: Option<OutputFormat>,
+  pub should_scope_hoist: Option<bool>,
+  pub should_optimize: Option<bool>,
+  pub source_type: Option<SourceType>,
+}
+
+/// This Dependency mostly replicates the core Dependency type however it only features
+/// fields that can be modified by transformers and some properties are
+/// optional as they will be merged into the Asset later
+/// Similar to packages/core/types-internal/src/index.js#DependencyOptions
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcDependencyResult {
+  pub id: String,
+  pub bundle_behavior: Option<BundleBehavior>,
+  pub env: Option<RpcEnvironmentResult>,
+  #[serde(default)]
+  pub loc: Option<SourceLocation>,
+  #[serde(default)]
+  pub meta: JSONObject,
+  #[serde(default)]
+  pub package_conditions: Option<ExportsCondition>,
+  #[serde(default)]
+  pub pipeline: Option<String>,
+  pub priority: Option<Priority>,
+  pub range: Option<String>,
+  pub resolve_from: Option<PathBuf>,
+  pub specifier: String,
+  pub specifier_type: SpecifierType,
+  #[serde(default)]
+  pub symbols: Option<Vec<Symbol>>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTransformerOpts {
+  pub resolve_from: String,
+  pub specifier: String,
+  pub options: RpcPluginOptions,
+  pub asset: Asset,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcTransformerResult {
+  pub asset: RpcAssetResult,
+  pub dependencies: Vec<RpcDependencyResult>,
+}
+
 pub trait RpcWorker: Send + Sync {
   fn ping(&self) -> anyhow::Result<()>;
-  fn register_transformer(&self, resolve_from: &Path, specifier: &str) -> anyhow::Result<()>;
+  fn run_transformer(&self, opts: RpcTransformerOpts) -> anyhow::Result<RpcTransformerResult>;
 }

--- a/crates/atlaspack_plugin_rpc/src/rpc_host.rs
+++ b/crates/atlaspack_plugin_rpc/src/rpc_host.rs
@@ -28,7 +28,7 @@ pub struct RpcPluginOptions {
 }
 
 /// This Asset mostly replicates the core Asset type however it only features
-/// fields that can be modified by transformers to save on desialization
+/// fields that can be modified by transformers
 #[derive(Default, PartialEq, Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RpcAssetResult {

--- a/packages/core/core/src/atlaspack-v3/worker/compat.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat.js
@@ -1,0 +1,82 @@
+// @flow
+import type {PluginOptions, BundleBehavior, AST} from '@atlaspack/types';
+
+import Environment from '../../public/Environment';
+import {
+  BundleBehaviorNames,
+  BundleBehavior as BundleBehaviorMap,
+} from '../../types';
+
+export type InnerAsset = {|
+  id: string,
+  filePath: string,
+  code: Array<number>,
+  type: string,
+  bundleBehavior: number | null,
+  env: any,
+|};
+
+export class AssetCompat {
+  _inner: InnerAsset;
+  _ast: ?AST;
+  // TODO: Type properly
+  _dependencies: Array<any>;
+
+  constructor(_inner: InnerAsset, options: PluginOptions) {
+    this._inner = _inner;
+    // $FlowFixMe This isn't correct to flow but is enough to satisfy the runtime checks
+    this.env = new Environment(_inner.env, options);
+    this._dependencies = [];
+  }
+
+  get id(): string {
+    return this._inner.id;
+  }
+
+  get filePath(): string {
+    return this._inner.filePath;
+  }
+
+  get type(): string {
+    return this._inner.type;
+  }
+  set type(value: string) {
+    this._inner.type = value;
+  }
+
+  get bundleBehavior(): ?BundleBehavior {
+    let bundleBehavior = this._inner.bundleBehavior;
+    return bundleBehavior == null ? null : BundleBehaviorNames[bundleBehavior];
+  }
+  set bundleBehavior(bundleBehavior: ?BundleBehavior): void {
+    this._inner.bundleBehavior = bundleBehavior
+      ? BundleBehaviorMap[bundleBehavior]
+      : null;
+  }
+
+  getCode(): string {
+    return Buffer.from(this._inner.code).toString();
+  }
+  setCode(code: string) {
+    this._inner.code = Array.from(new TextEncoder().encode(code));
+  }
+
+  getAST(): ?AST {
+    return this._ast;
+  }
+  setAST(ast: AST) {
+    this._ast = ast;
+  }
+
+  addDependency(): string {
+    throw new Error(
+      '[V3] Unimplemented: Asset.addDependency not yet implemented',
+    );
+  }
+
+  addURLDependency(): string {
+    throw new Error(
+      '[V3] Unimplemented: Asset.addURLDependency not yet implemented',
+    );
+  }
+}

--- a/packages/core/core/src/atlaspack-v3/worker/worker.js
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.js
@@ -1,26 +1,87 @@
 // @flow
+import assert from 'assert';
 import * as napi from '@atlaspack/rust';
-import type {Transformer} from '@atlaspack/types';
+import type {Transformer, PluginOptions} from '@atlaspack/types';
 import {workerData} from 'worker_threads';
 import * as module from 'module';
 
+import {AssetCompat} from './compat';
+import type {InnerAsset} from './compat';
+
+const CONFIG = Symbol.for('parcel-plugin-config');
+
 export class AtlaspackWorker {
-  #transformers: Map<string, Transformer<any>>;
-
-  constructor() {
-    this.#transformers = new Map();
-  }
-
   ping() {
     // console.log('Hi');
   }
 
-  async transformerRegister(resolve_from: string, specifier: string) {
-    let customRequire = module.createRequire(resolve_from);
+  async runTransformer({
+    resolveFrom,
+    specifier,
+    options,
+    asset,
+  }: {|
+    resolveFrom: string,
+    specifier: string,
+    options: PluginOptions,
+    asset: InnerAsset,
+  |}): any {
+    let customRequire = module.createRequire(resolveFrom);
     let resolvedPath = customRequire.resolve(specifier);
     // $FlowFixMe
-    let transformer = await import(resolvedPath);
-    this.#transformers.set(`${resolve_from}:${specifier}`, transformer);
+    let transformerModule = await import(resolvedPath);
+    let transformer: Transformer<*> = transformerModule.default.default[CONFIG];
+
+    let assetCompat = new AssetCompat(asset, options);
+
+    try {
+      if (transformer.parse) {
+        // $FlowFixMe
+        let ast = await transformer.parse({asset: assetCompat});
+        // $FlowFixMe
+        assetCompat.setAST(ast);
+      }
+
+      // $FlowFixMe
+      let result = await transformer.transform({
+        // $FlowFixMe
+        asset: assetCompat,
+        options,
+        config: null,
+      });
+
+      if (transformer.generate) {
+        // $FlowFixMe
+        let output = await transformer.generate({
+          // $FlowFixMe
+          asset: assetCompat,
+          // $FlowFixMe
+          ast: assetCompat.getAST(),
+        });
+        // $FlowFixMe
+        assetCompat.setCode(output.content);
+      }
+
+      assert(
+        result.length === 1,
+        '[V3] Unimplemented: Multiple asset return from Node transformer',
+      );
+      assert(
+        result[0] === assetCompat,
+        '[V3] Unimplemented: New asset returned from Node transformer',
+      );
+
+      return {
+        asset,
+        dependencies: assetCompat._dependencies,
+      };
+    } catch (e) {
+      // TODO: Improve error logging from JS plugins. Without this you currently
+      // only see the error message, no stack trace.
+      // eslint-disable-next-line no-console
+      console.error(e);
+      throw e;
+    }
   }
 }
 

--- a/packages/core/integration-tests/test/data-url.js
+++ b/packages/core/integration-tests/test/data-url.js
@@ -16,7 +16,7 @@ describe('data-url:', function () {
     await removeDistDirectory();
   });
 
-  it('inlines text content as a data url', async () => {
+  it.v2('inlines text content as a data url', async () => {
     await fsFixture(overlayFS, __dirname)`
       index.js:
         import svg from 'data-url:./img.svg';

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3202,28 +3202,31 @@ describe('javascript', function () {
     assert.deepEqual(await (await run(b)).default, 43);
   });
 
-  it('can share sibling bundles reachable from a common dependency', async () => {
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/shared-sibling-common-dependency/index.js',
-      ),
-    );
+  it.v2(
+    'can share sibling bundles reachable from a common dependency',
+    async () => {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/shared-sibling-common-dependency/index.js',
+        ),
+      );
 
-    let bundles = b.getBundles();
-    let asyncJsBundles = bundles.filter(
-      b => !b.needsStableName && b.type === 'js',
-    );
-    assert.equal(asyncJsBundles.length, 2);
+      let bundles = b.getBundles();
+      let asyncJsBundles = bundles.filter(
+        b => !b.needsStableName && b.type === 'js',
+      );
+      assert.equal(asyncJsBundles.length, 2);
 
-    // Every bundlegroup with an async js bundle should have the corresponding css
-    for (let bundle of asyncJsBundles) {
-      for (let bundleGroup of b.getBundleGroupsContainingBundle(bundle)) {
-        let bundlesInGroup = b.getBundlesInBundleGroup(bundleGroup);
-        assert(bundlesInGroup.find(s => s.type === 'css'));
+      // Every bundlegroup with an async js bundle should have the corresponding css
+      for (let bundle of asyncJsBundles) {
+        for (let bundleGroup of b.getBundleGroupsContainingBundle(bundle)) {
+          let bundlesInGroup = b.getBundlesInBundleGroup(bundleGroup);
+          assert(bundlesInGroup.find(s => s.type === 'css'));
+        }
       }
-    }
-  });
+    },
+  );
 
   it.v2('should throw a diagnostic for unknown pipelines', async function () {
     let fixture = path.join(__dirname, 'integration/pipeline-unknown/a.js');

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -861,17 +861,20 @@ describe('output formats', function () {
       },
     );
 
-    it('should support importing sibling bundles in library mode', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/formats/esm-siblings/a.js'),
-      );
+    it.v2(
+      'should support importing sibling bundles in library mode',
+      async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/formats/esm-siblings/a.js'),
+        );
 
-      let dist = await outputFS.readFile(
-        b.getBundles().find(b => b.type === 'js').filePath,
-        'utf8',
-      );
-      assert(dist.includes('import "./index.css"'));
-    });
+        let dist = await outputFS.readFile(
+          b.getBundles().find(b => b.type === 'js').filePath,
+          'utf8',
+        );
+        assert(dist.includes('import "./index.css"'));
+      },
+    );
 
     it('should support esmodule output (skipped exports)', async function () {
       let b = await bundle(
@@ -1695,7 +1698,7 @@ describe('output formats', function () {
       assert.strictEqual(res.output, 30);
     });
 
-    it('should support async split bundles for workers', async function () {
+    it.v2('should support async split bundles for workers', async function () {
       await bundle(
         path.join(
           __dirname,

--- a/packages/core/integration-tests/test/packager.js
+++ b/packages/core/integration-tests/test/packager.js
@@ -25,52 +25,58 @@ function hasPolyfill(code) {
 
 describe('packager', function () {
   describe('globalThis polyfill', function () {
-    it('should exclude globalThis polyfill in modern builds', async function () {
-      const entryPoint = path.join(
-        __dirname,
-        'integration/html-js-dynamic/index.html',
-      );
-      const options = {
-        mode: 'production',
-        defaultTargetOptions: {
-          shouldOptimize: false,
-          engines: {
-            browsers: 'last 2 Chrome version',
+    it.v2(
+      'should exclude globalThis polyfill in modern builds',
+      async function () {
+        const entryPoint = path.join(
+          __dirname,
+          'integration/html-js-dynamic/index.html',
+        );
+        const options = {
+          mode: 'production',
+          defaultTargetOptions: {
+            shouldOptimize: false,
+            engines: {
+              browsers: 'last 2 Chrome version',
+            },
           },
-        },
-      };
-      const bundleGraph = await runBundler(entryPoint, options);
+        };
+        const bundleGraph = await runBundler(entryPoint, options);
 
-      for (const b of bundleGraph.getBundles()) {
-        if (b.type !== 'js') continue;
-        let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
-        assert.ok(!hasPolyfill(code));
-      }
-    });
+        for (const b of bundleGraph.getBundles()) {
+          if (b.type !== 'js') continue;
+          let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
+          assert.ok(!hasPolyfill(code));
+        }
+      },
+    );
 
-    it('should include globalThis polyfill in ie11 builds', async function () {
-      const entryPoint = path.join(
-        __dirname,
-        'integration/packager-global-this/index.html',
-      );
-      const options = {
-        mode: 'production',
-        defaultTargetOptions: {
-          shouldOptimize: false,
-          engines: {
-            browsers: 'ie 11',
+    it.v2(
+      'should include globalThis polyfill in ie11 builds',
+      async function () {
+        const entryPoint = path.join(
+          __dirname,
+          'integration/packager-global-this/index.html',
+        );
+        const options = {
+          mode: 'production',
+          defaultTargetOptions: {
+            shouldOptimize: false,
+            engines: {
+              browsers: 'ie 11',
+            },
           },
-        },
-      };
+        };
 
-      const bundleGraph = await runBundler(entryPoint, options);
+        const bundleGraph = await runBundler(entryPoint, options);
 
-      for (const b of bundleGraph.getBundles()) {
-        if (b.type !== 'js') continue;
-        let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
-        assert.ok(hasPolyfill(code));
-      }
-    });
+        for (const b of bundleGraph.getBundles()) {
+          if (b.type !== 'js') continue;
+          let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
+          assert.ok(hasPolyfill(code));
+        }
+      },
+    );
 
     it.v2(
       'should exclude globalThis polyfill in node builds',

--- a/packages/core/integration-tests/test/resolver.js
+++ b/packages/core/integration-tests/test/resolver.js
@@ -424,7 +424,7 @@ describe('resolver', function () {
     assert.strictEqual(output.default, 2);
   });
 
-  it('should support very long dependency specifiers', async function () {
+  it.v2('should support very long dependency specifiers', async function () {
     this.timeout(8000);
 
     let inputDir = path.join(__dirname, 'input');

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4066,17 +4066,20 @@ describe('scope hoisting', function () {
       assert.equal(output.foo, 'b');
     });
 
-    it("doesn't insert parcelRequire for missing non-js assets", async function () {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/scope-hoisting/commonjs/missing-non-js/a.js',
-        ),
-      );
+    it.v2(
+      "doesn't insert parcelRequire for missing non-js assets",
+      async function () {
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/scope-hoisting/commonjs/missing-non-js/a.js',
+          ),
+        );
 
-      let output = await run(b);
-      assert.equal(output, 27);
-    });
+        let output = await run(b);
+        assert.equal(output, 27);
+      },
+    );
 
     it.v2('define exports in the outermost scope', async function () {
       let b = await bundle(
@@ -4610,7 +4613,7 @@ describe('scope hoisting', function () {
       assert.deepEqual(out, ['a', 'b', 'c', 'd']);
     });
 
-    it('supports requiring a CSS asset', async function () {
+    it.v2('supports requiring a CSS asset', async function () {
       let b = await bundle(
         path.join(
           __dirname,

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -9,8 +9,8 @@ import {
 } from '@atlaspack/test-utils';
 import path from 'path';
 
-describe.v2('svg', function () {
-  it('should support bundling SVG', async () => {
+describe('svg', function () {
+  it.v2('should support bundling SVG', async () => {
     let b = await bundle(path.join(__dirname, '/integration/svg/circle.svg'));
 
     assertBundles(b, [
@@ -101,7 +101,7 @@ describe.v2('svg', function () {
     );
   });
 
-  it('should minify SVG bundles', async function () {
+  it.v2('should minify SVG bundles', async function () {
     let b = await bundle(path.join(__dirname, '/integration/svg/circle.svg'), {
       defaultTargetOptions: {
         shouldOptimize: true,
@@ -115,7 +115,7 @@ describe.v2('svg', function () {
     assert(!file.includes('comment'));
   });
 
-  it('support SVGO config files', async function () {
+  it.v2('support SVGO config files', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/svgo-config/index.html'),
       {
@@ -133,36 +133,39 @@ describe.v2('svg', function () {
     assert(file.includes('comment'));
   });
 
-  it('should detect xml-stylesheet processing instructions', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/svg-xml-stylesheet/img.svg'),
-    );
+  it.v2(
+    'should detect xml-stylesheet processing instructions',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/svg-xml-stylesheet/img.svg'),
+      );
 
-    assertBundles(b, [
-      {
-        name: 'img.svg',
-        assets: ['img.svg'],
-      },
-      {
-        type: 'css',
-        assets: ['style1.css'],
-      },
-      {
-        type: 'css',
-        assets: ['style3.css'],
-      },
-    ]);
+      assertBundles(b, [
+        {
+          name: 'img.svg',
+          assets: ['img.svg'],
+        },
+        {
+          type: 'css',
+          assets: ['style1.css'],
+        },
+        {
+          type: 'css',
+          assets: ['style3.css'],
+        },
+      ]);
 
-    let file = await outputFS.readFile(
-      b.getBundles().find(b => b.type === 'svg').filePath,
-      'utf-8',
-    );
+      let file = await outputFS.readFile(
+        b.getBundles().find(b => b.type === 'svg').filePath,
+        'utf-8',
+      );
 
-    assert(file.includes('<?xml-stylesheet'));
-    assert(file.includes('<?xml-not-a-stylesheet'));
-  });
+      assert(file.includes('<?xml-stylesheet'));
+      assert(file.includes('<?xml-not-a-stylesheet'));
+    },
+  );
 
-  it('should handle inline CSS with @imports', async function () {
+  it.v2('should handle inline CSS with @imports', async function () {
     const b = await bundle(
       path.join(__dirname, '/integration/svg-inline-css-import/img.svg'),
     );
@@ -206,7 +209,7 @@ describe.v2('svg', function () {
     assert(!svg.includes('import '));
   });
 
-  it('should process inline styles using lang', async function () {
+  it.v2('should process inline styles using lang', async function () {
     const b = await bundle(
       path.join(__dirname, '/integration/svg-inline-sass/img.svg'),
       {


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR adds basic Node JS plugin support to Atlaspack V3. I've stripped back the code to not bother handle dependencies at all. This requires a bunch more changes which I have done in [another branch](https://github.com/atlassian-labs/atlaspack/tree/node-plugin-html) but I'm not sure if we really want to continue supporting dependencies in JS plugins going forward. If we decide we'd like to add this feature we can follow up with that. 

For now this PR is enough to get a basic transformer like `@atlaspack/transformer-svg` working which I have enabled an integration test for in this PR. There's still a bunch more things to add like invalidations and source-maps but this is a good start. 

## Checklist

- [] Existing or new tests cover this change
