### PR TITLE
[V3] Fix broken/missing transformer plugin behaviours

### DIFF
--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/mod.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/mod.rs
@@ -7,6 +7,7 @@ mod nodejs_rpc_reporter;
 mod nodejs_rpc_resolver;
 mod nodejs_rpc_runtime;
 mod nodejs_rpc_transformer;
+mod plugin_options;
 
 pub use self::nodejs_rpc_bundler::*;
 pub use self::nodejs_rpc_compressor::*;

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
@@ -24,6 +24,7 @@ use atlaspack_core::types::*;
 use super::super::rpc::nodejs_rpc_worker_farm::NodeJsWorkerCollection;
 use super::super::rpc::LoadPluginKind;
 use super::super::rpc::LoadPluginOptions;
+use super::plugin_options::RpcPluginOptions;
 
 pub struct NodejsRpcTransformerPlugin {
   rpc_workers: Arc<NodeJsWorkerCollection>,
@@ -31,7 +32,6 @@ pub struct NodejsRpcTransformerPlugin {
   plugin_options: RpcPluginOptions,
   resolve_from: PathBuf,
   specifier: String,
-  project_root: PathBuf,
   started: OnceCell<Vec<()>>,
 }
 
@@ -58,7 +58,6 @@ impl NodejsRpcTransformerPlugin {
       plugin_options,
       specifier: plugin.package_name.clone(),
       resolve_from: (&*plugin.resolve_from).to_path_buf(),
-      project_root: (&*ctx.options.project_root).to_path_buf(),
       started: OnceCell::new(),
     })
   }
@@ -133,21 +132,6 @@ impl TransformerPlugin for NodejsRpcTransformerPlugin {
   }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcHmrOptions {
-  pub port: Option<u16>,
-  pub host: Option<String>,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct RpcPluginOptions {
-  pub hmr_options: Option<RpcHmrOptions>,
-  pub project_root: PathBuf,
-  pub mode: BuildMode,
-}
-
 /// This Asset mostly replicates the core Asset type however it only features
 /// fields that can be modified by transformers
 #[derive(PartialEq, Clone, Debug, Deserialize, Serialize)]
@@ -192,7 +176,6 @@ pub struct RpcTransformerOpts {
   pub key: String,
   pub options: RpcPluginOptions,
   pub env: Arc<Environment>,
-  pub project_root: PathBuf,
   pub asset: Asset,
 }
 

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
@@ -50,6 +50,7 @@ impl NodejsRpcTransformerPlugin {
     let plugin_options = RpcPluginOptions {
       hmr_options: None,
       project_root: ctx.options.project_root.clone(),
+      mode: ctx.options.mode.clone(),
     };
     Ok(Self {
       rpc_workers,
@@ -93,7 +94,6 @@ impl TransformerPlugin for NodejsRpcTransformerPlugin {
       // TODO: Pass this just once to each worker
       options: self.plugin_options.clone(),
       env: asset_env.clone(),
-      project_root: self.project_root.clone(),
       asset,
     };
 
@@ -145,6 +145,7 @@ pub struct RpcHmrOptions {
 pub struct RpcPluginOptions {
   pub hmr_options: Option<RpcHmrOptions>,
   pub project_root: PathBuf,
+  pub mode: BuildMode,
 }
 
 /// This Asset mostly replicates the core Asset type however it only features

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/plugin_options.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/plugin_options.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+use atlaspack_core::types::BuildMode;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcHmrOptions {
+  pub port: Option<u16>,
+  pub host: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RpcPluginOptions {
+  pub hmr_options: Option<RpcHmrOptions>,
+  pub project_root: PathBuf,
+  pub mode: BuildMode,
+}

--- a/packages/core/core/src/atlaspack-v3/worker/compat/mutable-asset.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/mutable-asset.js
@@ -43,6 +43,7 @@ export class MutableAsset implements IMutableAsset {
   #inner: InnerAsset;
   #ast: ?AST;
   #contents: Buffer;
+  #astDirty: boolean;
 
   get astGenerator(): ?ASTGenerator {
     throw new Error('get MutableAsset.astGenerator');
@@ -74,6 +75,7 @@ export class MutableAsset implements IMutableAsset {
     this.#contents = Buffer.from(asset.code);
     this.fs = fs;
     this.env = env;
+    this.#astDirty = false;
   }
 
   // eslint-disable-next-line require-await
@@ -82,11 +84,12 @@ export class MutableAsset implements IMutableAsset {
   }
 
   setAST(ast: AST): void {
+    this.#astDirty = true;
     this.#ast = ast;
   }
 
   isASTDirty(): boolean {
-    throw new Error('MutableAsset.isASTDirty()');
+    return this.#astDirty;
   }
 
   // eslint-disable-next-line require-await
@@ -128,7 +131,8 @@ export class MutableAsset implements IMutableAsset {
   }
 
   getMap(): Promise<?SourceMap> {
-    throw new Error('MutableAsset.getMap');
+    // TODO: Provide source maps once they exist
+    return Promise.resolve(null);
   }
 
   // eslint-disable-next-line no-unused-vars
@@ -161,24 +165,24 @@ export class MutableAsset implements IMutableAsset {
 
   // eslint-disable-next-line no-unused-vars
   invalidateOnFileChange(invalidation: FilePath): void {
-    throw new Error('MutableAsset.invalidateOnFileChange()');
+    // TODO: Forward invalidations to Rust
   }
 
   // eslint-disable-next-line no-unused-vars
   invalidateOnFileCreate(invalidation: FileCreateInvalidation): void {
-    throw new Error('MutableAsset.invalidateOnFileCreate()');
+    // TODO: Forward invalidations to Rust
   }
 
   // eslint-disable-next-line no-unused-vars
   invalidateOnEnvChange(invalidation: string): void {
-    throw new Error('MutableAsset.invalidateOnEnvChange()');
+    // TODO: Forward invalidations to Rust
   }
 
   invalidateOnStartup(): void {
-    throw new Error('MutableAsset.invalidateOnStartup()');
+    // TODO: Forward invalidations to Rust
   }
 
   invalidateOnBuild(): void {
-    throw new Error('MutableAsset.invalidateOnBuild()');
+    // TODO: Forward invalidations to Rust
   }
 }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR works around/fixes a few small behaviours with JS plugin loading that was discovered while building JFE.

## Changes

- Make `options.mode` available to Plugins
- Don't error when an AST isn't returned from `Transformer.generate`
- Implement `Asset.isASTDirty`
- Make the following methods noops for now
  - `Asset.invalidateOn*`
  - `Asset.getMap`

## Checklist

- [ ] Existing or new tests cover this change
