### PR TITLE
V3: Resolver API

### DIFF
--- a/packages/core/core/src/atlaspack-v3/worker/compat/asset-compat.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/asset-compat.js
@@ -1,11 +1,11 @@
 // @flow
 import type {PluginOptions, BundleBehavior, AST} from '@atlaspack/types';
 
-import Environment from '../../public/Environment';
+import Environment from '../../../public/Environment';
 import {
   BundleBehaviorNames,
   BundleBehavior as BundleBehaviorMap,
-} from '../../types';
+} from '../../../types';
 
 export type InnerAsset = {|
   id: string,

--- a/packages/core/core/src/atlaspack-v3/worker/compat/asset-symbols.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/asset-symbols.js
@@ -1,0 +1,132 @@
+// @flow
+
+import type {Symbol as NapiSymbol} from '@atlaspack/rust';
+import type {
+  AssetSymbols as ClassicAssetSymbols,
+  MutableAssetSymbols as ClassicMutableAssetSymbols,
+  MutableDependencySymbols as ClassicMutableDependencySymbols,
+  Symbol,
+  SourceLocation,
+  Meta,
+} from '@atlaspack/types';
+
+export class MutableDependencySymbols
+  implements ClassicMutableDependencySymbols
+{
+  #symbols: Map<Symbol, DependencyAssetSymbol>;
+  #locals: Set<Symbol>;
+
+  get isCleared(): boolean {
+    return this.#symbols.size === 0;
+  }
+
+  constructor(inner: NapiSymbol[]) {
+    this.#symbols = new Map();
+    this.#locals = new Set();
+    for (const {exported, local, loc, isWeak} of inner) {
+      this.set(exported, local, loc, isWeak);
+    }
+  }
+
+  ensure(): void {
+    throw new Error('MutableDependencySymbols.ensure()');
+  }
+
+  get(exportSymbol: Symbol): ?DependencyAssetSymbol {
+    return this.#symbols.get(exportSymbol);
+  }
+
+  hasExportSymbol(exportSymbol: Symbol): boolean {
+    return this.#symbols.has(exportSymbol);
+  }
+
+  hasLocalSymbol(local: Symbol): boolean {
+    return this.#locals.has(local);
+  }
+
+  exportSymbols(): Iterable<Symbol> {
+    return this.#symbols.keys();
+  }
+
+  set(
+    exportSymbol: Symbol,
+    local: Symbol,
+    loc: ?SourceLocation,
+    isWeak: ?boolean,
+  ): void {
+    this.#locals.add(local);
+    this.#symbols.set(exportSymbol, {
+      local,
+      loc,
+      meta: {},
+      isWeak: isWeak ?? false,
+    });
+  }
+
+  delete(exportSymbol: Symbol): void {
+    let existing = this.#symbols.get(exportSymbol);
+    if (!existing) return;
+    this.#locals.delete(existing.local);
+    this.#symbols.delete(exportSymbol);
+  }
+
+  /*::  @@iterator(): Iterator<[Symbol, DependencyAssetSymbol]> { return ({}: any); } */
+  // $FlowFixMe Flow can't do computed properties
+  [Symbol.iterator]() {
+    return this.#symbols.values();
+  }
+}
+
+// TODO
+export class AssetSymbols
+  extends Array<[Symbol, AssetSymbol]>
+  implements ClassicAssetSymbols
+{
+  isCleared: boolean;
+
+  // eslint-disable-next-line no-unused-vars
+  get(exportSymbol: Symbol): ?AssetSymbol {}
+
+  // eslint-disable-next-line no-unused-vars
+  hasExportSymbol(exportSymbol: Symbol): boolean {
+    throw new Error('AssetSymbols.hasExportSymbol');
+  }
+
+  // eslint-disable-next-line no-unused-vars
+  hasLocalSymbol(local: Symbol): boolean {
+    throw new Error('AssetSymbols.hasExportSymbol');
+  }
+
+  exportSymbols(): Iterable<Symbol> {
+    return [];
+  }
+}
+
+// TODO
+export class MutableAssetSymbols
+  extends AssetSymbols
+  implements ClassicMutableAssetSymbols
+{
+  ensure(): void {}
+  set(
+    // eslint-disable-next-line no-unused-vars
+    exportSymbol: Symbol,
+    // eslint-disable-next-line no-unused-vars
+    local: Symbol,
+    // eslint-disable-next-line no-unused-vars
+    loc: ?SourceLocation,
+    // eslint-disable-next-line no-unused-vars
+    meta?: ?Meta,
+  ): void {}
+
+  // eslint-disable-next-line no-unused-vars
+  delete(exportSymbol: Symbol): void {}
+}
+
+export type AssetSymbol = {|local: Symbol, loc: ?SourceLocation, meta?: ?Meta|};
+export type DependencyAssetSymbol = {|
+  local: Symbol,
+  loc: ?SourceLocation,
+  meta?: ?Meta,
+  isWeak: boolean,
+|};

