### PR TITLE
Optimize request tracker cache invalidation

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -544,6 +544,10 @@ export default class Atlaspack {
     return this.#farm.takeHeapSnapshot();
   }
 
+  async unstable_invalidate(): Promise<void> {
+    await this._init();
+  }
+
   async unstable_transform(
     options: AtlaspackTransformOptions,
   ): Promise<Array<Asset>> {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -818,32 +818,59 @@ export class RequestGraph extends ContentGraph<
     node: FileNameNode,
     filePath: ProjectPath,
     matchNodes: Array<FileNode>,
+    invalidateNode: (NodeId, InvalidateReason) => void,
   ) {
     // If there is an edge between this file_name node and one of the original file nodes pointed to
     // by the original file_name node, and the matched node is inside the current directory, invalidate
     // all connected requests pointed to by the file node.
-    let dirname = path.dirname(fromProjectPathRelative(filePath));
 
     let nodeId = this.getNodeIdByContentKey(node.id);
-    for (let matchNode of matchNodes) {
-      let matchNodeId = this.getNodeIdByContentKey(matchNode.id);
-      if (
-        this.hasEdge(
-          nodeId,
-          matchNodeId,
-          requestGraphEdgeTypes.invalidated_by_create_above,
-        ) &&
-        isDirectoryInside(
-          fromProjectPathRelative(toProjectPathUnsafe(matchNode.id)),
-          dirname,
+    let dirname = path.dirname(fromProjectPathRelative(filePath));
+
+    if (getFeatureFlag('fixQuadraticCacheInvalidation')) {
+      while (dirname !== '/') {
+        if (!this.hasContentKey(dirname)) break;
+        const matchNodeId = this.getNodeIdByContentKey(dirname);
+        if (
+          !this.hasEdge(
+            nodeId,
+            matchNodeId,
+            requestGraphEdgeTypes.invalidated_by_create_above,
+          )
         )
-      ) {
-        let connectedNodes = this.getNodeIdsConnectedTo(
+          break;
+
+        const connectedNodes = this.getNodeIdsConnectedTo(
           matchNodeId,
           requestGraphEdgeTypes.invalidated_by_create,
         );
         for (let connectedNode of connectedNodes) {
-          this.invalidateNode(connectedNode, FILE_CREATE);
+          invalidateNode(connectedNode, FILE_CREATE);
+        }
+
+        dirname = path.dirname(dirname);
+      }
+    } else {
+      for (let matchNode of matchNodes) {
+        let matchNodeId = this.getNodeIdByContentKey(matchNode.id);
+        if (
+          this.hasEdge(
+            nodeId,
+            matchNodeId,
+            requestGraphEdgeTypes.invalidated_by_create_above,
+          ) &&
+          isDirectoryInside(
+            fromProjectPathRelative(toProjectPathUnsafe(matchNode.id)),
+            dirname,
+          )
+        ) {
+          let connectedNodes = this.getNodeIdsConnectedTo(
+            matchNodeId,
+            requestGraphEdgeTypes.invalidated_by_create,
+          );
+          for (let connectedNode of connectedNodes) {
+            this.invalidateNode(connectedNode, FILE_CREATE);
+          }
         }
       }
     }
@@ -866,6 +893,7 @@ export class RequestGraph extends ContentGraph<
           parent,
           toProjectPathUnsafe(dirname),
           matchNodes,
+          invalidateNode,
         );
       }
     }
@@ -880,7 +908,38 @@ export class RequestGraph extends ContentGraph<
     let count = 0;
     let predictedTime = 0;
     let startTime = Date.now();
-    const removeOrphans = !getFeatureFlag('fixQuadraticCacheInvalidation');
+    const enableOptimization = getFeatureFlag('fixQuadraticCacheInvalidation');
+    const removeOrphans = !enableOptimization;
+
+    const invalidatedNodes = new Set();
+    const invalidateNode = (nodeId, reason) => {
+      if (enableOptimization && invalidatedNodes.has(nodeId)) {
+        return;
+      }
+      invalidatedNodes.add(nodeId);
+      this.invalidateNode(nodeId, reason);
+    };
+    const aboveCache = new Map();
+    const getAbove = fileNameNodeId => {
+      const cachedResult = aboveCache.get(fileNameNodeId);
+      if (enableOptimization && cachedResult) {
+        return cachedResult;
+      }
+
+      let above = [];
+      const children = this.getNodeIdsConnectedTo(
+        fileNameNodeId,
+        requestGraphEdgeTypes.invalidated_by_create_above,
+      );
+      for (const nodeId of children) {
+        let node = nullthrows(this.getNode(nodeId));
+        if (node.type === FILE) {
+          above.push(node);
+        }
+      }
+      aboveCache.set(fileNameNodeId, above);
+      return above;
+    };
 
     for (let {path: _path, type} of events) {
       if (++count === 256) {
@@ -939,7 +998,7 @@ export class RequestGraph extends ContentGraph<
 
         for (let connectedNode of nodes) {
           didInvalidate = true;
-          this.invalidateNode(connectedNode, FILE_UPDATE);
+          invalidateNode(connectedNode, FILE_UPDATE);
         }
 
         if (type === 'create') {
@@ -949,7 +1008,7 @@ export class RequestGraph extends ContentGraph<
           );
           for (let connectedNode of nodes) {
             didInvalidate = true;
-            this.invalidateNode(connectedNode, FILE_CREATE);
+            invalidateNode(connectedNode, FILE_CREATE);
           }
         }
       } else if (type === 'create') {
@@ -961,21 +1020,15 @@ export class RequestGraph extends ContentGraph<
           );
 
           // Find potential file nodes to be invalidated if this file name pattern matches
-          let above: Array<FileNode> = [];
-          for (const nodeId of this.getNodeIdsConnectedTo(
-            fileNameNodeId,
-            requestGraphEdgeTypes.invalidated_by_create_above,
-          )) {
-            let node = nullthrows(this.getNode(nodeId));
-            // these might also be `glob` nodes which get handled below, we only care about files here.
-            if (node.type === FILE) {
-              above.push(node);
-            }
-          }
-
+          let above: Array<FileNode> = getAbove(fileNameNodeId);
           if (above.length > 0) {
             didInvalidate = true;
-            this.invalidateFileNameNode(fileNameNode, _filePath, above);
+            this.invalidateFileNameNode(
+              fileNameNode,
+              _filePath,
+              above,
+              invalidateNode,
+            );
           }
         }
 
@@ -990,7 +1043,7 @@ export class RequestGraph extends ContentGraph<
             );
             for (let connectedNode of connectedNodes) {
               didInvalidate = true;
-              this.invalidateNode(connectedNode, FILE_CREATE);
+              invalidateNode(connectedNode, FILE_CREATE);
             }
           }
         }
