### PR TITLE
V3: Resolver.loadConfig() and some arguments

### DIFF
--- a/crates/atlaspack_plugin_rpc/src/plugin/resolver.rs
+++ b/crates/atlaspack_plugin_rpc/src/plugin/resolver.rs
@@ -22,6 +22,7 @@ pub struct RpcResolverPlugin {
   specifier: String,
   started: bool,
   rpc_worker: RpcWorkerRef,
+  project_root: PathBuf,
 }
 
 impl Debug for RpcResolverPlugin {
@@ -32,7 +33,7 @@ impl Debug for RpcResolverPlugin {
 
 impl RpcResolverPlugin {
   pub fn new(
-    _ctx: &PluginContext,
+    ctx: &PluginContext,
     plugin: &PluginNode,
     rpc_worker: RpcWorkerRef,
   ) -> Result<Self, anyhow::Error> {
@@ -41,6 +42,7 @@ impl RpcResolverPlugin {
       specifier: plugin.package_name.clone(),
       rpc_worker,
       started: false,
+      project_root: (&*ctx.options.project_root).to_path_buf(),
     })
   }
 }
@@ -68,6 +70,8 @@ impl ResolverPlugin for RpcResolverPlugin {
       key: self.specifier.clone(),
       dependency: (&*ctx.dependency).clone(),
       specifier: (&*ctx.specifier).to_owned(),
+      pipeline: ctx.pipeline.clone(),
+      project_root: self.project_root.clone(),
     })
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/rpc/resolver.rs
+++ b/crates/atlaspack_plugin_rpc/src/rpc/resolver.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use atlaspack_core::types::Dependency;
 use serde::{Deserialize, Serialize};
 
@@ -7,4 +9,6 @@ pub struct RunResolverResolve {
   pub key: String,
   pub dependency: Dependency,
   pub specifier: String,
+  pub pipeline: Option<String>,
+  pub project_root: PathBuf,
 }


### PR DESCRIPTION
- Added `Resolver.loadConfig()`
- Added partial `PluginOptions`
- Added partial `PluginConfig`
- [TEMP] Initialize `NodeFS` for workers
- [TEMP] Initialize `PackageManger` in worker

NOTE: This would not pass integration tests because the `NodeFS` does not work there. Discussion on this might be to rewrite the integration tests to use the real FS for integration tests