### PR TITLE
Don't clean-up orphaned nodes on every event

### DIFF
--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -451,7 +451,7 @@ describe('RequestTracker', () => {
   });
 });
 
-describe.only('cleanUpOrphans', () => {
+describe('cleanUpOrphans', () => {
   it('cleans-up unreachable nodes', () => {
     const graph: Graph<string, number> = new Graph();
     const root = graph.addNode('root');

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -10,6 +10,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   atlaspackV3: false,
   useWatchmanWatcher: false,
   importRetry: false,
+  fixQuadraticCacheInvalidation: false,
   fastOptimizeInlineRequires: false,
   useLmdbJsLite: false,
   fastNeedsDefaultInterop: false,

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -20,6 +20,10 @@ export type FeatureFlags = {|
    */
   useLmdbJsLite: boolean,
   /**
+   * Fixes quadratic cache invalidation issue
+   */
+  fixQuadraticCacheInvalidation: boolean,
+  /**
    * Enable rust based inline requires optimization
    */
   fastOptimizeInlineRequires: boolean,

--- a/packages/core/graph/src/ContentGraph.js
+++ b/packages/core/graph/src/ContentGraph.js
@@ -86,11 +86,11 @@ export default class ContentGraph<TNode, TEdgeType: number = 1> extends Graph<
     return this._contentKeyToNodeId.has(contentKey);
   }
 
-  removeNode(nodeId: NodeId): void {
+  removeNode(nodeId: NodeId, removeOrphans: boolean = true): void {
     this._assertHasNodeId(nodeId);
     let contentKey = nullthrows(this._nodeIdToContentKey.get(nodeId));
     this._contentKeyToNodeId.delete(contentKey);
     this._nodeIdToContentKey.delete(nodeId);
-    super.removeNode(nodeId);
+    super.removeNode(nodeId, removeOrphans);
   }
 }

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -186,7 +186,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   }
 
   // Removes node and any edges coming from or to that node
-  removeNode(nodeId: NodeId) {
+  removeNode(nodeId: NodeId, removeOrphans: boolean = true) {
     if (!this.hasNode(nodeId)) {
       return;
     }
@@ -203,7 +203,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     }
 
     for (let {type, to} of this.adjacencyList.getOutboundEdgesByType(nodeId)) {
-      this._removeEdge(nodeId, to, type);
+      this._removeEdge(nodeId, to, type, removeOrphans);
     }
 
     this.nodes[nodeId] = null;


### PR DESCRIPTION
This should improve performance of handling filesystem events, since there won't be one graph traversal for every event. Since complexity of this particular section is reduced to be roughly linear we expect worst case performance of handling events to improve.
