### PR TITLE
Remove inline interfaces

### DIFF
--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -854,11 +854,15 @@ class Stat {
   }
 }
 
+interface DirEntry {
+  mode: number;
+}
+
 class Dirent {
   name: string;
   #mode: number;
 
-  constructor(name: string, entry: interface {mode: number}) {
+  constructor(name: string, entry: DirEntry) {
     this.name = name;
     this.#mode = entry.mode;
   }

--- a/packages/core/test-utils/src/fsFixture.js
+++ b/packages/core/test-utils/src/fsFixture.js
@@ -17,7 +17,7 @@ export function fsFixture(
 ): (
   strings: Array<string>,
   ...exprs: Array<
-    null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
+    null | string | number | boolean | {...} | $ReadOnlyArray<mixed>,
   >
 ) => Promise<void> {
   return async function apply(strings, ...exprs) {
@@ -415,7 +415,7 @@ export function escapeFixtureContent(content: string): string {
 export function dedentRaw(
   strings: Array<string>,
   ...exprs: Array<
-    null | string | number | boolean | interface {} | $ReadOnlyArray<mixed>,
+    null | string | number | boolean | {...} | $ReadOnlyArray<mixed>,
   >
 ): string {
   let src = '';

--- a/packages/core/utils/src/DefaultMap.js
+++ b/packages/core/utils/src/DefaultMap.js
@@ -22,9 +22,11 @@ export class DefaultMap<K, V> extends Map<K, V> {
   }
 }
 
+interface Key {}
+
 // Duplicated from DefaultMap implementation for Flow
 // Roughly mirrors https://github.com/facebook/flow/blob/2eb5a78d92c167117ba9caae070afd2b9f598599/lib/core.js#L617
-export class DefaultWeakMap<K: interface {}, V> extends WeakMap<K, V> {
+export class DefaultWeakMap<K: Key, V> extends WeakMap<K, V> {
   _getDefault: (K) => V;
 
   constructor(getDefault: (K) => V, entries?: Iterable<[K, V]>) {

--- a/packages/core/utils/src/dependency-location.js
+++ b/packages/core/utils/src/dependency-location.js
@@ -1,10 +1,10 @@
 // @flow
 
 export default function createDependencyLocation(
-  start: interface {
+  start: {|
     line: number,
     column: number,
-  },
+  |},
   specifier: string,
   lineOffset: number = 0,
   columnOffset: number = 0,


### PR DESCRIPTION
## Motivation

Inline flow interfaces are not supported by the TypeScript codemod, and thus have been modified to be compatible with it.

## Changes

* Extract out `DirEntry` and `Key` interface
* Inline `start` and `strings` types

## Checklist

- [x] Existing or new tests cover this change
