### PR TITLE
V3: Include stack traces for napi threadsafe functions

### DIFF
--- a/crates/atlaspack_napi_helpers/src/js_callable/serde.rs
+++ b/crates/atlaspack_napi_helpers/src/js_callable/serde.rs
@@ -35,5 +35,8 @@ pub fn map_return_serde<Return>() -> MapJsReturn<Return>
 where
   Return: Send + DeserializeOwned + 'static,
 {
-  Box::new(move |env, value| env.from_js_value(&value))
+  Box::new(move |env, value| match env.from_js_value(&value) {
+    Ok(result) => Ok(result),
+    Err(err) => Err(anyhow::anyhow!(err.to_string())),
+  })
 }

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc_conn_nodejs.rs
@@ -1,5 +1,4 @@
 use atlaspack_core::plugin::Resolved;
-use atlaspack_napi_helpers::anyhow_from_napi;
 use atlaspack_napi_helpers::js_callable::JsCallable;
 use napi::{JsObject, JsUnknown};
 
@@ -32,34 +31,22 @@ impl NodejsWorker {
 
 impl RpcWorker for NodejsWorker {
   fn ping(&self) -> anyhow::Result<()> {
-    self
-      .ping_fn
-      .call_with_return(
-        |_env| Ok(Vec::<JsUnknown>::new()),
-        |_env, _| Ok(Vec::<()>::new()),
-      )
-      .map_err(anyhow_from_napi)?;
+    self.ping_fn.call(
+      |_env| Ok(Vec::<JsUnknown>::new()),
+      |_env, _| Ok(Vec::<()>::new()),
+    )?;
     Ok(())
   }
 
   fn load_plugin(&self, opts: LoadPluginOptions) -> anyhow::Result<()> {
-    self
-      .load_plugin_fn
-      .call_with_return_serde(opts)
-      .map_err(anyhow_from_napi)
+    self.load_plugin_fn.call_serde(opts)
   }
 
   fn run_resolver_resolve(&self, opts: RunResolverResolve) -> anyhow::Result<Resolved> {
-    self
-      .run_resolver_resolve_fn
-      .call_with_return_serde(opts)
-      .map_err(anyhow_from_napi)
+    self.run_resolver_resolve_fn.call_serde(opts)
   }
 
   fn run_transformer(&self, opts: RpcTransformerOpts) -> anyhow::Result<RpcTransformerResult> {
-    self
-      .transformer_register_fn
-      .call_with_return_serde(opts)
-      .map_err(anyhow_from_napi)
+    self.transformer_register_fn.call_serde(opts)
   }
 }

--- a/crates/node-bindings/src/atlaspack/file_system_napi.rs
+++ b/crates/node-bindings/src/atlaspack/file_system_napi.rs
@@ -40,28 +40,28 @@ impl FileSystem for FileSystemNapi {
   fn canonicalize_base(&self, path: &Path) -> io::Result<PathBuf> {
     self
       .canonicalize_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e))
   }
 
   fn create_directory(&self, path: &Path) -> std::io::Result<()> {
     self
       .create_directory_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e))
   }
 
   fn cwd(&self) -> io::Result<PathBuf> {
     self
       .cwd_fn
-      .call_with_return_serde(None::<bool>)
+      .call_serde(None::<bool>)
       .map_err(|e| io::Error::other(e))
   }
 
   fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
     let result = self
       .read_file_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e));
 
     result
@@ -70,21 +70,21 @@ impl FileSystem for FileSystemNapi {
   fn read_to_string(&self, path: &Path) -> io::Result<String> {
     self
       .read_file_fn
-      .call_with_return_serde((path.to_path_buf(), "utf8"))
+      .call_serde((path.to_path_buf(), "utf8"))
       .map_err(|e| io::Error::other(e))
   }
 
   fn is_file(&self, path: &Path) -> bool {
     self
       .is_file_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .expect("TODO handle error case")
   }
 
   fn is_dir(&self, path: &Path) -> bool {
     self
       .is_dir_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .expect("TODO handle error case")
   }
 }

--- a/crates/node-bindings/src/atlaspack/package_manager_napi.rs
+++ b/crates/node-bindings/src/atlaspack/package_manager_napi.rs
@@ -1,6 +1,5 @@
 use std::path::Path;
 
-use anyhow::anyhow;
 use napi::{Env, JsObject};
 
 use atlaspack_napi_helpers::js_callable::JsCallable;
