### PR TITLE
Fix reading feature-flags when resolving options

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -57,7 +57,7 @@ import {
   fromProjectPathRelative,
 } from './projectPath';
 import {tracer} from '@atlaspack/profiler';
-import {setFeatureFlags} from '@atlaspack/feature-flags';
+import {setFeatureFlags, DEFAULT_FEATURE_FLAGS} from '@atlaspack/feature-flags';
 import {AtlaspackV3, toFileSystemV3} from './atlaspack-v3';
 
 registerCoreWithSerializer();
@@ -105,6 +105,12 @@ export default class Atlaspack {
       return;
     }
 
+    const featureFlags = {
+      ...DEFAULT_FEATURE_FLAGS,
+      ...this.#initialOptions.featureFlags,
+    };
+    setFeatureFlags(featureFlags);
+
     await initSourcemaps;
     await initRust?.();
     try {
@@ -117,9 +123,10 @@ export default class Atlaspack {
       logger.warn(e);
     }
 
-    let resolvedOptions: AtlaspackOptions = await resolveOptions(
-      this.#initialOptions,
-    );
+    let resolvedOptions: AtlaspackOptions = await resolveOptions({
+      ...this.#initialOptions,
+      featureFlags,
+    });
     this.#resolvedOptions = resolvedOptions;
 
     let rustAtlaspack: AtlaspackV3;
@@ -151,8 +158,6 @@ export default class Atlaspack {
         },
       });
     }
-
-    setFeatureFlags(resolvedOptions.featureFlags);
 
     let {config} = await loadAtlaspackConfig(resolvedOptions);
     this.#config = new AtlaspackConfig(config, resolvedOptions);

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -231,6 +231,8 @@ export default async function resolveOptions(
       outputFormat: initialOptions?.defaultTargetOptions?.outputFormat,
       isLibrary: initialOptions?.defaultTargetOptions?.isLibrary,
     },
+    // unused, feature-flags are set above this to allow this function to use
+    // feature-flags
     featureFlags: {...DEFAULT_FEATURE_FLAGS, ...initialOptions?.featureFlags},
     parcelVersion: ATLASPACK_VERSION,
   };

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -24,6 +24,7 @@ import ThrowableDiagnostic, {
 } from '@atlaspack/diagnostic';
 import globals from 'globals';
 import path from 'path';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';


### PR DESCRIPTION
PR https://github.com/atlassian-labs/atlaspack/pull/72 added a feature-flag to switch to the new LMDB back-end, however that flag isn't correctly read because it is not set when resolving options.

This PR changes the feature-flags code to set feature-flags before anything else.

`AFB-786`