--- a/packages/core/core/src/atlaspack-v3/worker/compat/bitflags.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/bitflags.js
@@ -1,0 +1,86 @@
+// @flow
+
+import type {
+  BundleBehavior,
+  DependencyPriority,
+  SpecifierType,
+} from '@atlaspack/types';
+
+/// BitFlags is used to map number/string types from napi types
+export class BitFlags<K, V> {
+  #kv: {[key: K]: V};
+  #vk: {[key: V]: K};
+
+  constructor(source: {[key: K]: V}) {
+    this.#kv = source;
+    this.#vk = Object.fromEntries(
+      // $FlowFixMe
+      Object.entries(source).map(a => a.reverse()),
+    );
+  }
+
+  into(key: K): V {
+    const found = this.#kv[key];
+    if (found === undefined) {
+      // $FlowFixMe
+      throw new Error(`Invalid BundleBehavior(${key})`);
+    }
+    return found;
+  }
+
+  intoArray(keys: K[]): V[] {
+    return keys.map(key => this.into(key));
+  }
+
+  from(key: V): K {
+    const found = this.#vk[key];
+    if (found === undefined) {
+      // $FlowFixMe
+      throw new Error(`Invalid BundleBehavior(${key})`);
+    }
+    return found;
+  }
+
+  fromArray(keys: V[]): K[] {
+    return keys.map(key => this.from(key));
+  }
+}
+
+export const bundleBehaviorMap: BitFlags<BundleBehavior, number> = new BitFlags(
+  {
+    inline: 0,
+    isolated: 1,
+  },
+);
+
+export const dependencyPriorityMap: BitFlags<DependencyPriority, number> =
+  new BitFlags({
+    sync: 0,
+    parallel: 1,
+    lazy: 2,
+    conditional: 3,
+  });
+
+export const packageConditionsMap: BitFlags<string, number> = new BitFlags({
+  import: 0,
+  require: 1,
+  module: 2,
+  node: 3,
+  browser: 4,
+  worker: 5,
+  worklet: 6,
+  electron: 7,
+  development: 8,
+  production: 9,
+  types: 10,
+  default: 11,
+  style: 12,
+  sass: 13,
+});
+
+export const specifierTypeMap: BitFlags<SpecifierType, number> = new BitFlags({
+  esm: 0,
+  commonjs: 1,
+  url: 2,
+  custom: 3,
+});

--- a/packages/core/core/src/atlaspack-v3/worker/compat/dependency.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/dependency.js
@@ -1,0 +1,83 @@
+// @flow
+
+import type {Dependency as NapiDependency} from '@atlaspack/rust';
+import type {
+  Dependency as ClassicDependency,
+  DependencySpecifier,
+  SpecifierType,
+  DependencyPriority,
+  BundleBehavior,
+  SourceLocation,
+  Environment as ClassicEnvironment,
+  Meta,
+  Target as ClassicTarget,
+  FilePath,
+  SemverRange,
+  MutableDependencySymbols as ClassicMutableDependencySymbols,
+} from '@atlaspack/types';
+import {Target} from './target';
+import {MutableDependencySymbols} from './asset-symbols';
+import {
+  bundleBehaviorMap,
+  specifierTypeMap,
+  dependencyPriorityMap,
+  packageConditionsMap,
+} from './bitflags';
+
+export class Dependency implements ClassicDependency {
+  env: ClassicEnvironment;
+  meta: Meta;
+  target: ?ClassicTarget;
+  symbols: ClassicMutableDependencySymbols;
+  specifier: DependencySpecifier;
+  specifierType: SpecifierType;
+  priority: DependencyPriority;
+  bundleBehavior: ?BundleBehavior;
+  needsStableName: boolean;
+  isOptional: boolean;
+  isEntry: boolean;
+  loc: ?SourceLocation;
+  packageConditions: ?Array<string>;
+  sourceAssetId: ?string;
+  sourcePath: ?FilePath;
+  sourceAssetType: ?string;
+  resolveFrom: ?FilePath;
+  range: ?SemverRange;
+  pipeline: ?string;
+
+  get id(): string {
+    throw new Error('Dependency.id');
+  }
+
+  constructor(inner: NapiDependency, env: ClassicEnvironment) {
+    this.env = env;
+    this.meta = inner.meta || {};
+    this.target = undefined;
+    if (inner.target) {
+      this.target = new Target(inner.target, this.env);
+    }
+    if (!inner.bundleBehavior) {
+      this.bundleBehavior = undefined;
+    } else {
+      this.bundleBehavior = bundleBehaviorMap.from(inner.bundleBehavior);
+    }
+    this.bundleBehavior = undefined;
+    this.symbols = new MutableDependencySymbols(inner.symbols || []);
+    this.specifier = inner.specifier;
+    this.specifierType = specifierTypeMap.from(inner.specifierType);
+    this.priority = dependencyPriorityMap.from(inner.priority);
+    this.needsStableName = inner.needsStableName;
+    this.isOptional = inner.isOptional;
+    this.isEntry = inner.isEntry;
+    this.loc = inner.loc;
+    this.packageConditions = packageConditionsMap.fromArray(
+      inner.packageConditions || [],
+    );
+    this.sourceAssetId = inner.sourceAssetId;
+    this.sourcePath = inner.sourcePath;
+    this.sourceAssetType = inner.sourceAssetType;
+    this.resolveFrom = inner.resolveFrom;
+    this.range = inner.range;
+    this.pipeline = inner.pipeline;
+  }
+}

