### PR TITLE
Implement canonicalize_base for OsFileSystem

### DIFF
--- a/crates/atlaspack_filesystem/src/lib.rs
+++ b/crates/atlaspack_filesystem/src/lib.rs
@@ -33,14 +33,14 @@ pub trait FileSystem: std::fmt::Debug {
   fn cwd(&self) -> std::io::Result<PathBuf> {
     Err(std::io::Error::new(
       std::io::ErrorKind::Other,
-      "Not implemented",
+      "Not implemented: FileSystem::cwd",
     ))
   }
 
   fn canonicalize_base(&self, _path: &Path) -> std::io::Result<PathBuf> {
     Err(std::io::Error::new(
       std::io::ErrorKind::Other,
-      "Not implemented",
+      "Not implemented: FileSystem::canonicalize_base",
     ))
   }
 

--- a/crates/atlaspack_filesystem/src/os_file_system.rs
+++ b/crates/atlaspack_filesystem/src/os_file_system.rs
@@ -19,6 +19,10 @@ impl FileSystem for OsFileSystem {
     canonicalize(path, cache)
   }
 
+  fn canonicalize_base(&self, path: &Path) -> std::io::Result<PathBuf> {
+    canonicalize(path, &Default::default())
+  }
+
   fn create_directory(&self, path: &Path) -> std::io::Result<()> {
     std::fs::create_dir_all(path)
   }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR implements `canonicalize_base` for the OsFileSystem which fixes the config loading of extends files when running in Jira. 

For now I've just passed a default cache through to the `canonicalize` function. Not sure if this is the ideal fix long term. 

## Checklist

- [ ] Existing or new tests cover this change
