### PR TITLE
V3: Moving Transformers from "&mut self" to "&self"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "criterion",
  "glob-match",
  "indexmap 1.9.3",
+ "parking_lot",
  "pretty_assertions",
  "serde",
  "swc_core",

--- a/crates/atlaspack_core/src/plugin/transformer_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/transformer_plugin.rs
@@ -66,7 +66,7 @@ pub trait TransformerPlugin: Any + Debug + Send + Sync {
   }
   /// Transform the asset and/or add new assets
   fn transform(
-    &mut self,
+    &self,
     context: TransformContext,
     asset: Asset,
   ) -> Result<TransformResult, anyhow::Error>;

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
@@ -87,11 +87,7 @@ impl TransformerPlugin for NodejsRpcTransformerPlugin {
     hasher.finish()
   }
 
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let state = self.get_or_init_state()?;
     let asset_env = asset.env.clone();
     let stats = asset.stats.clone();

--- a/crates/atlaspack_plugin_rpc/src/testing.rs
+++ b/crates/atlaspack_plugin_rpc/src/testing.rs
@@ -178,7 +178,7 @@ impl RuntimePlugin for TestingRpcPlugin {
 
 impl TransformerPlugin for TestingRpcPlugin {
   fn transform(
-    &mut self,
+    &self,
     _context: TransformContext,
     asset: Asset,
   ) -> Result<TransformResult, anyhow::Error> {

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -65,7 +65,7 @@ impl AtlaspackCssTransformerPlugin {
     })
   }
 
-  fn is_css_module(&mut self, asset: &Asset) -> bool {
+  fn is_css_module(&self, asset: &Asset) -> bool {
     let is_style_tag = asset
       .meta
       .get("type")
@@ -95,11 +95,7 @@ impl AtlaspackCssTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackCssTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let css_modules = if self.is_css_module(&asset) {
       Some(lightningcss::css_modules::Config {
         dashed_idents: asset.is_source && self.css_modules_config.dashed_idents.unwrap_or_default(),
@@ -414,7 +410,7 @@ mod tests {
 
   fn run_plugin(asset: &Asset) -> anyhow::Result<TransformResult> {
     let file_system = Arc::new(InMemoryFileSystem::default());
-    let mut plugin = AtlaspackCssTransformerPlugin::new(&PluginContext {
+    let plugin = AtlaspackCssTransformerPlugin::new(&PluginContext {
       config: Arc::new(ConfigLoader {
         fs: file_system.clone(),
         project_root: PathBuf::default(),

--- a/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
@@ -28,11 +28,7 @@ impl AtlaspackHtmlTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackHtmlTransformerPlugin {
-  fn transform(
-    &mut self,
-    context: TransformContext,
-    input: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, context: TransformContext, input: Asset) -> Result<TransformResult, Error> {
     let bytes: &[u8] = input.code.bytes();
     let mut dom = parse_html(bytes)?;
     let context = HTMLTransformationContext {

--- a/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_image/src/image_transformer.rs
@@ -20,11 +20,7 @@ impl AtlaspackImageTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackImageTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let mut asset = asset.clone();
 
     if asset.bundle_behavior.is_none() {
@@ -111,7 +107,7 @@ mod tests {
   #[test]
   fn returns_image_asset() {
     let file_system = Arc::new(InMemoryFileSystem::default());
-    let mut plugin = AtlaspackImageTransformerPlugin::new(&PluginContext {
+    let plugin = AtlaspackImageTransformerPlugin::new(&PluginContext {
       config: Arc::new(ConfigLoader {
         fs: file_system.clone(),
         project_root: PathBuf::default(),

--- a/crates/atlaspack_plugin_transformer_inline/src/inline_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline/src/inline_transformer.rs
@@ -16,11 +16,7 @@ impl AtlaspackInlineTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackInlineTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let mut asset = asset.clone();
 
     asset.bundle_behavior = Some(BundleBehavior::Inline);
@@ -47,7 +43,7 @@ mod tests {
   #[test]
   fn returns_inline_string_asset() {
     let file_system = Arc::new(InMemoryFileSystem::default());
-    let mut plugin = AtlaspackInlineTransformerPlugin::new(&PluginContext {
+    let plugin = AtlaspackInlineTransformerPlugin::new(&PluginContext {
       config: Arc::new(ConfigLoader {
         fs: file_system.clone(),
         project_root: PathBuf::default(),

--- a/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_inline_string/src/inline_string_transformer.rs
@@ -12,11 +12,7 @@ impl AtlaspackInlineStringTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackInlineStringTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let mut asset = asset.clone();
 
     asset.bundle_behavior = Some(BundleBehavior::Inline);
@@ -47,7 +43,7 @@ mod tests {
   #[test]
   fn returns_inline_string_asset() {
     let file_system = Arc::new(InMemoryFileSystem::default());
-    let mut plugin = AtlaspackInlineStringTransformerPlugin::new(&PluginContext {
+    let plugin = AtlaspackInlineStringTransformerPlugin::new(&PluginContext {
       config: Arc::new(ConfigLoader {
         fs: file_system.clone(),
         project_root: PathBuf::default(),

--- a/crates/atlaspack_plugin_transformer_js/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_js/Cargo.toml
@@ -21,6 +21,7 @@ glob-match = { workspace = true }
 indexmap = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 swc_core = { workspace = true, features = ["ecma_ast"] }
+parking_lot = { workspace = true }
 
 [dev-dependencies]
 atlaspack_filesystem = { path = "../atlaspack_filesystem" }

--- a/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_json/src/json_transformer.rs
@@ -15,11 +15,7 @@ impl AtlaspackJsonTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackJsonTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let mut asset = asset.clone();
 
     let code = std::str::from_utf8(asset.code.bytes())?;
@@ -66,7 +62,7 @@ mod tests {
 
   #[test]
   fn returns_js_asset_from_json() {
-    let mut plugin = create_json_plugin();
+    let plugin = create_json_plugin();
 
     let asset = Asset {
       code: Arc::new(Code::from(
@@ -104,7 +100,7 @@ mod tests {
 
   #[test]
   fn returns_js_asset_from_json5() {
-    let mut plugin = create_json_plugin();
+    let plugin = create_json_plugin();
 
     let asset = Asset {
       code: Arc::new(Code::from(

--- a/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_raw/src/raw_transformer.rs
@@ -13,11 +13,7 @@ impl AtlaspackRawTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackRawTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let mut asset = asset.clone();
 
     asset.bundle_behavior = Some(BundleBehavior::Isolated);
@@ -44,7 +40,7 @@ mod tests {
   #[test]
   fn returns_raw_asset() {
     let file_system = Arc::new(InMemoryFileSystem::default());
-    let mut plugin = AtlaspackRawTransformerPlugin::new(&PluginContext {
+    let plugin = AtlaspackRawTransformerPlugin::new(&PluginContext {
       config: Arc::new(ConfigLoader {
         fs: file_system.clone(),
         project_root: PathBuf::default(),

--- a/crates/atlaspack_plugin_transformer_yaml/src/yaml_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_yaml/src/yaml_transformer.rs
@@ -15,11 +15,7 @@ impl AtlaspackYamlTransformerPlugin {
 }
 
 impl TransformerPlugin for AtlaspackYamlTransformerPlugin {
-  fn transform(
-    &mut self,
-    _context: TransformContext,
-    asset: Asset,
-  ) -> Result<TransformResult, Error> {
+  fn transform(&self, _context: TransformContext, asset: Asset) -> Result<TransformResult, Error> {
     let mut asset = asset.clone();
 
     let code = serde_yml::from_slice::<serde_yml::Value>(asset.code.bytes())?;
@@ -65,7 +61,7 @@ mod tests {
 
   #[test]
   fn returns_js_asset_from_yaml() {
-    let mut plugin = create_yaml_plugin();
+    let plugin = create_yaml_plugin();
 
     let asset = Asset {
       code: Arc::new(Code::from(String::from(


### PR DESCRIPTION
Transformers currently require a mutable reference. This PR changes them to be immutable. The one case of mutation was migrated to interior mutability.

This is required because plugins are shared across threads and this allows us to avoid wrapping `TransformerPlugin`s in a `RwLock`.