### PR TITLE
Clean-up faster packager feature-flag

### DIFF
--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -13,7 +13,6 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   fixQuadraticCacheInvalidation: false,
   fastOptimizeInlineRequires: false,
   useLmdbJsLite: false,
-  fastNeedsDefaultInterop: false,
   conditionalBundlingApi: false,
 };
 

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -28,12 +28,6 @@ export type FeatureFlags = {|
    */
   fastOptimizeInlineRequires: boolean,
   /**
-   * Enable fast path for needsDefaultInterop.
-   *
-   * This improves bundling performance of large applications very significantly.
-   */
-  fastNeedsDefaultInterop: boolean,
-  /**
    * Enables an experimental "conditional bundling" API - this allows the use of `importCond` syntax
    * in order to have (consumer) feature flag driven bundling. This feature is very experimental,
    * and requires server-side support.

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -24,7 +24,6 @@ import ThrowableDiagnostic, {
 } from '@atlaspack/diagnostic';
 import globals from 'globals';
 import path from 'path';
-import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
@@ -1459,17 +1458,7 @@ ${code}
       asset.symbols.hasExportSymbol('*') &&
       !asset.symbols.hasExportSymbol('default')
     ) {
-      if (getFeatureFlag('fastNeedsDefaultInterop')) {
-        return true;
-      }
-
-      let deps = this.bundleGraph.getIncomingDependencies(asset);
-      return deps.some(
-        dep =>
-          this.bundle.hasDependency(dep) &&
-          // dep.meta.isES6Module &&
-          dep.symbols.hasExportSymbol('default'),
-      );
+      return true;
     }
 
     return false;


### PR DESCRIPTION
Cleans-up a feature-flag that improved bundling performance by 30% by bailing-out earlier on default interop checks.