### PR TITLE
Fix worker paths and add missing filename

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "check": "flow check",
     "lint": "eslint . && prettier \"./packages/*/*/{src,bin,test}/**/*.{js,json,md}\" --list-different && cargo fmt --all -- --check",
     "prepublishOnly": "yarn adjust-versions && yarn build && yarn build-ts",
-    "test:unit": "cross-env NODE_ENV=test mocha --timeout 5000 && cargo test",
+    "test:unit": "cross-env NODE_ENV=test mocha --conditions=development --timeout 5000 && cargo test",
     "test:integration": "yarn workspace @atlaspack/integration-tests test",
     "test:integration-ci": "yarn workspace @atlaspack/integration-tests test-ci",
     "test": "yarn test:unit && yarn test:integration",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -54,6 +54,13 @@
     "graphviz": "^0.0.9",
     "tempy": "^0.2.1"
   },
+  "exports": {
+    ".": "./lib/index.js",
+    "./worker": {
+      "development": "./src/worker.js",
+      "default": "./lib/worker.js"
+    }
+  },
   "browser": {
     "./src/serializerCore.js": "./src/serializerCore.browser.js"
   }

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -647,7 +647,7 @@ export function createWorkerFarm(
     ...options,
     // $FlowFixMe
     workerPath: process.browser
-      ? '@atlaspack/core/src/worker.js'
+      ? '@atlaspack/core/worker'
       : require.resolve('./worker'),
   });
 }

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -15,7 +15,7 @@ import {toProjectPath} from '../src/projectPath';
 import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
 
 const options = DEFAULT_OPTIONS;
