### PR TITLE
Change fallback behaviour for __MCOND and fix dependency for runtime

### DIFF
--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -289,7 +289,12 @@ export function shallowEqual(
   return true;
 }
 
-type RunOpts = {require?: boolean, strict?: boolean, ...};
+type RunOpts = {
+  require?: boolean,
+  strict?: boolean,
+  entryAsset?: Asset,
+  ...
+};
 
 export async function runBundles(
   bundleGraph: BundleGraph<PackagedBundle>,
@@ -299,11 +304,13 @@ export async function runBundles(
   opts: RunOpts = {},
   externalModules?: ExternalModules,
 ): Promise<mixed> {
-  let entryAsset = nullthrows(
-    bundles
-      .map(([, b]) => b.getMainEntry() || b.getEntryAssets()[0])
-      .filter(Boolean)[0],
-  );
+  let entryAsset = opts.entryAsset
+    ? opts.entryAsset
+    : nullthrows(
+        bundles
+          .map(([, b]) => b.getMainEntry() || b.getEntryAssets()[0])
+          .filter(Boolean)[0],
+      );
   let env = entryAsset.env;
   let target = env.context;
   let outputFormat = env.outputFormat;

--- a/packages/examples/conditional-bundling/features.js
+++ b/packages/examples/conditional-bundling/features.js
@@ -1,0 +1,8 @@
+const FEATURES = {
+  'my.feature': true,
+  'feature.async.condition': true,
+  'feature.ui': false,
+  'my.feature.lazy': true,
+};
+
+module.exports = FEATURES;

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -8,11 +8,10 @@
     "build:inspect:on": "PARCEL_WORKERS=0 node --inspect-brk $(yarn bin atlaspack) build --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
     "build:off": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=false src/index.html",
     "build:on": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
-    "build:on": "atlaspack build --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
     "dev:off": "npx nodemon -e 'ts, tsx, json, .parcelrc' --watch . --ignore 'dist/' --exec 'yarn build:off && node serve.js'",
     "dev:on": "npx nodemon -e 'ts, tsx, json, .parcelrc' --watch . --ignore 'dist/' --exec 'yarn build:on && node serve.js'",
-    "serve:on": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=true src/index.html",
-    "serve:off": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=false src/index.html"
+    "serve:off": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=false src/index.html",
+    "serve:on": "atlaspack serve --no-cache --feature-flag conditionalBundlingApi=true src/index.html"
   },
   "dependencies": {
     "@atlaskit/button": "*",

--- a/packages/examples/conditional-bundling/src/index.html
+++ b/packages/examples/conditional-bundling/src/index.html
@@ -7,6 +7,13 @@
   </head>
   <body>
     <div id="container"></div>
+    <script type="module">
+      import features from '../features.js';
+
+      globalThis.__MCOND = function (cond) {
+        return features[cond];
+      };
+    </script>
     <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/packages/examples/conditional-bundling/src/index.tsx
+++ b/packages/examples/conditional-bundling/src/index.tsx
@@ -7,10 +7,13 @@ const Feature = importCond<
   typeof import('./feature-enabled'),
   typeof import('./feature-disabled')
 >('my.feature', './feature-enabled', './feature-disabled');
+console.log('Feature', Feature);
+
 const FeatureWithUI = importCond<
   typeof import('./feature-ui-enabled'),
   typeof import('./feature-ui-disabled')
 >('feature.ui', './feature-ui-enabled', './feature-ui-disabled');
+console.log('FeatureWithUI', FeatureWithUI);
 
 const LazyComponent = lazy(() => import('./lazy-component'));
 
@@ -25,8 +28,6 @@ function LazyComponentContainer() {
 const App = () => {
   const [showLazyComponent, setShowLazyComponent] = useState(false);
 
-  console.log('FeatureWithUI', FeatureWithUI);
-  console.log('Feature', Feature);
   return (
     <div>
       <p>Hello from React</p>

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -210,7 +210,10 @@ export default (new Runtime({
         assets.push({
           filePath: path.join(__dirname, `/conditions/${cond.publicId}.js`),
           code: assetCode,
-          dependency: cond.ifTrueDependency,
+          // This dependency is important, as it's the last symbol handled in scope hoisting.
+          // That means that scope hoisting will use the module id for this asset to replace the symbol
+          // (rather than the actual conditional deps)
+          dependency: cond.ifFalseDependency,
           env: {sourceType: 'module'},
         });
       }

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -365,7 +365,9 @@ pub fn transform(
                 module.visit_mut_with(&mut ContextualImportsInlineRequireVisitor::new(
                   unresolved_mark,
                   ContextualImportsConfig {
-                    server: Some(false),
+                    server: false,
+                    // Fallback to false variant when flag is off
+                    default_if_undefined: true,
                   },
                 ));
               }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation
We need a safe rollout when `globalThis.__MCOND` is not defined (if we mess something up on the control branch of the rollout). We also have an issue where some dependencies don't get loaded correctly when prod mode is on.


## Changes

Two major changes here:

- Check if `globalThis.__MCOND` exists when configured, so we can have a safe rollout when feature flag is disabled
- Fix the dependency in scope hoisting, as we don't pick up the correct dep

I also added a new integration test and fixed some tests not using the correct data. This can probably allow some refactoring in the style of the new test. Dev mode is broken so I skip the test I fixed (as it's now red). 

## Checklist

- [x] Existing or new tests cover this change