@@ -1001,7 +1054,7 @@ export class RequestGraph extends ContentGraph<
           requestGraphEdgeTypes.invalidated_by_delete,
         )) {
           didInvalidate = true;
-          this.invalidateNode(connectedNode, FILE_DELETE);
+          invalidateNode(connectedNode, FILE_DELETE);
         }
 
         // Delete the file node since it doesn't exist anymore.
@@ -1033,7 +1086,7 @@ export class RequestGraph extends ContentGraph<
               nodeId,
               requestGraphEdgeTypes.invalidated_by_update,
             )) {
-              this.invalidateNode(
+              invalidateNode(
                 connectedNode,
                 type === 'delete' ? FILE_DELETE : FILE_UPDATE,
               );

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -942,7 +942,7 @@ export class RequestGraph extends ContentGraph<
     };
 
     for (let {path: _path, type} of events) {
-      if (++count === 256) {
+      if (!enableOptimization && ++count === 256) {
         let duration = Date.now() - startTime;
         predictedTime = duration * (events.length >> 8);
         if (predictedTime > threshold) {

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -6,11 +6,12 @@ import type {FeatureFlags as _FeatureFlags} from './types';
 export type FeatureFlags = _FeatureFlags;
 
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
+  exampleConsistencyCheckFeature: 'OLD',
   exampleFeature: false,
   atlaspackV3: false,
   useWatchmanWatcher: false,
   importRetry: false,
-  fixQuadraticCacheInvalidation: false,
+  fixQuadraticCacheInvalidation: 'OLD',
   fastOptimizeInlineRequires: false,
   useLmdbJsLite: false,
   fastNeedsDefaultInterop: false,
@@ -24,5 +25,71 @@ export function setFeatureFlags(flags: FeatureFlags) {
 }
 
 export function getFeatureFlag(flagName: $Keys<FeatureFlags>): boolean {
-  return featureFlagValues[flagName];
+  const value = featureFlagValues[flagName];
+  return value === true || value === 'NEW';
+}
+
+export type DiffResult<CustomDiagnostic> = {|
+  isDifferent: boolean,
+  custom: CustomDiagnostic,
+|};
+
+export type Diagnostic<CustomDiagnostic> = {|
+  isDifferent: boolean,
+  oldExecutionTimeMs: number,
+  newExecutionTimeMs: number,
+  custom: CustomDiagnostic,
+|};
+
+/**
+ * Run a function with a consistency check.
+ */
+export function runWithConsistencyCheck<Result, CustomDiagnostic>(
+  flag: string,
+  oldFn: () => Result,
+  newFn: () => Result,
+  diffFn: (
+    oldResult: Result,
+    newResult: Result,
+  ) => DiffResult<CustomDiagnostic>,
+  report: (
+    diagnostic: Diagnostic<CustomDiagnostic>,
+    oldResult: Result,
+    newResult: Result,
+  ) => void,
+): Result {
+  const value = featureFlagValues[flag];
+  if (!value || value === false || value === 'OLD') {
+    return oldFn();
+  }
+  if (value === true || value === 'NEW') {
+    return newFn();
+  }
+
+  const oldStartTime = performance.now();
+  const oldResult = oldFn();
+  const oldExecutionTimeMs = performance.now() - oldStartTime;
+
+  const newStartTime = performance.now();
+  const newResult = newFn();
+  const newExecutionTimeMs = performance.now() - newStartTime;
+
+  const diff = diffFn(oldResult, newResult);
+
+  report(
+    {
+      isDifferent: diff.isDifferent,
+      oldExecutionTimeMs,
+      newExecutionTimeMs,
+      custom: diff.custom,
+    },
+    oldResult,
+    newResult,
+  );
+
+  if (value === 'NEW_AND_CHECK') {
+    return newResult;
+  }
+
+  return oldResult;
 }

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -3,6 +3,7 @@
 export type FeatureFlags = {|
   // This feature flag mostly exists to test the feature flag system, and doesn't have any build/runtime effect
   +exampleFeature: boolean,
+  +exampleConsistencyCheckFeature: ConsistencyCheckFeatureFlagValue,
   /**
    * Rust backed requests
    */
@@ -22,7 +23,7 @@ export type FeatureFlags = {|
   /**
    * Fixes quadratic cache invalidation issue
    */
-  fixQuadraticCacheInvalidation: boolean,
+  fixQuadraticCacheInvalidation: ConsistencyCheckFeatureFlagValue,
   /**
    * Enable rust based inline requires optimization
    */
@@ -40,3 +41,9 @@ export type FeatureFlags = {|
    */
   conditionalBundlingApi: boolean,
 |};
+
+export type ConsistencyCheckFeatureFlagValue =
+  | 'NEW'
+  | 'OLD'
+  | 'NEW_AND_CHECK'
+  | 'OLD_AND_CHECK';

--- a/packages/core/feature-flags/test/feature-flags.test.js
+++ b/packages/core/feature-flags/test/feature-flags.test.js
@@ -25,7 +25,7 @@ describe('feature-flag test', () => {
     assert.equal(getFeatureFlag('exampleFeature'), true);
   });
 
-  describe.only('consistency checks', () => {
+  describe('consistency checks', () => {
     it('runs the old function if the flag is off', () => {
       setFeatureFlags({
         ...DEFAULT_FEATURE_FLAGS,

--- a/packages/core/feature-flags/test/feature-flags.test.js
+++ b/packages/core/feature-flags/test/feature-flags.test.js
@@ -1,6 +1,12 @@
 // @flow strict
 import assert from 'assert';
-import {getFeatureFlag, DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../src';
+import {
+  getFeatureFlag,
+  DEFAULT_FEATURE_FLAGS,
+  setFeatureFlags,
+  runWithConsistencyCheck,
+} from '../src';
+import sinon from 'sinon';
 
 describe('feature-flag test', () => {
   beforeEach(() => {
@@ -17,5 +23,83 @@ describe('feature-flag test', () => {
   it('can override', () => {
     setFeatureFlags({...DEFAULT_FEATURE_FLAGS, exampleFeature: true});
     assert.equal(getFeatureFlag('exampleFeature'), true);
+  });
+
+  describe.only('consistency checks', () => {
+    it('runs the old function if the flag is off', () => {
+      setFeatureFlags({
+        ...DEFAULT_FEATURE_FLAGS,
+        exampleConsistencyCheckFeature: 'OLD',
+      });
+      const result = runWithConsistencyCheck(
+        'exampleConsistencyCheckFeature',
+        () => 'old',
+        () => 'new',
+        sinon.spy(),
+        sinon.spy(),
+      );
+      assert.equal(result, 'old');
+    });
+
+    it('runs the new function if the flag is on', () => {
+      setFeatureFlags({
+        ...DEFAULT_FEATURE_FLAGS,
+        exampleConsistencyCheckFeature: 'NEW',
+      });
+      const result = runWithConsistencyCheck(
+        'exampleConsistencyCheckFeature',
+        () => 'old',
+        () => 'new',
+        sinon.spy(),
+        sinon.spy(),
+      );
+      assert.equal(result, 'new');
+    });
+
+    it('diffs old and new values if there is a diff value', () => {
+      setFeatureFlags({
+        ...DEFAULT_FEATURE_FLAGS,
+        exampleConsistencyCheckFeature: 'OLD_AND_CHECK',
+      });
+      const reportSpy = sinon.spy();
+      const result = runWithConsistencyCheck(
+        'exampleConsistencyCheckFeature',
+        () => 'old',
+        () => 'new',
+        () => ({isDifferent: false, custom: 'diff'}),
+        reportSpy,
+      );
+
+      assert.equal(result, 'old');
+      sinon.assert.calledWith(reportSpy, {
+        isDifferent: false,
+        oldExecutionTimeMs: sinon.match.number,
+        newExecutionTimeMs: sinon.match.number,
+        custom: 'diff',
+      });
+    });
+
+    it('diffs old and new values if there is a diff new value', () => {
+      setFeatureFlags({
+        ...DEFAULT_FEATURE_FLAGS,
+        exampleConsistencyCheckFeature: 'NEW_AND_CHECK',
+      });
+      const reportSpy = sinon.spy();
+      const result = runWithConsistencyCheck(
+        'exampleConsistencyCheckFeature',
+        () => 'old',
+        () => 'new',
+        () => ({isDifferent: true, custom: 'diff'}),
+        reportSpy,
+      );
+
+      assert.equal(result, 'new');
+      sinon.assert.calledWith(reportSpy, {
+        isDifferent: true,
+        oldExecutionTimeMs: sinon.match.number,
+        newExecutionTimeMs: sinon.match.number,
+        custom: 'diff',
+      });
+    });
   });
 });


### PR DESCRIPTION
This commit fixes several performance problems in the cache invalidation implementation. Overall, this improves performance of handling a large number of events from updating `node_modules` on a large application by 1500x.

The request graph stores a tasks, and their inter-dependencies, as well as their relationship with files. Relationship with files is used for cache invalidation.

There are a few problems with the current implementation:

* Cache invalidation performs `O(events * tasks)` amount of work. This is not fixed
* The "file above" invalidation type has extremely poor performance because even though the files are structured in a prefix tree sort of structure, the implementation is listing all incoming nodes and then iterating them to check for file-path matches. This means that for every package.json/index.js/common-file-path file change, we will perform N comparisons, where N is the number of directories in the entire project + dependencies that contains one of these files. On large projects, this number is in the hundreds of thousands, and since this is effectively `O(N ^ 2)` with respect of that number, this takes an unmanageable amount of time to complete.

The current time to process 300k events (which is the number of events) triggered on a yarn install is over 2 hours. After this change, the time becomes under 4 seconds. There are still significant optimizations that can be made.

A better write-up of these changes and validation of their correctness will be shared on a subsequent document.