-const farm = new WorkerFarm({workerPath: require.resolve('../src/worker.js')});
+const farm = new WorkerFarm({workerPath: require.resolve('../src/worker')});
 
 describe('RequestTracker', () => {
   it('should not run requests that have not been invalidated', async () => {

--- a/packages/core/core/test/requests/ConfigRequest.test.js
+++ b/packages/core/core/test/requests/ConfigRequest.test.js
@@ -21,7 +21,7 @@ const mockCast = (f: any): any => f;
 describe('ConfigRequest tests', () => {
   const projectRoot = 'project_root';
   const farm = new WorkerFarm({
-    workerPath: require.resolve('../../src/worker.js'),
+    workerPath: require.resolve('../../src/worker'),
     maxConcurrentWorkers: 1,
   });
   let fs = new MemoryFS(farm);

--- a/packages/core/fs/test/OverlayFS.test.js
+++ b/packages/core/fs/test/OverlayFS.test.js
@@ -15,7 +15,7 @@ describe('OverlayFS', () => {
 
   beforeEach(() => {
     workerFarm = new WorkerFarm({
-      workerPath: require.resolve('@atlaspack/core/src/worker.js'),
+      workerPath: require.resolve('@atlaspack/core/worker'),
     });
     underlayFS = new MemoryFS(workerFarm);
     fs = new OverlayFS(workerFarm, underlayFS);

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/atlassian-labs/atlaspack.git"
   },
   "scripts": {
-    "test": "cross-env NODE_ENV=test ATLASPACK_BUILD_ENV=test mocha --experimental-vm-modules",
+    "test": "cross-env NODE_ENV=test ATLASPACK_BUILD_ENV=test mocha --conditions=development --experimental-vm-modules",
     "test-ci": "yarn test --config .mocharc.ci.json"
   },
   "devDependencies": {

--- a/packages/core/package-manager/test/NodePackageManager.test.js
+++ b/packages/core/package-manager/test/NodePackageManager.test.js
@@ -49,7 +49,7 @@ describe('NodePackageManager', function () {
 
   beforeEach(() => {
     workerFarm = new WorkerFarm({
-      workerPath: require.resolve('@atlaspack/core/src/worker.js'),
+      workerPath: require.resolve('@atlaspack/core/worker'),
     });
     fs = new OverlayFS(new MemoryFS(workerFarm), new NodeFS());
     packageInstaller = new MockPackageInstaller();

--- a/packages/core/test-utils/test/fsFixture.test.js
+++ b/packages/core/test-utils/test/fsFixture.test.js
@@ -496,7 +496,7 @@ describe('fsFixture', () => {
 
   beforeEach(() => {
     workerFarm = new WorkerFarm({
-      workerPath: require.resolve('@atlaspack/core/src/worker.js'),
+      workerPath: require.resolve('@atlaspack/core/worker'),
     });
     fs = new MemoryFS(workerFarm);
   });
@@ -608,7 +608,7 @@ describe('toFixture', () => {
 
   beforeEach(() => {
     workerFarm = new WorkerFarm({
-      workerPath: require.resolve('@atlaspack/core/src/worker.js'),
+      workerPath: require.resolve('@atlaspack/core/worker'),
     });
     fs = new MemoryFS(workerFarm);
   });

--- a/packages/core/workers/src/WorkerFarm.js
+++ b/packages/core/workers/src/WorkerFarm.js
@@ -105,7 +105,7 @@ export default class WorkerFarm extends EventEmitter {
 
     // $FlowFixMe
     if (process.browser) {
-      if (this.options.workerPath === '@atlaspack/core/src/worker.js') {
+      if (this.options.workerPath === '@atlaspack/core/worker') {
         this.localWorker = coreWorker;
       } else {
         throw new Error(
@@ -357,7 +357,7 @@ export default class WorkerFarm extends EventEmitter {
     } else if (location) {
       // $FlowFixMe
       if (process.browser) {
-        if (location === '@atlaspack/workers/src/bus.js') {
+        if (location === '@atlaspack/workers/bus') {
           mod = (bus: any);
         } else {
           throw new Error('No dynamic require possible: ' + location);

--- a/packages/core/workers/src/bus.js
+++ b/packages/core/workers/src/bus.js
@@ -8,9 +8,7 @@ class Bus extends EventEmitter {
       child.workerApi.callMaster(
         {
           // $FlowFixMe
-          location: process.browser
-            ? '@atlaspack/workers/src/bus.js'
-            : __filename,
+          location: process.browser ? '@atlaspack/workers/bus' : __filename,
           method: 'emit',
           args: [event, ...args],
         },

--- a/packages/core/workers/src/child.js
+++ b/packages/core/workers/src/child.js
@@ -103,7 +103,7 @@ export class Child {
   async childInit(module: string, childId: number): Promise<void> {
     // $FlowFixMe
     if (process.browser) {
-      if (module === '@atlaspack/core/src/worker.js') {
+      if (module === '@atlaspack/core/worker') {
         this.module = coreWorker;
       } else {
         throw new Error('No dynamic require possible: ' + module);

--- a/packages/core/workers/src/core-worker.browser.js
+++ b/packages/core/workers/src/core-worker.browser.js
@@ -1,3 +1,4 @@
 // @flow
-// eslint-disable-next-line monorepo/no-internal-import
-module.exports = require('@atlaspack/core/src/worker.js');
+
+// $FlowFixMe
+module.exports = require('@atlaspack/core/worker');

--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -8,10 +8,9 @@ import type {
   WorkerMessage,
 } from '../types';
 import childProcess, {type ChildProcess} from 'child_process';
-import path from 'path';
 import {serialize, deserialize} from '@atlaspack/core';
 
-const WORKER_PATH = path.join(__dirname, 'ProcessChild.js');
+const WORKER_PATH = require.resolve('./ProcessChild');
 
 export default class ProcessWorker implements WorkerImpl {
   execArgv: Object;

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -8,13 +8,12 @@ import type {
   WorkerMessage,
 } from '../types';
 import {Worker} from 'worker_threads';
-import path from 'path';
 import {
   prepareForSerialization,
   restoreDeserializedObject,
 } from '@atlaspack/core';
 
-const WORKER_PATH = path.join(__dirname, 'ThreadsChild.js');
+const WORKER_PATH = require.resolve('./ThreadsChild');
 
 export default class ThreadsWorker implements WorkerImpl {
   execArgv: Object;

--- a/packages/dev/eslint-plugin/test/utils.test.js
+++ b/packages/dev/eslint-plugin/test/utils.test.js
@@ -16,11 +16,15 @@ const pkgPath = pkgInfo.path;
 const pkgName = pkgInfo.pkg.name;
 
 describe('utils', () => {
+  let opts = {
+    babelOptions: {filename: 'test.js'},
+  };
+
   describe('isRequire', () => {
     it('identifies requires', () => {
       assert.equal(
         isStaticRequire(
-          getFirstExpression(parse("require('@atlaspack/core')")),
+          getFirstExpression(parse("require('@atlaspack/core')"), opts),
         ),
         true,
       );
@@ -28,7 +32,7 @@ describe('utils', () => {
 
     it("doesn't handle dynamic requires", () => {
       assert.equal(
-        isStaticRequire(getFirstExpression(parse('require(dynamic)'))),
+        isStaticRequire(getFirstExpression(parse('require(dynamic)'), opts)),
         false,
       );
     });
@@ -38,7 +42,7 @@ describe('utils', () => {
     it('identifies built-in require.resolve', () => {
       assert.equal(
         isStaticResolve(
-          getFirstExpression(parse("require.resolve('@atlaspack/core')")),
+          getFirstExpression(parse("require.resolve('@atlaspack/core')"), opts),
         ),
         true,
       );


### PR DESCRIPTION
## Motivation

When migrating to TypeScript, all of the worker paths break due to the change in extension. Additionally, the babel dependency in the eslint plugin changes slightly and requires a filename in the tests.

## Changes

* Resolve worker paths without an extension
* Use a public export name for the worker paths using the development condition
* Add filename to eslint parser

## Checklist

- [x] Existing or new tests cover this change
