### PR TITLE
Fix setRootConnections for large asset groups

### DIFF
--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -168,9 +168,11 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
         nodes.push(node);
       }
     } else if (assetGroups) {
-      nodes.push(
-        ...assetGroups.map(assetGroup => nodeFromAssetGroup(assetGroup)),
-      );
+      for (const assetGroup of assetGroups) {
+        // Adding nodes individually ensures we do not encounter a range stack size exceeded error
+        // when there are >100000 asset groups
+        nodes.push(nodeFromAssetGroup(assetGroup));
+      }
     }
     this.replaceNodeIdsConnectedTo(
       nullthrows(this.rootNodeId),


### PR DESCRIPTION
## Motivation

When building Confluence SSR with Atlaspack, `setRootConnections` fails with the following error:

> RangeError: Maximum call stack size exceeded

This is similar to the problem described [here](https://stackoverflow.com/questions/22123769/rangeerror-maximum-call-stack-size-exceeded-why) where we are adding too many nodes (117618) at once on the stack, which causes the failure.

## Changes

Use a for of loop

## Checklist

- [x] Existing or new tests cover this change
