### PR TITLE
[V3] CSS improvements and fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,6 +479,7 @@ dependencies = [
  "atlaspack_filesystem",
  "lightningcss",
  "pretty_assertions",
+ "serde",
  "serde_json",
 ]
 
@@ -2398,6 +2399,7 @@ checksum = "53e225b3fa0a8bd5562c8833b1a32afa88761c4e661d3177b8cdc4e13cbf078e"
 dependencies = [
  "ahash 0.8.11",
  "bitflags 2.6.0",
+ "browserslist-rs",
  "const-str",
  "cssparser",
  "cssparser-color",

--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -253,7 +253,7 @@ impl Plugins for ConfigPlugins {
         "@atlaspack/transformer-posthtml" => continue,
         "@atlaspack/transformer-postcss" => continue,
         "@atlaspack/transformer-js" => Box::new(AtlaspackJsTransformerPlugin::new(&self.ctx)?),
-        "@atlaspack/transformer-css" => Box::new(AtlaspackCssTransformerPlugin::new(&self.ctx)),
+        "@atlaspack/transformer-css" => Box::new(AtlaspackCssTransformerPlugin::new(&self.ctx)?),
         "@atlaspack/transformer-inline-string" => {
           Box::new(AtlaspackInlineStringTransformerPlugin::new(&self.ctx))
         }

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -313,7 +313,7 @@ impl AssetGraphBuilder {
     }
 
     for (_id, dependency) in unique_deps.into_iter() {
-      // Find if this dependency points to a discovered_asset
+      // Check if this dependency points to a discovered_asset
       let discovered_asset = discovered_assets.iter().find(|discovered_asset| {
         discovered_asset
           .asset
@@ -322,7 +322,7 @@ impl AssetGraphBuilder {
           .is_some_and(|key| key == &dependency.specifier)
       });
 
-      // Check if the depden
+      // Check if this dependency points to the root asset
       let dep_to_root_asset = root_asset
         .0
         .unique_key

--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -8,7 +8,7 @@ use pathdiff::diff_paths;
 use petgraph::graph::NodeIndex;
 
 use atlaspack_core::asset_graph::{AssetGraph, DependencyNode, DependencyState};
-use atlaspack_core::types::{AssetWithDependencies, Dependency};
+use atlaspack_core::types::{Asset, AssetWithDependencies, Dependency};
 
 use crate::request_tracker::{Request, ResultAndInvalidations, RunRequestContext, RunRequestError};
 
@@ -240,12 +240,32 @@ impl AssetGraphBuilder {
       .asset_request_to_asset
       .insert(request_id, asset_node_index);
 
+    let root_asset = (&asset, asset_node_index);
     let mut added_discovered_assets: HashMap<String, NodeIndex> = HashMap::new();
+
+    // Attach the "direct" discovered assets to the graph
+    let direct_discovered_assets = get_direct_discovered_assets(&discovered_assets, &dependencies);
+    for discovered_asset in direct_discovered_assets {
+      let asset_node_index = self
+        .graph
+        .add_asset(incoming_dep_node_index, discovered_asset.asset.clone());
+
+      self.add_asset_dependencies(
+        &discovered_asset.dependencies,
+        &discovered_assets,
+        asset_node_index,
+        &mut added_discovered_assets,
+        root_asset,
+      );
+      self.propagate_requested_symbols(asset_node_index, incoming_dep_node_index);
+    }
+
     self.add_asset_dependencies(
-      dependencies,
+      &dependencies,
       &discovered_assets,
       asset_node_index,
       &mut added_discovered_assets,
+      root_asset,
     );
 
     self.propagate_requested_symbols(asset_node_index, incoming_dep_node_index);
@@ -262,15 +282,16 @@ impl AssetGraphBuilder {
 
   fn add_asset_dependencies(
     &mut self,
-    dependencies: Vec<Dependency>,
+    dependencies: &Vec<Dependency>,
     discovered_assets: &Vec<AssetWithDependencies>,
     asset_node_index: NodeIndex,
     added_discovered_assets: &mut HashMap<String, NodeIndex>,
+    root_asset: (&Asset, NodeIndex),
   ) {
     // Connect dependencies of the Asset
     let mut unique_deps: IndexMap<String, Dependency> = IndexMap::new();
 
-    for mut dependency in dependencies {
+    for dependency in dependencies {
       unique_deps
         .entry(dependency.id())
         .and_modify(|d| {
@@ -279,7 +300,7 @@ impl AssetGraphBuilder {
           // e.g. 'process'. I think ideally we wouldn't end up with two
           // dependencies post-transform but that needs further investigation to
           // resolve and understand...
-          d.meta.append(&mut dependency.meta);
+          d.meta.extend(dependency.meta.clone());
           if let Some(symbols) = d.symbols.as_mut() {
             if let Some(merge_symbols) = dependency.symbols.as_ref() {
               symbols.extend(merge_symbols.clone());
@@ -301,7 +322,18 @@ impl AssetGraphBuilder {
           .is_some_and(|key| key == &dependency.specifier)
       });
 
+      // Check if the depden
+      let dep_to_root_asset = root_asset
+        .0
+        .unique_key
+        .as_ref()
+        .is_some_and(|key| key == &dependency.specifier);
+
       let dep_node = self.graph.add_dependency(asset_node_index, dependency);
+
+      if dep_to_root_asset {
+        self.graph.add_edge(&dep_node, &root_asset.1);
+      }
 
       // If the dependency points to a dicovered asset then add the asset using the new
       // dep as it's parent
@@ -324,11 +356,13 @@ impl AssetGraphBuilder {
           added_discovered_assets.insert(asset.id.clone(), asset_node_index);
 
           self.add_asset_dependencies(
-            dependencies.clone(),
+            dependencies,
             discovered_assets,
             asset_node_index,
             added_discovered_assets,
+            root_asset,
           );
+          self.propagate_requested_symbols(asset_node_index, dep_node);
         }
       }
     }
@@ -403,6 +437,49 @@ impl AssetGraphBuilder {
     *work_count += 1;
     let _ = request_context.queue_request(request, sender.clone());
   }
+}
+
+/// Direct discovered assets are discovered assets that don't have any
+/// dependencies importing them. This means they need to be attached to the
+/// original asset directly otherwise they'll be left out of the graph entirely.
+///
+/// CSS module JS export files are a good example of this.
+fn get_direct_discovered_assets<'a>(
+  discovered_assets: &'a [AssetWithDependencies],
+  dependencies: &'a [Dependency],
+) -> Vec<&'a AssetWithDependencies> {
+  // Find all the discovered_asset unique keys
+  let discovered_asset_unique_keys: HashSet<String> = discovered_assets
+    .iter()
+    .filter_map(|discovered_asset| discovered_asset.asset.unique_key.clone())
+    .collect();
+
+  let all_dependencies = dependencies.iter().chain(
+    discovered_assets
+      .iter()
+      .flat_map(|discovered_asset| discovered_asset.dependencies.iter()),
+  );
+
+  // Find all the "indirect" discovered assets.
+  // Assets that are pointed to by one of the generated dependencies within the
+  // asset request
+  let mut indirect_discovered_assets = HashSet::new();
+  for dependency in all_dependencies {
+    if discovered_asset_unique_keys.contains(&dependency.specifier) {
+      indirect_discovered_assets.insert(dependency.specifier.clone());
+    }
+  }
+
+  discovered_assets
+    .iter()
+    .filter(|discovered_asset| {
+      !discovered_asset
+        .asset
+        .unique_key
+        .as_ref()
+        .is_some_and(|unique_key| indirect_discovered_assets.contains(unique_key))
+    })
+    .collect()
 }
 
 #[cfg(test)]

--- a/crates/atlaspack_core/src/asset_graph.rs
+++ b/crates/atlaspack_core/src/asset_graph.rs
@@ -263,7 +263,10 @@ impl AssetGraph {
           .edges_directed(dep_node, Direction::Outgoing)
           .next()
         {
-          self.propagate_requested_symbols(resolved.target(), dep_node, on_undeferred);
+          // Avoid infintite loops for self references
+          if resolved.target() != asset_node {
+            self.propagate_requested_symbols(resolved.target(), dep_node, on_undeferred);
+          }
         } else {
           on_undeferred(dep_node, Arc::clone(&dependency));
         }

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -330,10 +330,9 @@ impl Asset {
 
   pub fn new_discovered(
     source_asset: &Asset,
-    unique_key: String,
+    unique_key: Option<String>,
     file_type: FileType,
     code: String,
-    side_effects: bool,
   ) -> anyhow::Result<Self> {
     let asset_id = create_asset_id(CreateAssetIdParams {
       environment_id: &source_asset.env.id(),
@@ -344,7 +343,7 @@ impl Asset {
       code: Some(code.as_str()),
       pipeline: None,
       query: None,
-      unique_key: Some(&unique_key),
+      unique_key: unique_key.as_deref(),
       file_type: &file_type,
     });
 
@@ -352,8 +351,7 @@ impl Asset {
       code: Arc::new(Code::from(code)),
       file_type,
       id: asset_id,
-      side_effects,
-      unique_key: Some(unique_key),
+      unique_key,
       ..source_asset.clone()
     })
   }

--- a/crates/atlaspack_plugin_transformer_css/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_css/Cargo.toml
@@ -9,7 +9,8 @@ description = "CSS transformer plugin for the Atlaspack Bundler"
 anyhow = "1"
 atlaspack_core = { path = "../atlaspack_core" }
 atlaspack_filesystem = { path = "../atlaspack_filesystem" }
-lightningcss = "1.0.0-alpha.59"
+lightningcss = { version = "1.0.0-alpha.59", features = ["browserslist"] }
+serde = { version = "1.0.200", features = ["derive"] }
 serde_json = "1.0.116"
 
 [dev-dependencies]

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -35,11 +35,8 @@ struct PackageJson {
 
 impl AtlaspackCssTransformerPlugin {
   pub fn new(ctx: &PluginContext) -> Result<Self, Error> {
-    let config = ctx
-      .config
-      .load_package_json::<PackageJson>()
-      .map(|config| config.contents.config.unwrap_or_default())
-      .map_err(|err| {
+    let config = ctx.config.load_package_json::<PackageJson>().map_or_else(
+      |err| {
         let diagnostic = err.downcast_ref::<Diagnostic>();
 
         if diagnostic.is_some_and(|d| d.kind != ErrorKind::NotFound) {
@@ -47,9 +44,9 @@ impl AtlaspackCssTransformerPlugin {
         }
 
         Ok(CssTransformerConfig::default())
-      })
-      .ok()
-      .unwrap_or_default();
+      },
+      |config| Ok(config.contents.config.unwrap_or_default()),
+    )?;
 
     let css_modules_config = config
       .css_modules

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -469,15 +469,40 @@ mod tests {
 
     let result = run_plugin(&asset).unwrap();
 
+    assert_eq!(
+      result.asset,
+      Asset {
+        code: Arc::new(".EcQGha_root {\n  display: \"block\";\n}\n".into()),
+        unique_key: Some("css-module".into()),
+        symbols: Some(vec![
+          Symbol {
+            local: "default".into(),
+            exported: "default".into(),
+            loc: None,
+            is_weak: false,
+            is_esm_export: true,
+            self_referenced: false,
+          },
+          Symbol {
+            local: "EcQGha_root".into(),
+            exported: "root".into(),
+            loc: None,
+            is_weak: false,
+            is_esm_export: true,
+            self_referenced: false,
+          },
+        ]),
+        ..asset
+      }
+    );
     assert_eq!(result.discovered_assets.len(), 1);
     assert_eq!(
       result.discovered_assets[0],
       AssetWithDependencies {
         asset: Asset {
-          id: "41d174432961c58d".into(),
-          code: Arc::new(Code::from("module.exports[\"root\"] = `EcQGha_root`;\n")),
+          id: "88540641b9eed86d".into(),
+          code: Arc::new("module.exports[\"root\"] = `EcQGha_root`;\n".into()),
           file_path: "styles.module.css".into(),
-          unique_key: Some("css-module:module".into()),
           is_source: true,
           ..Default::default()
         },

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer_config.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer_config.rs
@@ -1,0 +1,21 @@
+use serde::Deserialize;
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CssModulesFullConfig {
+  pub global: Option<bool>,
+  pub dashed_idents: Option<bool>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum CssModulesConfig {
+  GlobalOnly(bool),
+  Full(CssModulesFullConfig),
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CssTransformerConfig {
+  pub css_modules: Option<CssModulesConfig>,
+}

--- a/crates/atlaspack_plugin_transformer_css/src/lib.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/lib.rs
@@ -1,3 +1,4 @@
 pub use css_transformer::AtlaspackCssTransformerPlugin;
 
 mod css_transformer;
+mod css_transformer_config;

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -58,11 +58,8 @@ struct PackageJson {
 
 impl AtlaspackJsTransformerPlugin {
   pub fn new(ctx: &PluginContext) -> Result<Self, Error> {
-    let config = ctx
-      .config
-      .load_package_json::<PackageJson>()
-      .map(|config| config.contents.config.unwrap_or_default())
-      .map_err(|err| {
+    let config = ctx.config.load_package_json::<PackageJson>().map_or_else(
+      |err| {
         let diagnostic = err.downcast_ref::<Diagnostic>();
 
         if diagnostic.is_some_and(|d| d.kind != ErrorKind::NotFound) {
@@ -70,9 +67,9 @@ impl AtlaspackJsTransformerPlugin {
         }
 
         Ok(JsTransformerConfig::default())
-      })
-      .ok()
-      .unwrap_or_default();
+      },
+      |config| Ok(config.contents.config.unwrap_or_default()),
+    )?;
 
     let ts_config = ctx
       .config

--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -524,16 +524,16 @@ describe('css modules', () => {
         },
       );
 
-      // assertBundles(b, [
-      //   {
-      //     name: 'index.js',
-      //     assets: ['index.js', 'index.css'],
-      //   },
-      //   {
-      //     name: 'index.css',
-      //     assets: ['index.css'],
-      //   },
-      // ]);
+      assertBundles(b, [
+        {
+          name: 'index.js',
+          assets: ['index.js', 'index.css'],
+        },
+        {
+          name: 'index.css',
+          assets: ['index.css'],
+        },
+      ]);
 
       let css = await outputFS.readFile(
         path.join(distDir, 'index.css'),

--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -14,7 +14,7 @@ import {
 } from '@atlaspack/test-utils';
 import postcss from 'postcss';
 
-describe.v2('css modules', () => {
+describe.only('css modules', () => {
   it('should support transforming css modules (require)', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-modules-cjs/index.js'),
@@ -206,7 +206,7 @@ describe.v2('css modules', () => {
     );
   });
 
-  it('should support css modules composes imports', async () => {
+  it.v2('should support css modules composes imports', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index.js'),
     );
@@ -249,7 +249,7 @@ describe.v2('css modules', () => {
     assert(css.includes(`.${cssClass2}`));
   });
 
-  it('should not include css twice for composes imports', async () => {
+  it.v2('should not include css twice for composes imports', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index.js'),
     );
@@ -263,7 +263,7 @@ describe.v2('css modules', () => {
     );
   });
 
-  it('should support composes imports for sass', async () => {
+  it.v2('should support composes imports for sass', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index2.js'),
     );
@@ -291,7 +291,7 @@ describe.v2('css modules', () => {
     assert(css.includes('height: 200px;'));
   });
 
-  it('should support composes imports with custom path names', async () => {
+  it.v2('should support composes imports with custom path names', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index3.js'),
     );
@@ -319,7 +319,7 @@ describe.v2('css modules', () => {
     assert(css.includes('height: 100px;'));
   });
 
-  it('should support deep nested composes imports', async () => {
+  it.v2('should support deep nested composes imports', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index4.js'),
     );
@@ -360,7 +360,7 @@ describe.v2('css modules', () => {
     assert(css.indexOf('_intermediate') < css.indexOf('_composes5'));
   });
 
-  it('should support composes imports for multiple selectors', async () => {
+  it.v2('should support composes imports for multiple selectors', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-composes/index5.js'),
     );
@@ -386,95 +386,107 @@ describe.v2('css modules', () => {
     assert(composes6Classes[2].endsWith('_test-2'));
   });
 
-  it('should throw an error when importing a missing class', async function () {
-    await assert.rejects(
-      () =>
-        bundle(
-          path.join(
-            __dirname,
-            '/integration/no-export-error-with-correct-filetype/src/App.jsx',
-          ),
-          {
-            shouldDisableCache: true,
-            defaultTargetOptions: {
-              shouldScopeHoist: true,
-            },
-          },
-        ),
-      {
-        name: 'BuildError',
-        diagnostics: [
-          {
-            codeFrames: [
-              {
-                filePath: path.join(
-                  __dirname,
-                  '/integration/no-export-error-with-correct-filetype/src/App.jsx',
-                ),
-                language: 'js',
-                codeHighlights: [
-                  {
-                    message: undefined,
-                    end: {
-                      column: 45,
-                      line: 7,
-                    },
-                    start: {
-                      column: 28,
-                      line: 7,
-                    },
-                  },
-                ],
+  it.v2(
+    'should throw an error when importing a missing class',
+    async function () {
+      await assert.rejects(
+        () =>
+          bundle(
+            path.join(
+              __dirname,
+              '/integration/no-export-error-with-correct-filetype/src/App.jsx',
+            ),
+            {
+              shouldDisableCache: true,
+              defaultTargetOptions: {
+                shouldScopeHoist: true,
               },
-            ],
-            message:
-              "integration/no-export-error-with-correct-filetype/src/app.module.css does not export 'notExisting'",
-            origin: '@atlaspack/core',
-          },
-        ],
-      },
-    );
-  });
+            },
+          ),
+        {
+          name: 'BuildError',
+          diagnostics: [
+            {
+              codeFrames: [
+                {
+                  filePath: path.join(
+                    __dirname,
+                    '/integration/no-export-error-with-correct-filetype/src/App.jsx',
+                  ),
+                  language: 'js',
+                  codeHighlights: [
+                    {
+                      message: undefined,
+                      end: {
+                        column: 45,
+                        line: 7,
+                      },
+                      start: {
+                        column: 28,
+                        line: 7,
+                      },
+                    },
+                  ],
+                },
+              ],
+              message:
+                "integration/no-export-error-with-correct-filetype/src/app.module.css does not export 'notExisting'",
+              origin: '@atlaspack/core',
+            },
+          ],
+        },
+      );
+    },
+  );
 
-  it('should fall back to postcss for legacy css modules', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/css-modules-legacy/index.js'),
-    );
+  it.v2(
+    'should fall back to postcss for legacy css modules',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/css-modules-legacy/index.js'),
+      );
 
-    assertBundles(b, [
-      {
-        name: 'index.js',
-        assets: ['index.js', 'index.module.css'],
-      },
-      {
-        name: 'index.css',
-        assets: ['index.module.css'],
-      },
-    ]);
+      assertBundles(b, [
+        {
+          name: 'index.js',
+          assets: ['index.js', 'index.module.css'],
+        },
+        {
+          name: 'index.css',
+          assets: ['index.module.css'],
+        },
+      ]);
 
-    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(css.includes('color: red'));
-  });
+      let css = await outputFS.readFile(
+        path.join(distDir, 'index.css'),
+        'utf8',
+      );
+      assert(css.includes('color: red'));
+    },
+  );
 
-  it('should fall back to postcss for legacy css modules with :export', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/css-modules-legacy/b.js'),
-    );
+  it.v2(
+    'should fall back to postcss for legacy css modules with :export',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/css-modules-legacy/b.js'),
+      );
 
-    assertBundles(b, [
-      {
-        name: 'b.js',
-        assets: ['b.js', 'b.module.css'],
-      },
-      {
-        name: 'b.css',
-        assets: ['b.module.css'],
-      },
-    ]);
+      assertBundles(b, [
+        {
+          name: 'b.js',
+          assets: ['b.js', 'b.module.css'],
+        },
+        {
+          name: 'b.css',
+          assets: ['b.module.css'],
+        },
+      ]);
 
-    let res = await run(b);
-    assert.deepEqual(res, {color: 'red'});
-  });
+      let res = await run(b);
+      assert.deepEqual(res, {color: 'red'});
+    },
+  );
 
   it('should optimize away unused @keyframes', async function () {
     let b = await bundle(
@@ -500,31 +512,41 @@ describe.v2('css modules', () => {
     assert(!css.includes('unused'));
   });
 
-  it('should not double optimize css modules processed with postcss', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/postcss-modules-optimize/index.js'),
-      {
-        mode: 'production',
-      },
-    );
+  // This test doesn't really make sense for v3 as postcss is completely
+  // disabled
+  it.v2(
+    'should not double optimize css modules processed with postcss',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/postcss-modules-optimize/index.js'),
+        {
+          mode: 'production',
+        },
+      );
 
-    assertBundles(b, [
-      {
-        name: 'index.js',
-        assets: ['index.js', 'index.css'],
-      },
-      {
-        name: 'index.css',
-        assets: ['index.css'],
-      },
-    ]);
+      // assertBundles(b, [
+      //   {
+      //     name: 'index.js',
+      //     assets: ['index.js', 'index.css'],
+      //   },
+      //   {
+      //     name: 'index.css',
+      //     assets: ['index.css'],
+      //   },
+      // ]);
 
-    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(css.includes('@keyframes test'));
-    assert(css.includes('@keyframes unused'));
-  });
+      let css = await outputFS.readFile(
+        path.join(distDir, 'index.css'),
+        'utf8',
+      );
+      assert(css.includes('@keyframes test'));
+      assert(css.includes('@keyframes unused'));
+    },
+  );
 
-  it('should compile css modules for multiple targets', async function () {
+  // Not sure why this one fails for v3 as yet, the graphs seems pretty close to
+  // identical
+  it.v2('should compile css modules for multiple targets', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/css-modules-targets/index.html'),
       {
@@ -552,7 +574,8 @@ describe.v2('css modules', () => {
     ]);
   });
 
-  it('should not fail with many css modules', async function () {
+  // Uses "composes"
+  it.v2('should not fail with many css modules', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/css-modules-bug/src/index.html'),
     );
@@ -680,22 +703,28 @@ describe.v2('css modules', () => {
     assert(contents.includes('.x'));
   });
 
-  it('should optimize away unused variables when dashedIdents option is used', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/css-modules-vars/index.js'),
-      {mode: 'production'},
-    );
-    let contents = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
-      'utf8',
-    );
-    assert.equal(
-      contents.split('\n')[0],
-      ':root{--wGsoEa_color:red;--wGsoEa_font:Helvetica;--wGsoEa_theme-sizes-1\\/12:2;--wGsoEa_from-js:purple}body{font:var(--wGsoEa_font)}._4fY2uG_foo{color:var(--wGsoEa_color);width:var(--wGsoEa_theme-sizes-1\\/12);height:var(--height)}',
-    );
-    let res = await run(b);
-    assert.deepEqual(res, ['_4fY2uG_foo', '--wGsoEa_from-js']);
-  });
+  // In v3, this results in JS worker issues where workers are called when they've
+  // already been shutdown. Not sure if this is surfacing an existing worker bug
+  // or if it's related to v3?
+  it.v2(
+    'should optimize away unused variables when dashedIdents option is used',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/css-modules-vars/index.js'),
+        {mode: 'production'},
+      );
+      let contents = await outputFS.readFile(
+        b.getBundles().find((b) => b.type === 'css').filePath,
+        'utf8',
+      );
+      assert.equal(
+        contents.split('\n')[0],
+        ':root{--wGsoEa_color:red;--wGsoEa_font:Helvetica;--wGsoEa_theme-sizes-1\\/12:2;--wGsoEa_from-js:purple}body{font:var(--wGsoEa_font)}._4fY2uG_foo{color:var(--wGsoEa_color);width:var(--wGsoEa_theme-sizes-1\\/12);height:var(--height)}',
+      );
+      let res = await run(b);
+      assert.deepEqual(res, ['_4fY2uG_foo', '--wGsoEa_from-js']);
+    },
+  );
 
   it('should group together css and css modules into one bundle', async function () {
     let b = await bundle(
@@ -715,29 +744,34 @@ describe.v2('css modules', () => {
     ]);
   });
 
-  it('should bundle css modules siblings together and their JS assets', async function () {
-    // This issue was first documented here
-    // https://github.com/parcel-bundler/parcel/issues/8716
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/css-modules-merging-siblings/index.html',
-      ),
-    );
-    let res = [];
-    await runBundle(
-      b,
-      b.getBundles().find((b) => b.name === 'index.html'),
-      {
-        sideEffect: (s) => res.push(s),
-      },
-    );
-    // Result is  [ 'mainJs', 'SX8vmq_container YpGmra_-expand' ]
-    assert.deepEqual(res[0][0], 'mainJs');
-    assert(res[0][1].includes('container') && res[0][1].includes('expand'));
-  });
+  // Uses "composes"
+  it.v2(
+    'should bundle css modules siblings together and their JS assets',
+    async function () {
+      // This issue was first documented here
+      // https://github.com/parcel-bundler/parcel/issues/8716
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/css-modules-merging-siblings/index.html',
+        ),
+      );
+      let res = [];
+      await runBundle(
+        b,
+        b.getBundles().find((b) => b.name === 'index.html'),
+        {
+          sideEffect: (s) => res.push(s),
+        },
+      );
+      // Result is  [ 'mainJs', 'SX8vmq_container YpGmra_-expand' ]
+      assert.deepEqual(res[0][0], 'mainJs');
+      assert(res[0][1].includes('container') && res[0][1].includes('expand'));
+    },
+  );
 
-  it('should duplicate css modules between targets', async function () {
+  // Breaks in v3 as it uses "composes"
+  it.v2('should duplicate css modules between targets', async function () {
     let b = await bundle([
       path.join(__dirname, '/integration/css-module-self-references/a'),
       path.join(__dirname, '/integration/css-module-self-references/b'),
@@ -779,8 +813,10 @@ describe.v2('css modules', () => {
     ]);
   });
 
-  it('should support the "include" and "exclude" options', async function () {
-    await fsFixture(overlayFS, __dirname)`
+  it.v2(
+    'should support the "include" and "exclude" options',
+    async function () {
+      await fsFixture(overlayFS, __dirname)`
       css-module-include
         a.css:
           .foo { color: red }
@@ -806,17 +842,21 @@ describe.v2('css modules', () => {
 
         yarn.lock:`;
 
-    let b = await bundle(path.join(__dirname, 'css-module-include/index.js'), {
-      mode: 'production',
-      inputFS: overlayFS,
-    });
+      let b = await bundle(
+        path.join(__dirname, 'css-module-include/index.js'),
+        {
+          mode: 'production',
+          inputFS: overlayFS,
+        },
+      );
 
-    let contents = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
-      'utf8',
-    );
-    assert(contents.includes('.foo'));
-    assert(contents.includes('.rp85ja_bar'));
-    assert(contents.includes('.baz'));
-  });
+      let contents = await outputFS.readFile(
+        b.getBundles().find((b) => b.type === 'css').filePath,
+        'utf8',
+      );
+      assert(contents.includes('.foo'));
+      assert(contents.includes('.rp85ja_bar'));
+      assert(contents.includes('.baz'));
+    },
+  );
 });

--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -14,7 +14,7 @@ import {
 } from '@atlaspack/test-utils';
 import postcss from 'postcss';
 
-describe.only('css modules', () => {
+describe('css modules', () => {
   it('should support transforming css modules (require)', async () => {
     let b = await bundle(
       path.join(__dirname, '/integration/postcss-modules-cjs/index.js'),

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -13,7 +13,7 @@ import {
   outputFS,
 } from '@atlaspack/test-utils';
 
-describe.v2('css', () => {
+describe('css', () => {
   afterEach(async () => {
     await removeDistDirectory();
   });
@@ -171,88 +171,105 @@ describe.v2('css', () => {
     assert(css.includes('.index'));
   });
 
-  it('should support linking to assets with url() from CSS', async function () {
-    let b = await bundle(path.join(__dirname, '/integration/css-url/index.js'));
+  it.v2(
+    'should support linking to assets with url() from CSS',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/css-url/index.js'),
+      );
 
-    assertBundles(b, [
-      {
-        name: 'index.js',
-        assets: ['index.js'],
-      },
-      {
-        name: 'index.css',
-        assets: ['index.css'],
-      },
-      {
-        type: 'woff2',
-        assets: ['test.woff2'],
-      },
-    ]);
-
-    let output = await run(b);
-    assert.equal(typeof output, 'function');
-    assert.equal(output(), 2);
-
-    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
-    assert(css.includes('url("http://google.com")'));
-    assert(css.includes('.index'));
-    assert(css.includes('url("data:image/gif;base64,quotes")'));
-    assert(css.includes('.quotes'));
-    assert(css.includes('url("data:image/gif;base64,no-quote")'));
-    assert(css.includes('.no-quote'));
-
-    assert(
-      await outputFS.exists(
-        path.join(distDir, css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]),
-      ),
-    );
-  });
-
-  it('should support linking to assets with url() from CSS in production', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/css-url/index.js'),
-      {
-        defaultTargetOptions: {
-          shouldOptimize: true,
+      assertBundles(b, [
+        {
+          name: 'index.js',
+          assets: ['index.js'],
         },
-      },
-    );
+        {
+          name: 'index.css',
+          assets: ['index.css'],
+        },
+        {
+          type: 'woff2',
+          assets: ['test.woff2'],
+        },
+      ]);
 
-    assertBundles(b, [
-      {
-        name: 'index.js',
-        assets: ['index.js'],
-      },
-      {
-        name: 'index.css',
-        assets: ['index.css'],
-      },
-      {
-        type: 'woff2',
-        assets: ['test.woff2'],
-      },
-    ]);
+      let output = await run(b);
+      assert.equal(typeof output, 'function');
+      assert.equal(output(), 2);
 
-    let output = await run(b);
-    assert.equal(typeof output, 'function');
-    assert.equal(output(), 2);
+      let css = await outputFS.readFile(
+        path.join(distDir, 'index.css'),
+        'utf8',
+      );
+      assert(/url\("test\.[0-9a-f]+\.woff2"\)/.test(css));
+      assert(css.includes('url("http://google.com")'));
+      assert(css.includes('.index'));
+      assert(css.includes('url("data:image/gif;base64,quotes")'));
+      assert(css.includes('.quotes'));
+      assert(css.includes('url("data:image/gif;base64,no-quote")'));
+      assert(css.includes('.no-quote'));
 
-    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(/url\(test\.[0-9a-f]+\.woff2\)/.test(css), 'woff ext found in css');
-    assert(css.includes('url(http://google.com)'), 'url() found');
-    assert(css.includes('.index'), '.index found');
-    assert(/url\("?data:image\/gif;base64,quotes"?\)/.test(css));
-    assert(css.includes('.quotes'));
-    assert(/url\("?data:image\/gif;base64,no-quote"?\)/.test(css));
-    assert(css.includes('.no-quote'));
+      assert(
+        await outputFS.exists(
+          path.join(distDir, css.match(/url\("(test\.[0-9a-f]+\.woff2)"\)/)[1]),
+        ),
+      );
+    },
+  );
 
-    assert(
-      await outputFS.exists(
-        path.join(distDir, css.match(/url\((test\.[0-9a-f]+\.woff2)\)/)[1]),
-      ),
-    );
-  });
+  it.v2(
+    'should support linking to assets with url() from CSS in production',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/css-url/index.js'),
+        {
+          defaultTargetOptions: {
+            shouldOptimize: true,
+          },
+        },
+      );
+
+      assertBundles(b, [
+        {
+          name: 'index.js',
+          assets: ['index.js'],
+        },
+        {
+          name: 'index.css',
+          assets: ['index.css'],
+        },
+        {
+          type: 'woff2',
+          assets: ['test.woff2'],
+        },
+      ]);
+
+      let output = await run(b);
+      assert.equal(typeof output, 'function');
+      assert.equal(output(), 2);
+
+      let css = await outputFS.readFile(
+        path.join(distDir, 'index.css'),
+        'utf8',
+      );
+      assert(
+        /url\(test\.[0-9a-f]+\.woff2\)/.test(css),
+        'woff ext found in css',
+      );
+      assert(css.includes('url(http://google.com)'), 'url() found');
+      assert(css.includes('.index'), '.index found');
+      assert(/url\("?data:image\/gif;base64,quotes"?\)/.test(css));
+      assert(css.includes('.quotes'));
+      assert(/url\("?data:image\/gif;base64,no-quote"?\)/.test(css));
+      assert(css.includes('.no-quote'));
+
+      assert(
+        await outputFS.exists(
+          path.join(distDir, css.match(/url\((test\.[0-9a-f]+\.woff2)\)/)[1]),
+        ),
+      );
+    },
+  );
 
   it('should support linking to assets in parent folders with url() from CSS', async function () {
     let b = await bundle(
@@ -326,56 +343,59 @@ describe.v2('css', () => {
     assert(css.includes('url("#default#VML")'));
   });
 
-  it('should throw a diagnostic for relative url() dependencies in custom properties', async function () {
-    let fixture = path.join(
-      __dirname,
-      'integration/css-url-custom-property/index.css',
-    );
-    let code = await inputFS.readFileSync(fixture, 'utf8');
-    // $FlowFixMe
-    await assert.rejects(
-      () =>
-        bundle(fixture, {
-          defaultTargetOptions: {
-            shouldOptimize: true,
-          },
-        }),
-      {
-        name: 'BuildError',
-        diagnostics: [
-          {
-            message:
-              "Ambiguous url('foo.png') in custom property. Relative paths are resolved from the location the var() is used, not where the custom property is defined. Use an absolute URL instead",
-            origin: '@atlaspack/transformer-css',
-            name: 'SyntaxError',
-            stack: undefined,
-            codeFrames: [
-              {
-                filePath: fixture,
-                code,
-                codeHighlights: [
-                  {
-                    start: {
-                      line: 2,
-                      column: 11,
+  it.v2(
+    'should throw a diagnostic for relative url() dependencies in custom properties',
+    async function () {
+      let fixture = path.join(
+        __dirname,
+        'integration/css-url-custom-property/index.css',
+      );
+      let code = await inputFS.readFileSync(fixture, 'utf8');
+      // $FlowFixMe
+      await assert.rejects(
+        () =>
+          bundle(fixture, {
+            defaultTargetOptions: {
+              shouldOptimize: true,
+            },
+          }),
+        {
+          name: 'BuildError',
+          diagnostics: [
+            {
+              message:
+                "Ambiguous url('foo.png') in custom property. Relative paths are resolved from the location the var() is used, not where the custom property is defined. Use an absolute URL instead",
+              origin: '@atlaspack/transformer-css',
+              name: 'SyntaxError',
+              stack: undefined,
+              codeFrames: [
+                {
+                  filePath: fixture,
+                  code,
+                  codeHighlights: [
+                    {
+                      start: {
+                        line: 2,
+                        column: 11,
+                      },
+                      end: {
+                        line: 2,
+                        column: 11,
+                      },
                     },
-                    end: {
-                      line: 2,
-                      column: 11,
-                    },
-                  },
-                ],
-              },
-            ],
-            hints: [
-              'Replace with: url(/integration/css-url-custom-property/foo.png)',
-            ],
-            documentationURL: 'https://parceljs.org/languages/css/#url()',
-          },
-        ],
-      },
-    );
-  });
+                  ],
+                },
+              ],
+              hints: [
+                'Replace with: url(/integration/css-url-custom-property/foo.png)',
+              ],
+              documentationURL: 'https://parceljs.org/languages/css/#url()',
+            },
+          ],
+        },
+      );
+    },
+  );
 
   it('should minify CSS when minify is set', async function () {
     let b = await bundle(
@@ -399,30 +419,37 @@ describe.v2('css', () => {
     assert.equal(css.split('\n').length, 1);
   });
 
-  it('should produce a sourcemap when sourceMaps are used', async function () {
-    await bundle(path.join(__dirname, '/integration/cssnano/index.js'), {
-      defaultTargetOptions: {
-        shouldOptimize: true,
-      },
-    });
+  it.v2(
+    'should produce a sourcemap when sourceMaps are used',
+    async function () {
+      await bundle(path.join(__dirname, '/integration/cssnano/index.js'), {
+        defaultTargetOptions: {
+          shouldOptimize: true,
+        },
+      });
 
-    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
-    assert(css.includes('.local'));
-    assert(css.includes('.index'));
+      let css = await outputFS.readFile(
+        path.join(distDir, 'index.css'),
+        'utf8',
+      );
+      assert(css.includes('.local'));
+      assert(css.includes('.index'));
 
-    let lines = css.trim().split('\n');
-    assert.equal(lines.length, 2);
-    assert.equal(lines[1], '/*# sourceMappingURL=index.css.map */');
+      let lines = css.trim().split('\n');
+      assert.equal(lines.length, 2);
+      assert.equal(lines[1], '/*# sourceMappingURL=index.css.map */');
 
-    let map = JSON.parse(
-      await outputFS.readFile(path.join(distDir, 'index.css.map'), 'utf8'),
-    );
-    assert.equal(map.file, 'index.css.map');
-    assert(map.sources.includes('integration/cssnano/local.css'));
-    assert(map.sources.includes('integration/cssnano/index.css'));
-  });
+      let map = JSON.parse(
+        await outputFS.readFile(path.join(distDir, 'index.css.map'), 'utf8'),
+      );
+      assert.equal(map.file, 'index.css.map');
+      assert(map.sources.includes('integration/cssnano/local.css'));
+      assert(map.sources.includes('integration/cssnano/index.css'));
+    },
+  );
 
-  it('should inline data-urls for text-encoded files', async () => {
+  // This breaks in v3 as it uses asset.addURLDependency inside the SVG transformer
+  it.v2('should inline data-urls for text-encoded files', async () => {
     await bundle(path.join(__dirname, '/integration/data-url/text.css'), {
       defaultTargetOptions: {
         sourceMaps: false,
@@ -446,55 +473,58 @@ describe.v2('css', () => {
     );
   });
 
-  it('should remap locations in diagnostics using the input source map', async () => {
-    let fixture = path.join(
-      __dirname,
-      'integration/diagnostic-sourcemap/index.scss',
-    );
-    let code = await inputFS.readFileSync(fixture, 'utf8');
-    // $FlowFixMe
-    await assert.rejects(
-      () =>
-        bundle(fixture, {
-          defaultTargetOptions: {
-            shouldOptimize: true,
-          },
-        }),
-      {
-        name: 'BuildError',
-        diagnostics: [
-          {
-            message: "Failed to resolve 'x.png' from './index.scss'",
-            origin: '@atlaspack/core',
-            codeFrames: [
-              {
-                filePath: fixture,
-                code,
-                codeHighlights: [
-                  {
-                    message: undefined,
-                    start: {
-                      line: 5,
-                      column: 3,
+  it.v2(
+    'should remap locations in diagnostics using the input source map',
+    async () => {
+      let fixture = path.join(
+        __dirname,
+        'integration/diagnostic-sourcemap/index.scss',
+      );
+      let code = await inputFS.readFileSync(fixture, 'utf8');
+      // $FlowFixMe
+      await assert.rejects(
+        () =>
+          bundle(fixture, {
+            defaultTargetOptions: {
+              shouldOptimize: true,
+            },
+          }),
+        {
+          name: 'BuildError',
+          diagnostics: [
+            {
+              message: "Failed to resolve 'x.png' from './index.scss'",
+              origin: '@atlaspack/core',
+              codeFrames: [
+                {
+                  filePath: fixture,
+                  code,
+                  codeHighlights: [
+                    {
+                      message: undefined,
+                      start: {
+                        line: 5,
+                        column: 3,
+                      },
+                      end: {
+                        line: 5,
+                        column: 3,
+                      },
                     },
-                    end: {
-                      line: 5,
-                      column: 3,
-                    },
-                  },
-                ],
-              },
-            ],
-          },
-          {
-            message: "Cannot load file './x.png' in './'.",
-            origin: '@atlaspack/resolver-default',
-            hints: [],
-          },
-        ],
-      },
-    );
-  });
+                  ],
+                },
+              ],
+            },
+            {
+              message: "Cannot load file './x.png' in './'.",
+              origin: '@atlaspack/resolver-default',
+              hints: [],
+            },
+          ],
+        },
+      );
+    },
+  );
 
   it('should support importing CSS from node_modules with the npm: scheme', async () => {
     let b = await bundle(
@@ -546,7 +576,9 @@ describe.v2('css', () => {
     );
   });
 
-  it('should support css nesting with lightningcss', async function () {
+  // This seems to broken due to the browser/target not being passed corrctly
+  // and the nesting doesn't get compiled out
+  it.v2('should support css nesting with lightningcss', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/css-nesting/a.css'),
       {


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR improves the CSS transformer and makes changes to the asset graph request to support CSS modules. Most CSS features are now supported except for the following: 
- [CSS module composes](https://github.com/css-modules/css-modules/blob/master/docs/composition.md) which can be added later if needed.
- Config options
  - exclude/include globs
  - [custom-naming-patterns](https://parceljs.org/languages/css/#custom-naming-patterns)
  - [custom-media-queries](https://parceljs.org/languages/css/#custom-media-queries)
  - [pseudo-class-replacement](https://parceljs.org/languages/css/#pseudo-class-replacement)

None of which are currently used in AFM. 

## Changes

- Support CSS transformer config loading
  - Global CSS modules
  - Dashed idents
- Consistent CSS module detection against v2
- Browserslist support for lightning transpilation
- Symbol/Dependency fixes for CSS modules
- Fixed attaching "direct" discovered assets
  - "direct" referring to the fact that they are not pointed to by any generated dependencies and therefore need to be attached to the root dependency directly
- Fixed an infinite loop in the asset graph request when self referencing dependencies are added
- Enable a bunch of tests in the css and css-module integration suites


## Checklist

- [x] Existing or new tests cover this change
