### PR TITLE
Remove import extensions

### DIFF
--- a/packages/core/core/src/requests/ConfigRequest.js
+++ b/packages/core/core/src/requests/ConfigRequest.js
@@ -18,7 +18,7 @@ import type {LoadedPlugin} from '../AtlaspackConfig';
 import type {RequestResult, RunAPI} from '../RequestTracker';
 import type {ProjectPath} from '../projectPath';
 
-import {serializeRaw} from '../serializer.js';
+import {serializeRaw} from '../serializer';
 import {PluginLogger} from '@atlaspack/logger';
 import PluginOptions from '../public/PluginOptions';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@atlaspack/diagnostic';

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -24,7 +24,7 @@ import WorkerFarm from '@atlaspack/workers';
 
 import {Npm} from './Npm';
 import {Yarn} from './Yarn';
-import {Pnpm} from './Pnpm.js';
+import {Pnpm} from './Pnpm';
 import {getConflictingLocalDependencies} from './utils';
 import getCurrentPackageManager from './getCurrentPackageManager';
 import validateModuleSpecifier from './validateModuleSpecifier';

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -48,7 +48,7 @@ export {
 } from './config';
 export {DefaultMap, DefaultWeakMap} from './DefaultMap';
 export {makeDeferredWithPromise} from './Deferred';
-export {getProgressMessage} from './progress-message.js';
+export {getProgressMessage} from './progress-message';
 export {
   isGlob,
   isGlobMatch,

--- a/packages/dev/bundle-stats-cli/src/deep-imports.js
+++ b/packages/dev/bundle-stats-cli/src/deep-imports.js
@@ -1,6 +1,6 @@
 // @flow
 /* eslint-disable monorepo/no-internal-import */
-import typeof {loadGraphs} from '@atlaspack/query/src/index.js';
+import typeof {loadGraphs} from '@atlaspack/query/src/index';
 import typeof {getBundleStats} from '@atlaspack/reporter-bundle-stats/src/BundleStatsReporter';
 import typeof {PackagedBundle as PackagedBundleClass} from '@atlaspack/core/src/public/Bundle';
 

--- a/packages/dev/query/src/cli.js
+++ b/packages/dev/query/src/cli.js
@@ -14,13 +14,13 @@ import {serialize} from 'v8';
 // $FlowFixMe
 import {table} from 'table';
 
-import {loadGraphs} from './index.js';
+import {loadGraphs} from './index';
 
 const {
   BundleGraph: {bundleGraphEdgeTypes: bundleGraphEdgeTypes},
   Priority,
   fromProjectPathRelative,
-} = require('./deep-imports.js');
+} = require('./deep-imports');
 
 export async function run(input: string[]) {
   let args = input;

--- a/packages/dev/query/src/deep-imports.js
+++ b/packages/dev/query/src/deep-imports.js
@@ -1,43 +1,43 @@
 // @flow
 /* eslint-disable monorepo/no-internal-import */
-import typeof AssetGraph from '@atlaspack/core/src/AssetGraph.js';
+import typeof AssetGraph from '@atlaspack/core/src/AssetGraph';
 import typeof BundleGraph, {
   bundleGraphEdgeTypes,
-} from '@atlaspack/core/src/BundleGraph.js';
+} from '@atlaspack/core/src/BundleGraph';
 import typeof RequestTracker, {
   RequestGraph,
   readAndDeserializeRequestGraph,
-} from '@atlaspack/core/src/RequestTracker.js';
-import typeof {requestGraphEdgeTypes} from '@atlaspack/core/src/RequestTracker.js';
-import typeof {LMDBCache} from '@atlaspack/cache/src/LMDBCache.js';
-import typeof {Priority} from '@atlaspack/core/src/types.js';
-import typeof {fromProjectPathRelative} from '@atlaspack/core/src/projectPath.js';
+} from '@atlaspack/core/src/RequestTracker';
+import typeof {requestGraphEdgeTypes} from '@atlaspack/core/src/RequestTracker';
+import typeof {LMDBCache} from '@atlaspack/cache/src/LMDBCache';
+import typeof {Priority} from '@atlaspack/core/src/types';
+import typeof {fromProjectPathRelative} from '@atlaspack/core/src/projectPath';
 
 const v =
   process.env.ATLASPACK_BUILD_ENV === 'production'
     ? {
         // Split up require specifier to outsmart packages/dev/babel-register/babel-plugin-module-translate.js
         // $FlowFixMe(unsupported-syntax)
-        AssetGraph: require('@atlaspack/core' + '/lib/AssetGraph.js').default,
+        AssetGraph: require('@atlaspack/core' + '/lib/AssetGraph').default,
         // $FlowFixMe(unsupported-syntax)
-        BundleGraph: require('@atlaspack/core' + '/lib/BundleGraph.js'),
+        BundleGraph: require('@atlaspack/core' + '/lib/BundleGraph'),
         // $FlowFixMe(unsupported-syntax)
-        RequestTracker: require('@atlaspack/core' + '/lib/RequestTracker.js'),
+        RequestTracker: require('@atlaspack/core' + '/lib/RequestTracker'),
         // $FlowFixMe(unsupported-syntax)
-        LMDBCache: require('@atlaspack/cache' + '/lib/LMDBCache.js').LMDBCache,
+        LMDBCache: require('@atlaspack/cache' + '/lib/LMDBCache').LMDBCache,
         // $FlowFixMe(unsupported-syntax)
-        Priority: require('@atlaspack/core' + '/lib/types.js').Priority,
+        Priority: require('@atlaspack/core' + '/lib/types').Priority,
         // $FlowFixMe(unsupported-syntax)
-        fromProjectPathRelative: require('@atlaspack/core' +
-          '/lib/projectPath.js').fromProjectPathRelative,
+        fromProjectPathRelative: require('@atlaspack/core' + '/lib/projectPath')
+          .fromProjectPathRelative,
       }
     : {
-        AssetGraph: require('@atlaspack/core/src/AssetGraph.js').default,
-        BundleGraph: require('@atlaspack/core/src/BundleGraph.js'),
-        RequestTracker: require('@atlaspack/core/src/RequestTracker.js'),
-        LMDBCache: require('@atlaspack/cache/src/LMDBCache.js').LMDBCache,
-        Priority: require('@atlaspack/core/src/types.js').Priority,
-        fromProjectPathRelative: require('@atlaspack/core/src/projectPath.js')
+        AssetGraph: require('@atlaspack/core/src/AssetGraph').default,
+        BundleGraph: require('@atlaspack/core/src/BundleGraph'),
+        RequestTracker: require('@atlaspack/core/src/RequestTracker'),
+        LMDBCache: require('@atlaspack/cache/src/LMDBCache').LMDBCache,
+        Priority: require('@atlaspack/core/src/types').Priority,
+        fromProjectPathRelative: require('@atlaspack/core/src/projectPath')
           .fromProjectPathRelative,
       };
 

