### PR TITLE
Add --production for production mode serve/watch

### DIFF
--- a/packages/core/cli/src/cli.js
+++ b/packages/core/cli/src/cli.js
@@ -343,7 +343,6 @@ async function run(
     }),
     shouldPatchConsole: false,
     ...options,
-    shouldScopeHoist: true,
   });
 
   let disposable = new Disposable();

--- a/packages/core/cli/src/cli.js
+++ b/packages/core/cli/src/cli.js
@@ -203,6 +203,7 @@ let serve = program
     '--lazy-exclude <excludes>',
     'Can only be used in combination with --lazy. Comma separated list of source file globs, async bundles whose entry points match these globs will not be built lazily',
   )
+  .option('--production', 'Run with production mode defaults')
   .action(runCommand);
 
 applyOptions(serve, hmrOptions);
@@ -214,6 +215,7 @@ let watch = program
   .option('--public-url <url>', 'the path prefix for absolute urls')
   .option('--no-content-hash', 'disable content hashing')
   .option('--watch-for-stdin', 'exit when stdin closes')
+  .option('--production', 'Run with production mode defaults')
   .action(runCommand);
 
 applyOptions(watch, hmrOptions);
@@ -341,6 +343,7 @@ async function run(
     }),
     shouldPatchConsole: false,
     ...options,
+    shouldScopeHoist: true,
   });
 
   let disposable = new Disposable();
@@ -474,12 +477,16 @@ function parseOptionInt(value) {
   return parsedValue;
 }
 
+function shouldUseProductionDefaults(command) {
+  return command.name() === 'build' || command.production === true;
+}
+
 async function normalizeOptions(
   command,
   inputFS,
 ): Promise<InitialAtlaspackOptions> {
   let nodeEnv;
-  if (command.name() === 'build') {
+  if (shouldUseProductionDefaults(command)) {
     nodeEnv = process.env.NODE_ENV || 'production';
     // Autoinstall unless explicitly disabled or we detect a CI environment.
     command.autoinstall = !(command.autoinstall === false || process.env.CI);
@@ -505,7 +512,10 @@ async function normalizeOptions(
   // Ensure port is valid and available
   let port = parsePort(command.port || '1234');
   let originalPort = port;
-  if (command.name() === 'serve' || command.hmr) {
+  if (
+    !shouldUseProductionDefaults(command) &&
+    (command.name() === 'serve' || command.hmr)
+  ) {
     try {
       port = await getPort({port, host});
     } catch (err) {
@@ -542,7 +552,7 @@ async function normalizeOptions(
   }
 
   let hmrOptions = null;
-  if (command.name() !== 'build' && command.hmr !== false) {
+  if (!shouldUseProductionDefaults(command) && command.hmr !== false) {
     let hmrport = command.hmrPort ? parsePort(command.hmrPort) : port;
     let hmrhost = command.hmrHost ? command.hmrHost : host;
 
@@ -571,7 +581,9 @@ async function normalizeOptions(
     });
   }
 
-  let mode = command.name() === 'build' ? 'production' : 'development';
+  let mode = shouldUseProductionDefaults(command)
+    ? 'production'
+    : 'development';
 
   const normalizeIncludeExcludeList = (input?: string): string[] => {
     if (typeof input !== 'string') return [];


### PR DESCRIPTION
This commit adds a `--production` CLI flag to serve/watch commands, so that we can run them in production mode to debug or test production build outputs in local/watch builds.

## Motivation

Sometimes app developers might need to profile or debug their apps in production mode, for example for performance/load time debugging or to understand certain issues that might be only happening on production builds.

Currently when using the CLI, all `atlaspack serve` / `atlaspack watch` builds are development mode and all `atlaspack build` builds are production mode.

This commit adds a `--production` flag that is used to turn on production mode in the `watch` / `serve` commands.

## Checklist

- [x] Existing or new tests cover this change