@@ -23,7 +22,6 @@ impl PackageManager for PackageManagerNapi {
   fn resolve(&self, specifier: &str, from: &Path) -> anyhow::Result<Resolution> {
     self
       .resolve_fn
-      .call_with_return_serde((specifier.to_owned(), from.to_path_buf()))
-      .map_err(|e| anyhow!(e))
+      .call_serde((specifier.to_owned(), from.to_path_buf()))
   }
 }

--- a/crates/node-bindings/src/atlaspack/package_manager_napi.rs
+++ b/crates/node-bindings/src/atlaspack/package_manager_napi.rs
@@ -12,7 +12,7 @@ pub struct PackageManagerNapi {
 impl PackageManagerNapi {
   pub fn new(env: &Env, js_file_system: &JsObject) -> napi::Result<Self> {
     Ok(Self {
-      resolve_fn: JsCallable::new_from_object_prop_bound("resolveSync", &js_file_system)?
+      resolve_fn: JsCallable::new_from_object_prop_bound("resolve", &js_file_system)?
         .into_unref(env)?,
     })
   }

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -58,7 +58,7 @@ import {
 } from './projectPath';
 import {tracer} from '@atlaspack/profiler';
 import {setFeatureFlags} from '@atlaspack/feature-flags';
-import {AtlaspackV3, toFileSystemV3} from './atlaspack-v3';
+import {AtlaspackV3} from './atlaspack-v3';
 
 registerCoreWithSerializer();
 
@@ -137,7 +137,7 @@ export default class Atlaspack {
           ? undefined
           : [entries],
         env: resolvedOptions.env,
-        fs: inputFS && toFileSystemV3(inputFS),
+        fs: inputFS,
         defaultTargetOptions: {
           // $FlowFixMe projectPath is just a string
           distDir: resolvedOptions.defaultTargetOptions.distDir,

--- a/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
+++ b/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
@@ -3,13 +3,17 @@
 import path from 'path';
 import {Worker} from 'worker_threads';
 import {AtlaspackNapi, type AtlaspackNapiOptions} from '@atlaspack/rust';
+import {NativePackageManager} from './package-manager';
+import type {FileSystem as ClassicFileSystem} from '@atlaspack/fs';
+import {NativeFileSystem} from './fs';
+import type {PackageManager as ClassicPackageManager} from '@atlaspack/types';
 
 const WORKER_PATH = path.join(__dirname, 'worker', 'index.js');
 
 export type AtlaspackV3Options = {|
-  fs?: AtlaspackNapiOptions['fs'],
+  fs?: ClassicFileSystem,
   nodeWorkers?: number,
-  packageManager?: AtlaspackNapiOptions['packageManager'],
+  packageManager?: ClassicPackageManager,
   threads?: number,
   ...AtlaspackNapiOptions['options'],
 |};
@@ -33,9 +37,10 @@ export class AtlaspackV3 {
     };
 
     this._internal = new AtlaspackNapi({
-      fs,
+      fs: fs && new NativeFileSystem(fs),
       nodeWorkers,
-      packageManager,
+      packageManager:
+        packageManager && new NativePackageManager(packageManager),
       threads,
       options,
     });

--- a/packages/core/core/src/atlaspack-v3/fs.js
+++ b/packages/core/core/src/atlaspack-v3/fs.js
@@ -1,41 +1,46 @@
 // @flow strict-local
 
+// import type { JsCallable } from "./jsCallable";
 import type {FileSystem} from '@atlaspack/rust';
 import type {
   Encoding,
   FilePath,
   FileSystem as ClassicFileSystem,
-} from '@atlaspack/types-internal';
+} from '@atlaspack/types';
 
 import {jsCallable} from './jsCallable';
 
 // Move to @atlaspack/utils or a dedicated v3 / migration package later
 export function toFileSystemV3(fs: ClassicFileSystem): FileSystem {
   return {
+    // $FlowFixMe migrate to TypeScript
     canonicalize: jsCallable((path: FilePath) => fs.realpathSync(path)),
     createDirectory: jsCallable((path: FilePath) => fs.mkdirp(path)),
+    // $FlowFixMe migrate to TypeScript
     cwd: jsCallable(() => fs.cwd()),
+    // $FlowFixMe migrate to TypeScript
     readFile: jsCallable((path: string, encoding?: Encoding) => {
       if (!encoding) {
         // $FlowFixMe
         return [...fs.readFileSync(path)];
-      } else {
-        return fs.readFileSync(path, encoding);
       }
+      return fs.readFileSync(path, encoding);
     }),
-    isFile: (path: string) => {
+    // $FlowFixMe migrate to TypeScript
+    isFile: jsCallable((path: string) => {
       try {
         return fs.statSync(path).isFile();
       } catch {
         return false;
       }
-    },
-    isDir: (path: string) => {
+    }),
+    // $FlowFixMe migrate to TypeScript
+    isDir: jsCallable((path: string) => {
       try {
         return fs.statSync(path).isDirectory();
       } catch {
         return false;
       }
-    },
+    }),
   };
 }

--- a/packages/core/core/src/atlaspack-v3/index.js
+++ b/packages/core/core/src/atlaspack-v3/index.js
@@ -1,5 +1,6 @@
 // @flow
 
-export {toFileSystemV3} from './fs';
+export * from './fs';
 export {AtlaspackV3} from './AtlaspackV3';
+export * from './package-manager';
 export type * from './AtlaspackV3';

--- a/packages/core/core/src/atlaspack-v3/jsCallable.js
+++ b/packages/core/core/src/atlaspack-v3/jsCallable.js
@@ -2,9 +2,7 @@
 
 export type JsCallable<Args: $ReadOnlyArray<mixed>, Return> = (
   ...Args
-) => JsCallableResult<Return>;
-
-export type JsCallableResult<Return> = Promise<[string | null, Return | null]>;
+) => Promise<[string | null, Return | null]>;
 
 export function jsCallable<Args: $ReadOnlyArray<mixed>, Return>(
   fn: (...Args) => Return | Promise<Return>,

--- a/packages/core/core/src/atlaspack-v3/jsCallable.js
+++ b/packages/core/core/src/atlaspack-v3/jsCallable.js
@@ -2,16 +2,24 @@
 
 export type JsCallable<Args: $ReadOnlyArray<mixed>, Return> = (
   ...Args
-) => Return;
+) => JsCallableResult<Return>;
+
+export type JsCallableResult<Return> = Promise<[string | null, Return | null]>;
 
 export function jsCallable<Args: $ReadOnlyArray<mixed>, Return>(
-  fn: (...Args) => Return,
-): (...Args) => Return {
-  return (...args: Args) => {
+  fn: (...Args) => Return | Promise<Return>,
+): JsCallable<Args, Return> {
+  return async (...args) => {
     try {
-      return fn(...args);
+      const result = await fn(...args);
+      return [null, result];
     } catch (err) {
-      return err;
+      if (err instanceof Error) {
+        return [err.stack, null];
+      }
+      // $FlowFixMe migrate to TypeScript
+      let errStr = `${err}`;
+      return [`${errStr}`, null];
     }
   };
 }

--- a/packages/core/core/src/atlaspack-v3/package-manager.js
+++ b/packages/core/core/src/atlaspack-v3/package-manager.js
@@ -1,0 +1,25 @@
+// @flow
+
+import type {PackageManager} from '@atlaspack/rust';
+import type {
+  PackageManager as ClassicPackageManager,
+  PackageManagerResolveResult,
+  DependencySpecifier,
+  FilePath,
+  PackageManagerPackageOptions,
+} from '@atlaspack/types';
+import type {JsCallable} from './jsCallable';
+import {jsCallable} from './jsCallable';
+
+export class NativePackageManager implements PackageManager {
+  #packageManager: ClassicPackageManager;
+
+  constructor(packageManager: ClassicPackageManager) {
+    this.#packageManager = packageManager;
+  }
+
+  resolve: JsCallable<
+    [DependencySpecifier, FilePath, ?PackageManagerPackageOptions],
+    Promise<PackageManagerResolveResult>,
+  > = jsCallable((...args) => this.#packageManager.resolve(...args));
+}

--- a/packages/core/core/src/atlaspack-v3/worker/worker.js
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.js
@@ -96,17 +96,10 @@ export class AtlaspackWorker {
     // console.log('Hi');
   }
 
-  async runTransformer({
-    resolveFrom,
-    specifier,
-    options,
-    asset,
-  }: {|
-    resolveFrom: string,
-    specifier: string,
-    options: PluginOptions,
-    asset: InnerAsset,
-  |}): any {
+  runTransformer: JsCallable<
+    [RunTransformerOptions],
+    Promise<RunTransformerResult>,
+  > = jsCallable(async ({resolveFrom, specifier, options, asset}) => {
     const customRequire = module.createRequire(resolveFrom);
     const resolvedPath = customRequire.resolve(specifier);
     // $FlowFixMe
@@ -116,58 +109,62 @@ export class AtlaspackWorker {
 
     let assetCompat = new AssetCompat(asset, options);
 
-    try {
-      if (transformer.parse) {
-        // $FlowFixMe
-        const ast = await transformer.parse({asset: assetCompat}); // missing "config"
-        // $FlowFixMe
-        assetCompat.setAST(ast);
-      }
-
+    if (transformer.parse) {
       // $FlowFixMe
-      const result = await transformer.transform({
+      const ast = await transformer.parse({asset: assetCompat}); // missing "config"
+      // $FlowFixMe
+      assetCompat.setAST(ast);
+    }
+
+    // $FlowFixMe
+    const result = await transformer.transform({
+      // $FlowFixMe
+      asset: assetCompat,
+      options,
+      config: null,
+    });
+
+    if (transformer.generate) {
+      // $FlowFixMe
+      let output = await transformer.generate({
         // $FlowFixMe
         asset: assetCompat,
-        options,
-        config: null,
+        // $FlowFixMe
+        ast: assetCompat.getAST(),
       });
-
-      if (transformer.generate) {
-        // $FlowFixMe
-        let output = await transformer.generate({
-          // $FlowFixMe
-          asset: assetCompat,
-          // $FlowFixMe
-          ast: assetCompat.getAST(),
-        });
-        // $FlowFixMe
-        assetCompat.setCode(output.content);
-      }
-
-      assert(
-        result.length === 1,
-        '[V3] Unimplemented: Multiple asset return from Node transformer',
-      );
-      assert(
-        result[0] === assetCompat,
-        '[V3] Unimplemented: New asset returned from Node transformer',
-      );
-
-      return {
-        asset,
-        dependencies: assetCompat._dependencies,
-      };
-    } catch (e) {
-      // TODO: Improve error logging from JS plugins. Without this you currently
-      // only see the error message, no stack trace.
-      // eslint-disable-next-line no-console
-      console.error(e);
-      throw e;
+      // $FlowFixMe
+      assetCompat.setCode(output.content);
     }
-  }
+
+    assert(
+      result.length === 1,
+      '[V3] Unimplemented: Multiple asset return from Node transformer',
+    );
+    assert(
+      result[0] === assetCompat,
+      '[V3] Unimplemented: New asset returned from Node transformer',
+    );
+
+    return {
+      asset,
+      dependencies: assetCompat._dependencies,
+    };
+  });
 }
 
 napi.registerWorker(workerData.tx_worker, new AtlaspackWorker());
+
+type RunTransformerOptions = {|
+  resolveFrom: string,
+  specifier: string,
+  options: PluginOptions,
+  asset: InnerAsset,
+|};
+
+type RunTransformerResult = {|
+  asset: mixed,
+  dependencies: mixed,
+|};
 
 type LoadPluginOptions = {|
   kind: 'resolver',

--- a/packages/core/core/test/Dependency.test.js
+++ b/packages/core/core/test/Dependency.test.js
@@ -1,4 +1,4 @@
-import expect from 'expect';
+import assert from 'assert';
 import {createDependencyId} from '../src/Dependency';
 import {createEnvironment} from '../src/Environment';
 
@@ -15,7 +15,7 @@ describe('Dependency', () => {
         env: createEnvironment(),
         specifierType: 'esm',
       });
-      expect(id1).toEqual(id2);
+      assert.equal(id1, id2);
     });
   });
 });

--- a/packages/core/core/test/Environment.test.js
+++ b/packages/core/core/test/Environment.test.js
@@ -1,8 +1,6 @@
 // @flow strict-local
 
 import assert from 'assert';
-// $FlowFixMe
-import expect from 'expect';
 import {createEnvironment} from '../src/Environment';
 import {initializeMonitoring} from '../../rust';
 
@@ -105,6 +103,6 @@ describe('createEnvironment', function () {
   it('returns a stable hash', () => {
     initializeMonitoring();
     const environment = createEnvironment({});
-    expect(environment.id).toEqual('d821e85f6b50315e');
+    assert.equal(environment.id, 'd821e85f6b50315e');
   });
 });

--- a/packages/core/integration-tests/test/atlaspack-v3.js
+++ b/packages/core/integration-tests/test/atlaspack-v3.js
@@ -2,7 +2,7 @@
 
 import {join} from 'path';
 
-import {AtlaspackV3, toFileSystemV3} from '@atlaspack/core';
+import {AtlaspackV3} from '@atlaspack/core';
 import {NodePackageManager} from '@atlaspack/package-manager';
 import {
   describe,
@@ -32,7 +32,7 @@ describe('AtlaspackV3', function () {
     let atlaspack = new AtlaspackV3({
       corePath: '',
       entries: [join(__dirname, 'index.js')],
-      fs: toFileSystemV3(overlayFS),
+      fs: overlayFS,
       nodeWorkers: 1,
       packageManager: new NodePackageManager(inputFS, __dirname),
     });

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -24,12 +24,19 @@ export interface ConfigRequest {
 }
 export interface RequestOptions {}
 
+export type IsOk = boolean;
+
+export type JsCallable<Args: $ReadOnlyArray<mixed>, Return> = (
+  ...Args
+) => [IsOk, Return] | Promise<[IsOk, Return]>;
+
 export interface FileSystem {
-  canonicalize(path: FilePath): FilePath;
-  cwd(): FilePath;
-  isDir(path: FilePath): boolean;
-  isFile(path: FilePath): boolean;
-  readFile(path: FilePath, encoding?: Encoding): string;
+  canonicalize: JsCallable<[FilePath], FilePath>;
+  cwd: JsCallable<[], FilePath>;
+  isDir: JsCallable<[FilePath], boolean>;
+  isFile: JsCallable<[FilePath], boolean>;
+  readFile: JsCallable<[FilePath], Array<number>>;
+  readFile: JsCallable<[FilePath, Encoding], string>;
 }
 
 export type AtlaspackNapiOptions = {|

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -4,7 +4,9 @@ import type {
   FileCreateInvalidation,
   FilePath,
   InitialAtlaspackOptions,
-  PackageManager,
+  PackageManagerResolveResult,
+  DependencySpecifier,
+  PackageManagerPackageOptions,
 } from '@atlaspack/types';
 
 declare export var init: void | (() => void);
@@ -28,15 +30,22 @@ export type IsOk = boolean;
 
 export type JsCallable<Args: $ReadOnlyArray<mixed>, Return> = (
   ...Args
-) => [IsOk, Return] | Promise<[IsOk, Return]>;
+) => Promise<[string | null, Return | null]>;
 
 export interface FileSystem {
   canonicalize: JsCallable<[FilePath], FilePath>;
+  createDirectory: JsCallable<[FilePath], Promise<void>>;
   cwd: JsCallable<[], FilePath>;
   isDir: JsCallable<[FilePath], boolean>;
   isFile: JsCallable<[FilePath], boolean>;
-  readFile: JsCallable<[FilePath], Array<number>>;
-  readFile: JsCallable<[FilePath, Encoding], string>;
+  readFile: JsCallable<[FilePath, Encoding | void], string | Array<number>>;
+}
+
+export interface PackageManager {
+  resolve: JsCallable<
+  [DependencySpecifier, FilePath, ?PackageManagerPackageOptions],
+  Promise<PackageManagerResolveResult>,
+>
 }
 
 export type AtlaspackNapiOptions = {|

--- a/packages/core/types-internal/src/PackageManager.js
+++ b/packages/core/types-internal/src/PackageManager.js
@@ -43,16 +43,22 @@ export interface PackageManager {
   require(
     id: DependencySpecifier,
     from: FilePath,
-    ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
+    options: ?PackageManagerPackageOptions,
   ): Promise<any>;
   resolve(
     id: DependencySpecifier,
     from: FilePath,
-    ?{|range?: ?SemverRange, shouldAutoInstall?: boolean, saveDev?: boolean|},
+    options: ?PackageManagerPackageOptions,
   ): Promise<PackageManagerResolveResult>;
   getInvalidations(id: DependencySpecifier, from: FilePath): Invalidations;
   invalidate(id: DependencySpecifier, from: FilePath): void;
 }
+
+export type PackageManagerPackageOptions = {|
+  range?: ?SemverRange,
+  shouldAutoInstall?: boolean,
+  saveDev?: boolean,
+|};
 
 export type ModuleRequest = {|
   +name: string,

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -25,6 +25,7 @@ import type {Glob} from './Glob';
 import type {PackageName} from './PackageName';
 import type {
   PackageManager,
+  PackageManagerPackageOptions,
   PackageManagerResolveResult,
   Invalidations,
   PackageInstaller,
@@ -62,6 +63,7 @@ export type {
   FileInvalidation,
   FileAboveInvalidation,
   PackageManager,
+  PackageManagerPackageOptions,
   PackageManagerResolveResult,
   Invalidations,
   PackageInstaller,


### PR DESCRIPTION
This adds stack traces to error thrown in Napi threadsafe functions

I will use better types when we move to TypeScript

This requires that the Rust `JsCallable` is paired with the JavaScript `JsCallable`

```javascript
const reportError = jsCallable(() => {
  throw new Error('Hello World')
})
```