### PR TITLE
[V3] Add native yaml transformer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "atlaspack_plugin_transformer_js",
  "atlaspack_plugin_transformer_json",
  "atlaspack_plugin_transformer_raw",
+ "atlaspack_plugin_transformer_yaml",
  "dyn-hash",
  "indexmap 2.5.0",
  "mockall",
@@ -499,6 +500,18 @@ dependencies = [
  "anyhow",
  "atlaspack_core",
  "atlaspack_filesystem",
+]
+
+[[package]]
+name = "atlaspack_plugin_transformer_yaml"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "atlaspack_core",
+ "atlaspack_filesystem",
+ "pretty_assertions",
+ "serde_json",
+ "serde_yml",
 ]
 
 [[package]]
@@ -2163,6 +2176,16 @@ checksum = "0e7bb23d733dfcc8af652a78b7bf232f0e967710d044732185e561e47c0336b6"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "libyml"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3302702afa434ffa30847a83305f0a69d6abd74293b6554c18ec85c7ef30c980"
+dependencies = [
+ "anyhow",
+ "version_check",
 ]
 
 [[package]]
@@ -3977,6 +4000,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yml"
+version = "0.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
+dependencies = [
+ "indexmap 2.5.0",
+ "itoa",
+ "libyml",
+ "memchr",
+ "ryu",
+ "serde",
+ "version_check",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5504,9 +5542,9 @@ checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/crates/atlaspack/Cargo.toml
+++ b/crates/atlaspack/Cargo.toml
@@ -20,6 +20,7 @@ atlaspack_plugin_transformer_inline_string = { path = "../atlaspack_plugin_trans
 atlaspack_plugin_transformer_js = { path = "../atlaspack_plugin_transformer_js" }
 atlaspack_plugin_transformer_json = { path = "../atlaspack_plugin_transformer_json" }
 atlaspack_plugin_transformer_raw = { path = "../atlaspack_plugin_transformer_raw" }
+atlaspack_plugin_transformer_yaml = { path = "../atlaspack_plugin_transformer_yaml" }
 atlaspack_plugin_rpc = { path = "../atlaspack_plugin_rpc" }
 atlaspack-resolver = { path = "../../packages/utils/node-resolver-rs" }
 

--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -33,6 +33,7 @@ use atlaspack_plugin_transformer_inline_string::AtlaspackInlineStringTransformer
 use atlaspack_plugin_transformer_js::AtlaspackJsTransformerPlugin;
 use atlaspack_plugin_transformer_json::AtlaspackJsonTransformerPlugin;
 use atlaspack_plugin_transformer_raw::AtlaspackRawTransformerPlugin;
+use atlaspack_plugin_transformer_yaml::AtlaspackYamlTransformerPlugin;
 
 use super::Plugins;
 use super::TransformerPipeline;
@@ -220,6 +221,7 @@ impl Plugins for ConfigPlugins {
         "@atlaspack/transformer-image" => Box::new(AtlaspackImageTransformerPlugin::new(&self.ctx)),
         "@atlaspack/transformer-raw" => Box::new(AtlaspackRawTransformerPlugin::new(&self.ctx)),
         "@atlaspack/transformer-json" => Box::new(AtlaspackJsonTransformerPlugin::new(&self.ctx)),
+        "@atlaspack/transformer-yaml" => Box::new(AtlaspackYamlTransformerPlugin::new(&self.ctx)),
         _ => {
           let Some(rpc_worker) = &self.rpc_worker else {
             anyhow::bail!("Unable to initialize JavaScript plugin")

--- a/crates/atlaspack_plugin_transformer_yaml/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_yaml/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "atlaspack_plugin_transformer_yaml"
+version = "0.1.0"
+authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
+edition = "2021"
+description = "Yaml transformer plugin for the Atlaspack Bundler"
+
+[dependencies]
+atlaspack_core = { path = "../atlaspack_core" }
+
+anyhow = "1"
+serde_json = "1.0.116"
+serde_yml = "0.0.12"
+
+[dev-dependencies]
+atlaspack_filesystem = { path = "../atlaspack_filesystem" }
+pretty_assertions = "1.4.0"

--- a/crates/atlaspack_plugin_transformer_yaml/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_yaml/src/lib.rs
@@ -1,0 +1,3 @@
+pub use yaml_transformer::AtlaspackYamlTransformerPlugin;
+
+mod yaml_transformer;

--- a/crates/atlaspack_plugin_transformer_yaml/src/yaml_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_yaml/src/yaml_transformer.rs
@@ -1,0 +1,103 @@
+use std::sync::Arc;
+
+use anyhow::Error;
+use atlaspack_core::plugin::{PluginContext, TransformerPlugin};
+use atlaspack_core::plugin::{TransformContext, TransformResult};
+use atlaspack_core::types::{Asset, Code, FileType};
+
+#[derive(Debug)]
+pub struct AtlaspackYamlTransformerPlugin {}
+
+impl AtlaspackYamlTransformerPlugin {
+  pub fn new(_ctx: &PluginContext) -> Self {
+    AtlaspackYamlTransformerPlugin {}
+  }
+}
+
+impl TransformerPlugin for AtlaspackYamlTransformerPlugin {
+  fn transform(
+    &mut self,
+    _context: TransformContext,
+    asset: Asset,
+  ) -> Result<TransformResult, Error> {
+    let mut asset = asset.clone();
+
+    let code = serde_yml::from_slice::<serde_yml::Value>(asset.code.bytes())?;
+    let code = serde_json::to_string(&code)?;
+
+    asset.code = Arc::new(Code::from(format!("module.exports = {code};")));
+    asset.file_type = FileType::Js;
+
+    Ok(TransformResult {
+      asset,
+      ..Default::default()
+    })
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use std::{path::PathBuf, sync::Arc};
+
+  use atlaspack_core::{
+    config_loader::ConfigLoader,
+    plugin::{PluginLogger, PluginOptions},
+  };
+  use atlaspack_filesystem::in_memory_file_system::InMemoryFileSystem;
+  use pretty_assertions::assert_eq;
+
+  use super::*;
+
+  fn create_yaml_plugin() -> AtlaspackYamlTransformerPlugin {
+    let file_system = Arc::new(InMemoryFileSystem::default());
+
+    AtlaspackYamlTransformerPlugin::new(&PluginContext {
+      config: Arc::new(ConfigLoader {
+        fs: file_system.clone(),
+        project_root: PathBuf::default(),
+        search_path: PathBuf::default(),
+      }),
+      file_system,
+      logger: PluginLogger::default(),
+      options: Arc::new(PluginOptions::default()),
+    })
+  }
+
+  #[test]
+  fn returns_js_asset_from_yaml() {
+    let mut plugin = create_yaml_plugin();
+
+    let asset = Asset {
+      code: Arc::new(Code::from(String::from(
+        "
+          a: 1
+          b:
+            c: 2
+            d: true
+          e:
+            - f
+            - g
+        ",
+      ))),
+      file_type: FileType::Json,
+      ..Asset::default()
+    };
+
+    let context = TransformContext::default();
+    let transformation = plugin.transform(context, asset).map_err(|e| e.to_string());
+
+    assert_eq!(
+      transformation,
+      Ok(TransformResult {
+        asset: Asset {
+          code: Arc::new(Code::from(String::from(
+            "module.exports = {\"a\":1,\"b\":{\"c\":2,\"d\":true},\"e\":[\"f\",\"g\"]};"
+          ))),
+          file_type: FileType::Js,
+          ..Asset::default()
+        },
+        ..Default::default()
+      })
+    );
+  }
+}

--- a/packages/core/integration-tests/test/yaml.js
+++ b/packages/core/integration-tests/test/yaml.js
@@ -13,13 +13,13 @@ import {
   run,
 } from '@atlaspack/test-utils';
 
-describe.v2('yaml', function () {
+describe('yaml', function () {
   beforeEach(async () => {
     await removeDistDirectory();
   });
 
   it('files can be required in JavaScript', async function () {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.js:
         const test = require('./test.yaml');
 
@@ -33,7 +33,7 @@ describe.v2('yaml', function () {
           c: 2
     `;
 
-    let b = await bundle('index.js', {inputFS: overlayFS});
+    let b = await bundle(join(__dirname, 'index.js'), {inputFS: overlayFS});
 
     assertBundles(b, [
       {
@@ -53,14 +53,14 @@ describe.v2('yaml', function () {
   });
 
   it('files are minified', async function () {
-    await fsFixture(overlayFS)`
+    await fsFixture(overlayFS, __dirname)`
       index.yaml:
         a: 1
         b:
           c: 2
     `;
 
-    await bundle('index.yaml', {
+    await bundle(join(__dirname, 'index.yaml'), {
       defaultTargetOptions: {
         shouldOptimize: true,
         shouldScopeHoist: false,


### PR DESCRIPTION
## Motivation

These changes port the yaml transformer to Rust so that more functionality works in v3. It also removes the overhead of calling into JavaScript plugins by using Rust directly.

## Changes

* Add `atlaspack_plugin_transformer_yaml` crate
* Use yaml transformer when `@atlaspack/transformer-yaml` is encountered
* Enable yaml tests

## Checklist

- [x] Existing or new tests cover this change