--- a/packages/core/core/src/atlaspack-v3/worker/compat/environment.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/environment.js
@@ -1,0 +1,92 @@
+// @flow
+
+import type {Environment as NapiEnvironment} from '@atlaspack/rust';
+import type {
+  Environment as ClassicEnvironment,
+  EnvironmentContext,
+  Engines,
+  PackageName,
+  OutputFormat,
+  SourceType,
+  TargetSourceMapOptions,
+  SourceLocation,
+  VersionMap,
+  EnvironmentFeature,
+} from '@atlaspack/types';
+
+export class Environment implements ClassicEnvironment {
+  id: string;
+  includeNodeModules:
+    | boolean
+    | Array<PackageName>
+    | {[PackageName]: boolean, ...};
+  context: EnvironmentContext;
+  engines: Engines;
+  outputFormat: OutputFormat;
+  sourceType: SourceType;
+  isLibrary: boolean;
+  shouldOptimize: boolean;
+  shouldScopeHoist: boolean;
+  sourceMap: ?TargetSourceMapOptions;
+  loc: ?SourceLocation;
+
+  constructor(inner: NapiEnvironment) {
+    // TODO
+    this.id = '';
+    this.includeNodeModules = inner.includeNodeModules;
+    // $FlowFixMe
+    this.context = inner.context;
+    this.engines = inner.engines;
+    // $FlowFixMe
+    this.outputFormat = inner.outputFormat;
+    // $FlowFixMe
+    this.sourceType = inner.sourceType;
+    this.isLibrary = inner.isLibrary;
+    this.shouldOptimize = inner.shouldOptimize;
+    this.shouldScopeHoist = inner.shouldScopeHoist;
+    this.sourceMap = inner.sourceMap;
+    this.loc = inner.loc;
+  }
+
+  // TODO
+  isBrowser(): boolean {
+    return true;
+  }
+
+  // TODO
+  isNode(): boolean {
+    return false;
+  }
+
+  // TODO
+  isElectron(): boolean {
+    return false;
+  }
+
+  // TODO
+  isWorker(): boolean {
+    return false;
+  }
+
+  // TODO
+  isWorklet(): boolean {
+    return false;
+  }
+
+  // TODO
+  isIsolated(): boolean {
+    return false;
+  }
+
+  // TODO
+  // eslint-disable-next-line no-unused-vars
+  matchesEngines(minVersions: VersionMap, defaultValue?: boolean): boolean {
+    return true;
+  }
+
+  // TODO
+  // eslint-disable-next-line no-unused-vars
+  supports(feature: EnvironmentFeature, defaultValue?: boolean): boolean {
+    return true;
+  }
+}

--- a/packages/core/core/src/atlaspack-v3/worker/compat/index.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/index.js
@@ -1,0 +1,7 @@
+// @flow
+export * from './asset-compat';
+export * from './asset-symbols';
+export * from './bitflags';
+export * from './dependency';
+export * from './environment';
+export * from './target';

