### PR TITLE
Fix bad version for @babel/helper-plugin-utils

### DIFF
--- a/packages/utils/babel-plugin-transform-contextual-imports/package.json
+++ b/packages/utils/babel-plugin-transform-contextual-imports/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.2",
-    "@babel/helper-plugin-utils": "^7.22.10"
+    "@babel/helper-plugin-utils": "^7.12.2"
   },
   "devDependencies": {
     "@types/babel__core": "^7.10.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,10 +443,10 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz#dd7ee3735e8a313b9f7b05a773d892e88e6d7295"
   integrity sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==
 
-"@babel/helper-plugin-utils@^7.22.10":
-  version "7.24.8"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.24.8.tgz#94ee67e8ec0e5d44ea7baeb51e571bd26af07878"
-  integrity sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==
+"@babel/helper-plugin-utils@^7.12.2":
+  version "7.25.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.25.7.tgz#8ec5b21812d992e1ef88a9b068260537b6f0e36c"
+  integrity sha512-eaPZai0PiqCi09pPs3pAFfl/zYgGaE6IdXtYvmf0qlcDTd3WCtO7JWCcRd64e0EQrcYgiHibEZnOGsSY4QSgaw==
 
 "@babel/helper-remap-async-to-generator@^7.22.20":
   version "7.22.20"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

#97 caused a dependency issue when introduced into Jira, as the version for @babel/helper-plugin-utils was broken.

## Changes

This change pins @babel/helper-plugin-utils to the same version as core.

## Checklist

- [x] Existing or new tests cover this change
