### PR TITLE
Fix release arm-unknown-linux-gnueabihf

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
             arch: armhf
             strip: arm-linux-gnueabihf-strip
             objcopy: arm-linux-gnueabihf-objcopy
-            cflags: -mfpu=neon
+            cflags: ''
           - target: aarch64-unknown-linux-gnu
             arch: arm64
             strip: aarch64-linux-gnu-strip


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Fixing the release for `arm-unknown-linux-gnueabihf` by removing an unneeded build arg.

## Changes

Dropping `-mfpu=neon`