--- a/packages/core/core/src/atlaspack-v3/worker/compat/target.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/target.js
@@ -1,0 +1,27 @@
+// @flow
+
+import type {Target as NapiTarget} from '@atlaspack/rust';
+import type {
+  Target as ClassicTarget,
+  FilePath,
+  Environment,
+  SourceLocation,
+} from '@atlaspack/types';
+
+export class Target implements ClassicTarget {
+  distEntry: ?FilePath;
+  distDir: FilePath;
+  env: Environment;
+  name: string;
+  publicUrl: string;
+  loc: ?SourceLocation;
+
+  constructor(inner: NapiTarget, env: Environment) {
+    this.distDir = inner.distDir;
+    this.distEntry = inner.distEntry;
+    this.name = inner.name;
+    this.publicUrl = inner.publicUrl;
+    this.loc = inner.loc;
+    this.env = env;
+  }
+}

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -127,36 +127,36 @@ export type Engines = {|
   browsers?: string | string[],
   electron?: string,
   node?: string,
-|}
+|};
 
 export type Environment = {|
-   context: string,
-   engines: Engines,
-   includeNodeModules: IncludeNodeModules,
-   isLibrary: boolean,
-   loc?: SourceLocation,
-   outputFormat: string,
-   shouldScopeHoist: boolean,
-   shouldOptimize: boolean,
-   sourceMap?: {|
+  context: string,
+  engines: Engines,
+  includeNodeModules: IncludeNodeModules,
+  isLibrary: boolean,
+  loc?: SourceLocation,
+  outputFormat: string,
+  shouldScopeHoist: boolean,
+  shouldOptimize: boolean,
+  sourceMap?: {|
     inline?: boolean,
     inlineSources?: boolean,
     sourceRoot?: string,
   |},
-   sourceType: string,
-|}
+  sourceType: string,
+|};
 
 export type SourceLocation = {|
   filePath: string,
   start: {|
-    line: number, 
-    column: number 
+    line: number,
+    column: number,
   |},
   end: {|
-    line: number, 
-    column: number 
+    line: number,
+    column: number,
   |},
-|}
+|};
 
 export type Symbol = {|
   local: string,
@@ -165,7 +165,7 @@ export type Symbol = {|
   isWeak: boolean,
   isEsmExport: boolean,
   selfReferenced: boolean,
-|}
+|};
 
 export type Target = {|
   distDir: string,
@@ -174,14 +174,14 @@ export type Target = {|
   loc?: SourceLocation,
   name: string,
   publicUrl: string,
-|}
+|};
 
 export type Dependency = {|
   bundleBehavior?: number,
   env: Environment,
   loc: SourceLocation,
   meta?: any,
-  packageConditions: number,
+  packageConditions: number[],
   pipeline?: string,
   priority: number,
   range?: string,
@@ -198,8 +198,8 @@ export type Dependency = {|
   needsStableName: boolean,
   shouldWrap: boolean,
   isEsm: boolean,
-  placeholder?: string,  
-|}
+  placeholder?: string,
+|};
 
 export type RpcAssetResult = {|
   id: String,
@@ -215,24 +215,24 @@ export type RpcAssetResult = {|
   sideEffects: boolean,
   isBundleSplittable: boolean,
   isSource: boolean,
-|}
+|};
 
 export type RpcTransformerOpts = {|
   resolveFrom: string,
   specifier: string,
   options: RpcPluginOptions,
   asset: Asset,
-|}
+|};
 
 export type RpcHmrOptions = {|
   port?: number,
   host?: string,
-|}
+|};
 
 export type RpcPluginOptions = {|
   hmrOptions?: RpcHmrOptions,
   projectRoot: string,
-|}
+|};
 
 export type Asset = {|
   id: string,
@@ -265,7 +265,7 @@ export type Asset = {|
   |}>,
   configPath?: string,
   configKeyPath?: string,
-|}
+|};
 
 declare export class Resolver {
   constructor(projectRoot: string, options: ResolverOptions): Resolver;
@@ -352,7 +352,10 @@ export interface JsFileSystemOptions {
 
 // Types below break IDE highlighting, place them at the bottom of the file
 
-export type IncludeNodeModules = boolean | Array<string> | {|[string]: boolean|}
+export type IncludeNodeModules =
+  | boolean
+  | Array<string>
+  | {|[string]: boolean|};
 
 export type Resolution =
   | {|type: 'Path', value: string|}


### PR DESCRIPTION
All Resolvers in JFE now pass

- Added compat types for napi structures that need to be used in JavaScript
  - `Dependency`
  - `Environment`
  - `Target`
  - `MutableDependencySymbols`
- Added compat mappings for bit types (`BundleBehavior`, etc) 