### PR TITLE
Annotate adjacency list types

### DIFF
--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -117,10 +117,10 @@ const MAX_LINK_TRIES: 3 = 3;
  *
  */
 export default class AdjacencyList<TEdgeType: number = 1> {
-  #nodes /*: NodeTypeMap<TEdgeType | NullEdgeType> */;
-  #edges /*: EdgeTypeMap<TEdgeType | NullEdgeType> */;
+  #nodes: NodeTypeMap<TEdgeType | NullEdgeType>;
+  #edges: EdgeTypeMap<TEdgeType | NullEdgeType>;
 
-  #params /*: AdjacencyListParams */;
+  #params: AdjacencyListParams;
 
   /**
    * Create a new `AdjacencyList` in one of two ways:


### PR DESCRIPTION
## Motivation

The `AdjacencyList` class uses unnecessary doc types that aren't understood by the TypeScript codemod, so they have been removed in favour of listing the actual types.

## Changes

Correctly annotate nodes, edges, and params types in the adjacency list
 
## Checklist

- [x] Existing or new tests cover this change
