### PR TITLE
Skip toProjectRoot relative paths when already relative

### DIFF
--- a/packages/core/core/test/requests/ConfigRequest.test.js
+++ b/packages/core/core/test/requests/ConfigRequest.test.js
@@ -229,10 +229,7 @@ describe('ConfigRequest tests', () => {
       invalidateOnConfigKeyChange: [
         {
           configKey: 'key1',
-          filePath: toProjectPath(
-            projectRoot,
-            path.join('project_root', 'config.json'),
-          ),
+          filePath: toProjectPath(projectRoot, 'config.json'),
         },
       ],
     });


### PR DESCRIPTION
## Motivation

These changes are similar to https://github.com/atlassian-labs/atlaspack/pull/81 but instead uses code that has been applied in Confluence for a while. Specifically when the cwd and project root are different, paths within symbols and loc would be processed twice resulting in invalid paths.

## Changes

Skip `toProjectPath` handling when the path is already relative from Atlaspack's point of view

## Checklist

- [x] Existing or new tests cover this change
