### PR TITLE
Fix ambiguous atlaspack config imports

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -31,7 +31,7 @@ import resolveOptions from './resolveOptions';
 import {ValueEmitter} from '@atlaspack/events';
 import {registerCoreWithSerializer} from './registerCoreWithSerializer';
 import {PromiseQueue} from '@atlaspack/utils';
-import AtlaspackConfig from './AtlaspackConfig';
+import {AtlaspackConfig} from './AtlaspackConfig';
 import logger from '@atlaspack/logger';
 import RequestTracker, {
   getWatcherOptions,

--- a/packages/core/core/src/AtlaspackConfig.js
+++ b/packages/core/core/src/AtlaspackConfig.js
@@ -55,7 +55,7 @@ export type LoadedPlugin<T> = {|
   range?: ?SemverRange,
 |};
 
-export default class AtlaspackConfig {
+export class AtlaspackConfig {
   options: AtlaspackOptions;
   filePath: ProjectPath;
   resolvers: PureAtlaspackConfigPipeline;

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -18,7 +18,7 @@ import type {
   ReportFn,
   RequestInvalidation,
 } from './types';
-import type AtlaspackConfig, {LoadedPlugin} from './AtlaspackConfig';
+import type {AtlaspackConfig, LoadedPlugin} from './AtlaspackConfig';
 import type InternalBundleGraph from './BundleGraph';
 import type {ConfigRequest} from './requests/ConfigRequest';
 import type {DevDepSpecifier} from './requests/DevDepRequest';

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -35,7 +35,7 @@ import ThrowableDiagnostic, {
 import {SOURCEMAP_EXTENSIONS} from '@atlaspack/utils';
 
 import {createDependency} from './Dependency';
-import AtlaspackConfig from './AtlaspackConfig';
+import {AtlaspackConfig} from './AtlaspackConfig';
 // TODO: eventually call path request as sub requests
 import {ResolverRunner} from './requests/PathRequest';
 import {

--- a/packages/core/core/src/Validation.js
+++ b/packages/core/core/src/Validation.js
@@ -9,7 +9,7 @@ import path from 'path';
 import {resolveConfig} from '@atlaspack/utils';
 import logger, {PluginLogger} from '@atlaspack/logger';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@atlaspack/diagnostic';
-import AtlaspackConfig from './AtlaspackConfig';
+import {AtlaspackConfig} from './AtlaspackConfig';
 import UncommittedAsset from './UncommittedAsset';
 import {createAsset} from './assetUtils';
 import {Asset} from './public/Asset';

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -11,7 +11,7 @@ import type {
   DevDepRequest,
   AtlaspackOptions,
 } from './types';
-import type AtlaspackConfig from './AtlaspackConfig';
+import type {AtlaspackConfig} from './AtlaspackConfig';
 import type PluginOptions from './public/PluginOptions';
 import type {RequestResult, RunAPI} from './RequestTracker';
 

--- a/packages/core/core/src/registerCoreWithSerializer.js
+++ b/packages/core/core/src/registerCoreWithSerializer.js
@@ -3,7 +3,7 @@ import {Graph} from '@atlaspack/graph';
 import {registerSerializableClass} from './serializer';
 import AssetGraph from './AssetGraph';
 import BundleGraph from './BundleGraph';
-import AtlaspackConfig from './AtlaspackConfig';
+import {AtlaspackConfig} from './AtlaspackConfig';
 import {RequestGraph} from './RequestTracker';
 import Config from './public/Config';
 import packageJson from '../package.json';

--- a/packages/core/core/src/requests/AtlaspackConfigRequest.js
+++ b/packages/core/core/src/requests/AtlaspackConfigRequest.js
@@ -33,12 +33,12 @@ import {parse} from 'json5';
 import path from 'path';
 import invariant from 'assert';
 
+import {AtlaspackConfig} from '../AtlaspackConfig';
 import AtlaspackConfigSchema from '../AtlaspackConfig.schema';
-import {optionsProxy} from '../utils';
-import AtlaspackConfig from '../AtlaspackConfig';
 import {createBuildCache} from '../buildCache';
 import {toProjectPath} from '../projectPath';
 import {requestTypes} from '../RequestTracker';
+import {optionsProxy} from '../utils';
 
 type ConfigMap<K, V> = {[K]: V, ...};
 

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -2,7 +2,7 @@
 
 import type {Async, Bundle as IBundle, Namer} from '@atlaspack/types';
 import type {SharedReference} from '@atlaspack/workers';
-import type AtlaspackConfig, {LoadedPlugin} from '../AtlaspackConfig';
+import type {AtlaspackConfig, LoadedPlugin} from '../AtlaspackConfig';
 import type {StaticRunOpts, RunAPI} from '../RequestTracker';
 import type {
   Asset,

--- a/packages/core/core/src/requests/DevDepRequest.js
+++ b/packages/core/core/src/requests/DevDepRequest.js
@@ -4,7 +4,7 @@ import type {
   SemverRange,
   Invalidations,
 } from '@atlaspack/types';
-import type AtlaspackConfig from '../AtlaspackConfig';
+import type {AtlaspackConfig} from '../AtlaspackConfig';
 import type {
   DevDepRequest,
   AtlaspackOptions,

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -28,7 +28,7 @@ import {normalizePath} from '@atlaspack/utils';
 import {report} from '../ReporterRunner';
 import {getPublicDependency} from '../public/Dependency';
 import PluginOptions from '../public/PluginOptions';
-import AtlaspackConfig from '../AtlaspackConfig';
+import {AtlaspackConfig, type LoadedPlugin} from '../AtlaspackConfig';
 import createAtlaspackConfigRequest, {
   getCachedAtlaspackConfig,
 } from './AtlaspackConfigRequest';
@@ -41,7 +41,6 @@ import {
 } from '../projectPath';
 import {Priority} from '../types';
 import {createBuildCache} from '../buildCache';
-import type {LoadedPlugin} from '../AtlaspackConfig';
 import {createConfig} from '../InternalConfig';
 import {loadPluginConfig, runConfigRequest} from './ConfigRequest';
 import {

--- a/packages/core/core/src/requests/ValidationRequest.js
+++ b/packages/core/core/src/requests/ValidationRequest.js
@@ -6,7 +6,7 @@ import type {AssetGroup} from '../types';
 import type {ConfigAndCachePath} from './AtlaspackConfigRequest';
 
 import nullthrows from 'nullthrows';
-import AtlaspackConfig from '../AtlaspackConfig';
+import {AtlaspackConfig} from '../AtlaspackConfig';
 import {report} from '../ReporterRunner';
 import Validation from '../Validation';
 import createAtlaspackConfigRequest from './AtlaspackConfigRequest';

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -36,7 +36,7 @@ import {
   createDevDependency,
   runDevDepRequest,
 } from './DevDepRequest';
-import AtlaspackConfig from '../AtlaspackConfig';
+import {AtlaspackConfig} from '../AtlaspackConfig';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@atlaspack/diagnostic';
 import {PluginTracer, tracer} from '@atlaspack/profiler';
 import {requestTypes} from '../RequestTracker';

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -20,7 +20,7 @@ import Transformation, {
 import {reportWorker, report} from './ReporterRunner';
 import PackagerRunner, {type RunPackagerRunnerResult} from './PackagerRunner';
 import Validation, {type ValidationOpts} from './Validation';
-import AtlaspackConfig from './AtlaspackConfig';
+import {AtlaspackConfig} from './AtlaspackConfig';
 import {registerCoreWithSerializer} from './registerCoreWithSerializer';
 import {clearBuildCaches} from './buildCache';
 import {init as initSourcemaps} from '@parcel/source-map';

--- a/packages/core/core/test/AtlaspackConfig.test.js
+++ b/packages/core/core/test/AtlaspackConfig.test.js
@@ -1,14 +1,17 @@
 // @flow strict-local
 
-import AtlaspackConfig from '../src/AtlaspackConfig';
 import assert from 'assert';
 import path from 'path';
-import sinon from 'sinon';
+
 import logger from '@atlaspack/logger';
 import {inputFS} from '@atlaspack/test-utils';
-import {parseAndProcessConfig} from '../src/requests/AtlaspackConfigRequest';
-import {DEFAULT_OPTIONS} from './test-utils';
+import sinon from 'sinon';
+
+import {AtlaspackConfig} from '../src/AtlaspackConfig';
 import {toProjectPath} from '../src/projectPath';
+import {parseAndProcessConfig} from '../src/requests/AtlaspackConfigRequest';
+
+import {DEFAULT_OPTIONS} from './test-utils';
 
 const ATLASPACKRC_PATH = toProjectPath('/', '/.parcelrc');
 

--- a/packages/core/core/test/AtlaspackConfigRequest.test.js
+++ b/packages/core/core/test/AtlaspackConfigRequest.test.js
@@ -1,8 +1,11 @@
 // @flow
 import assert from 'assert';
-import nullthrows from 'nullthrows';
 import path from 'path';
-import AtlaspackConfig from '../src/AtlaspackConfig';
+
+import nullthrows from 'nullthrows';
+
+import {AtlaspackConfig} from '../src/AtlaspackConfig';
+import {toProjectPath} from '../src/projectPath';
 import {
   validateConfigFile,
   mergePipelines,
@@ -13,8 +16,8 @@ import {
   resolveAtlaspackConfig,
   processConfig,
 } from '../src/requests/AtlaspackConfigRequest';
+
 import {DEFAULT_OPTIONS, relative} from './test-utils';
-import {toProjectPath} from '../src/projectPath';
 
 describe('AtlaspackConfigRequest', () => {
   describe('validateConfigFile', () => {


### PR DESCRIPTION
## Motivation

When running the TypeScript codemod, instances of the following code are left as is and later become errors:

```javascript
import type AtlaspackConfig, {LoadedPlugin} from './AtlaspackConfig';
```

> A type-only import can specify a default import or named bindings, but not both.

## Changes

Make `AtlaspackConfig` a named export to avoid the error during the migration

## Checklist

- [x] Existing or new tests cover this change
