### PR TITLE
Fix bug in inline requires

### DIFF
--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
@@ -24,7 +24,7 @@ pub struct RequireInitializer {
 fn default_require_matchers() -> Vec<RequireMatcher> {
   vec![
     RequireMatcher::Global(atom!("require")),
-    RequireMatcher::Global(atom!("parcelRequire")),
+    RequireMatcher::Keyword(atom!("parcelRequire")),
   ]
 }
 
@@ -109,6 +109,7 @@ fn match_parcel_default_initializer(decl: &VarDeclarator) -> Option<Id> {
 pub enum RequireMatcher {
   Id(Id),
   Global(Atom),
+  Keyword(Atom),
 }
 
 impl RequireMatcher {
@@ -118,6 +119,7 @@ impl RequireMatcher {
       RequireMatcher::Global(atom) => {
         ident.span.ctxt.outer() == unresolved_mark && ident.sym == *atom
       }
+      RequireMatcher::Keyword(atom) => ident.sym == *atom,
     }
   }
 }

--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -31,7 +31,7 @@ import {
             }
 
           other.js:
-            // this is here so that we don't scope hoist a.js
+            // this is here so that we don't scope hoist dependency/index.js
             import {exportedFunction} from './dependency';
             console.log(exportedFunction());
 

--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -1,0 +1,117 @@
+// @flow strict-local
+
+// $FlowFixMe
+import expect from 'expect';
+import path from 'path';
+import {
+  bundle,
+  describe,
+  fsFixture,
+  it,
+  overlayFS,
+} from '@atlaspack/test-utils';
+
+[false, true].forEach(value => {
+  const implementation = value ? 'rust' : 'js';
+  describe.v2(`inline requires - ${implementation}`, () => {
+    let options = {
+      defaultTargetOptions: {
+        shouldScopeHoist: true,
+        shouldOptimize: true,
+      },
+      mode: 'production',
+    };
+
+    it('inlines require statements', async () => {
+      await fsFixture(overlayFS, __dirname)`
+        inline-requires
+          dependency/index.js:
+            export function exportedFunction() {
+              throw new Error("Shouldn't be called");
+            }
+
+          other.js:
+            // this is here so that we don't scope hoist a.js
+            import {exportedFunction} from './dependency';
+            console.log(exportedFunction());
+
+          index.js:
+            import {exportedFunction} from './dependency';
+
+            import('./other');
+
+            setTimeout(() => {
+              exportedFunction();
+            }, 5000);
+
+          dependency/package.json:
+            {
+              "sideEffects": false
+            }
+
+          .parcelrc:
+            {
+              "extends": "@atlaspack/config-default",
+              "optimizers": {
+                "*.js": ["@atlaspack/optimizer-inline-requires"]
+              }
+            }
+    `;
+
+      const bundleGraph = await bundle(
+        path.join(__dirname, 'inline-requires/index.js'),
+        {
+          ...options,
+          inputFS: overlayFS,
+          config: path.join(__dirname, 'inline-requires/.parcelrc'),
+          featureFlags: {
+            fastOptimizeInlineRequires: value,
+          },
+        },
+      );
+      const bundles = bundleGraph.getBundles();
+      const mainBundle = bundles.find(b => b.name === 'index.js');
+      const otherBundle = bundles.find(b => b.name.includes('other'));
+      if (mainBundle == null) throw new Error('There was no JS bundle');
+      if (otherBundle == null) throw new Error('There was no JS bundle');
+      const bundleContents = overlayFS.readFileSync(
+        mainBundle.filePath,
+        'utf8',
+      );
+      const otherContentsRaw = overlayFS.readFileSync(
+        otherBundle.filePath,
+        'utf8',
+      );
+
+      const cleanRequires = (str: string) =>
+        str.replace(/parcelRequire\([^)]*\)/g, 'parcelRequire(...)');
+
+      const contents = cleanRequires(bundleContents);
+      const otherContents = cleanRequires(otherContentsRaw);
+
+      if (implementation === 'js') {
+        expect(otherContents).toContain(
+          `console.log((0, (0, parcelRequire(...)).exportedFunction)())`,
+        );
+        expect(contents).toContain(
+          `
+    setTimeout(()=>{
+        (0, (0, parcelRequire(...)).exportedFunction)();
+    }, 5000);
+      `.trim(),
+        );
+      } else {
+        expect(otherContents).toContain(
+          `console.log((0, parcelRequire(...).exportedFunction)())`,
+        );
+        expect(contents).toContain(
+          `
+    setTimeout(()=>{
+        (0, parcelRequire(...).exportedFunction)();
+    }, 5000);
+      `.trim(),
+        );
+      }
+    });
+  });
+});


### PR DESCRIPTION
The rust inline requires visitor wasn't doing anything on output bundles because the `parcelRequire = ...` symbol isn't always an unresolved global.