--- a/packages/dev/repl/SimplePackageInstaller/index.js
+++ b/packages/dev/repl/SimplePackageInstaller/index.js
@@ -6,7 +6,7 @@ import type {PackageInstaller, ModuleRequest} from '@atlaspack/package-manager';
 import fetch from 'isomorphic-fetch';
 import path from 'path';
 import semver from 'semver';
-import untar from './untar.js';
+import untar from './untar';
 
 async function findPackage(fs, dir) {
   while (dir !== '/' && path.basename(dir) !== 'node_modules') {

--- a/packages/dev/repl/src/atlaspack/AtlaspackWorker.js
+++ b/packages/dev/repl/src/atlaspack/AtlaspackWorker.js
@@ -20,8 +20,8 @@ import configRepl from '@atlaspack/config-repl';
 import {ExtendedMemoryFS} from './ExtendedMemoryFS';
 import {generatePackageJson, nthIndex} from '../utils/';
 import path from 'path';
-import {yarnInstall} from './yarn.js';
-import {BrowserPackageManager} from './BrowserPackageManager.js';
+import {yarnInstall} from './yarn';
+import {BrowserPackageManager} from './BrowserPackageManager';
 
 export type BundleOutputError = {|
   type: 'failure',

--- a/packages/dev/repl/src/components/helper.js
+++ b/packages/dev/repl/src/components/helper.js
@@ -2,7 +2,7 @@
 import type {BundleOutputError} from '../atlaspack/AtlaspackWorker';
 import {useCallback, useState, useEffect, useRef, memo} from 'react';
 import {ctrlKey} from '../utils';
-import renderGraph from '../graphs/index.js';
+import renderGraph from '../graphs/index';
 import {ASSET_PRESETS, extractZIP} from '../utils';
 import {type FSMap} from '../utils/assets';
 /* eslint-disable react/jsx-no-bind */

--- a/packages/runtimes/hmr/src/loaders/hmr-runtime.js
+++ b/packages/runtimes/hmr/src/loaders/hmr-runtime.js
@@ -5,7 +5,7 @@
 import type {
   HMRAsset,
   HMRMessage,
-} from '@atlaspack/reporter-dev-server/src/HMRServer.js';
+} from '@atlaspack/reporter-dev-server/src/HMRServer';
 interface ParcelRequire {
   (string): mixed;
   cache: {|[string]: ParcelModule|};


### PR DESCRIPTION
## Motivation

Some import sources hardcode the `.js` file extension as part of the path. This will not work when the source files are TypeScript, and thus have been removed in preparation for the [migration](https://github.com/atlassian-labs/atlaspack/pull/99).

## Changes

Remove `.js` extensions from import sources

## Checklist

- [x] Existing or new tests cover this change
