### PR TITLE
[V3] Return absolute file path for global resolve values

### DIFF
--- a/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
+++ b/crates/atlaspack_plugin_resolver/src/atlaspack_resolver.rs
@@ -374,7 +374,7 @@ impl ResolverPlugin for AtlaspackResolver {
         invalidations: Vec::new(),
         resolution: Resolution::Resolved(ResolvedResolution {
           code: Some(format!("module.exports={};", global)),
-          file_path: format!("{}.js", global).into(),
+          file_path: self.options.project_root.join(format!("{}.js", global)),
           query,
           side_effects,
           ..ResolvedResolution::default()


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

When global variables are returned from the resolver we create a virtual file for them to resolve to. This file path should be absolute otherwise the path_request will blow up. This behaviour is consistent with v2. 

## Checklist

- [ ] Existing or new tests cover this change
