### PR TITLE
V3: Slightly better error handling for jscallable

### DIFF
--- a/crates/atlaspack_napi_helpers/src/js_callable/js_callable.rs
+++ b/crates/atlaspack_napi_helpers/src/js_callable/js_callable.rs
@@ -1,4 +1,5 @@
 use std::sync::mpsc::channel;
+use std::sync::Arc;
 #[cfg(debug_assertions)]
 use std::thread::ThreadId;
 
@@ -27,21 +28,20 @@ pub type MapJsReturn<Return> = Box<dyn Fn(&Env, JsUnknown) -> napi::Result<Retur
 pub struct JsCallable {
   #[cfg(debug_assertions)]
   initial_thread: ThreadId,
-  #[allow(unused)]
-  name: String,
+  fn_name: Arc<String>,
   threadsafe_function: ThreadsafeFunction<MapJsParams, ErrorStrategy::Fatal>,
 }
 
 impl std::fmt::Debug for JsCallable {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("JsCallable")
-      .field("name", &self.name)
+      .field("name", &self.fn_name)
       .finish()
   }
 }
 
 impl JsCallable {
-  pub fn new(callback: JsFunction, name: String) -> napi::Result<Self> {
+  pub fn new(callback: JsFunction, fn_name: String) -> napi::Result<Self> {
     // Store the threadsafe function on the struct
     let tsfn: ThreadsafeFunction<MapJsParams, ErrorStrategy::Fatal> = callback
       .create_threadsafe_function(0, |ctx: ThreadSafeCallContext<MapJsParams>| {
@@ -51,13 +51,13 @@ impl JsCallable {
     Ok(Self {
       #[cfg(debug_assertions)]
       initial_thread: std::thread::current().id(),
-      name,
+      fn_name: Arc::new(fn_name),
       threadsafe_function: tsfn,
     })
   }
 
   /// Construct a JsCallable from an object property
-  pub fn new_from_object_prop(method_name: &str, obj: &JsObject) -> napi::Result<Self> {
+  pub fn new_method(method_name: &str, obj: &JsObject) -> napi::Result<Self> {
     Self::new(
       obj.get_named_property(method_name)?,
       method_name.to_string(),
@@ -65,7 +65,7 @@ impl JsCallable {
   }
 
   /// Construct a JsCallable from an object property, binding it to the source object
-  pub fn new_from_object_prop_bound(method_name: &str, obj: &JsObject) -> napi::Result<Self> {
+  pub fn new_method_bound(method_name: &str, obj: &JsObject) -> napi::Result<Self> {
     let jsfn: JsFunction = obj.get_named_property(method_name)?;
     let fn_obj = jsfn.coerce_to_object()?;
     let bind: JsFunction = fn_obj.get_named_property("bind")?;
@@ -78,35 +78,8 @@ impl JsCallable {
     Ok(self)
   }
 
-  /// Call JavaScript function and discard return value
-  pub fn call(
-    &self,
-    map_params: impl FnOnce(&Env) -> napi::Result<Vec<JsUnknown>> + 'static,
-  ) -> napi::Result<()> {
-    #[cfg(debug_assertions)]
-    if self.initial_thread == std::thread::current().id() {
-      return Err(napi::Error::from_reason(format!(
-        "Cannot run threadsafe function {} on main thread",
-        self.name
-      )));
-    }
-
-    self
-      .threadsafe_function
-      .call(Box::new(map_params), ThreadsafeFunctionCallMode::Blocking);
-
-    Ok(())
-  }
-
-  pub fn call_serde<Params>(&self, params: Params) -> napi::Result<()>
-  where
-    Params: Serialize + Send + Sync + 'static,
-  {
-    self.call(map_params_serde(params))
-  }
-
   /// Call JavaScript function and handle the return value
-  pub fn call_with_return<Return>(
+  pub fn call<Return>(
     &self,
     map_params: impl FnOnce(&Env) -> napi::Result<Vec<JsUnknown>> + 'static,
     map_return: impl Fn(&Env, JsUnknown) -> napi::Result<Return> + 'static,
@@ -118,7 +91,7 @@ impl JsCallable {
     if self.initial_thread == std::thread::current().id() {
       return Err(napi::Error::from_reason(format!(
         "Cannot run threadsafe function {} on main thread",
-        self.name
+        self.fn_name
       )));
     }
 
@@ -127,41 +100,86 @@ impl JsCallable {
     self.threadsafe_function.call_with_return_value(
       Box::new(map_params),
       ThreadsafeFunctionCallMode::NonBlocking,
-      move |JsValue(value, env)| {
-        if value.is_promise()? {
-          let result: JsObject = value.try_into()?;
-          let then: JsFunction = result.get_named_property("then")?;
+      {
+        let fn_name = self.fn_name.clone();
 
-          let tx2 = tx.clone();
-          let cb = env.create_function_from_closure("callback", move |ctx| {
-            tx.send(map_return(&env, ctx.get::<JsUnknown>(0)?)).unwrap();
-            ctx.env.get_undefined()
-          })?;
+        move |JsValue(value, env)| {
+          if value.is_promise()? {
+            let result: JsObject = value.try_into()?;
+            let then_fn: JsFunction = result.get_named_property("then")?;
 
-          let eb = env.create_function_from_closure("error_callback", move |ctx| {
-            let err = napi::Error::from(ctx.get::<JsUnknown>(0)?);
-            tx2.send(Err(err)).expect("send failure");
-            ctx.env.get_undefined()
-          })?;
+            let then_result_fn =
+              env.create_function_from_closure("JsCallable::then_result_fn", {
+                let tx = tx.clone();
+                let fn_name = fn_name.clone();
 
-          then.call(Some(&result), &[cb, eb])?;
-        } else if value.is_error()? {
-          tx.send(Err(napi::Error::from(value))).unwrap();
-        } else {
-          tx.send(map_return(&env, value)).unwrap();
+                move |ctx| {
+                  if tx.send(map_return(&env, ctx.get::<JsUnknown>(0)?)).is_err() {
+                    return Err(napi::Error::from_reason(format!(
+                      "JsCallable({}) SendError: Result.then()",
+                      &fn_name
+                    )));
+                  }
+                  ctx.env.get_undefined()
+                }
+              })?;
+
+            let then_error_fn = env.create_function_from_closure("JsCallable::then_error_fn", {
+              let tx = tx.clone();
+              let fn_name = fn_name.clone();
+
+              move |ctx| {
+                let err = napi::Error::from(ctx.get::<JsUnknown>(0)?);
+                if tx.send(Err(err)).is_err() {
+                  return Err(napi::Error::from_reason(format!(
+                    "JsCallable({}) SendError: Result.catch()",
+                    &fn_name
+                  )));
+                };
+                ctx.env.get_undefined()
+              }
+            })?;
+
+            then_fn.call(Some(&result), &[then_result_fn, then_error_fn])?;
+            return Ok(());
+          }
+
+          if value.is_error()? {
+            if tx.send(Err(napi::Error::from(value))).is_err() {
+              return Err(napi::Error::from_reason(format!(
+                "JsCallable({}) SendError: Sync Result Thrown",
+                &fn_name
+              )));
+            };
+            return Ok(());
+          }
+
+          if tx.send(map_return(&env, value)).is_err() {
+            return Err(napi::Error::from_reason(format!(
+              "JsCallable({}) SendError: Sync Result",
+              &fn_name
+            )));
+          };
+          Ok(())
         }
-        Ok(())
       },
     );
 
-    rx.recv().unwrap()
+    match rx.recv() {
+      Ok(Ok(result)) => Ok(result),
+      Ok(Err(err)) => Err(err),
+      Err(err) => Err(napi::Error::from_reason(format!(
+        "JsCallable({}) RecvError: {:?}",
+        &self.fn_name, err
+      ))),
+    }
   }
 
-  pub fn call_with_return_serde<Params, Return>(&self, params: Params) -> napi::Result<Return>
+  pub fn call_serde<Params, Return>(&self, params: Params) -> napi::Result<Return>
   where
     Params: Serialize + Send + Sync + 'static,
     Return: Send + DeserializeOwned + 'static,
   {
-    self.call_with_return(map_params_serde(params), map_return_serde())
+    self.call(map_params_serde(params), map_return_serde())
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_resolver.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_resolver.rs
@@ -90,7 +90,7 @@ impl ResolverPlugin for RpcNodejsResolverPlugin {
     self.nodejs_workers.exec_on_one(|worker| {
       worker
         .run_resolver_resolve_fn
-        .call_with_return_serde(RunResolverResolve {
+        .call_serde(RunResolverResolve {
           key: self.plugin_node.package_name.clone(),
           dependency: (&*ctx.dependency).clone(),
           specifier: (&*ctx.specifier).to_owned(),

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
@@ -102,7 +102,7 @@ impl TransformerPlugin for NodejsRpcTransformerPlugin {
     let result: RpcTransformerResult = self.nodejs_workers.exec_on_one(|worker| {
       worker
         .transformer_register_fn
-        .call_with_return_serde(run_transformer_opts)
+        .call_serde(run_transformer_opts)
         .map_err(anyhow_from_napi)
     })?;
 

--- a/crates/atlaspack_plugin_rpc/src/nodejs/rpc/nodejs_rpc_worker.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/rpc/nodejs_rpc_worker.rs
@@ -14,7 +14,7 @@ pub struct NodejsWorker {
 
 impl NodejsWorker {
   pub fn new(delegate: JsObject) -> napi::Result<Self> {
-    let bind = |method_name: &str| JsCallable::new_from_object_prop_bound(method_name, &delegate);
+    let bind = |method_name: &str| JsCallable::new_method_bound(method_name, &delegate);
 
     Ok(Self {
       load_plugin_fn: bind("loadPlugin")?,
@@ -26,7 +26,7 @@ impl NodejsWorker {
   pub fn load_plugin(&self, opts: LoadPluginOptions) -> anyhow::Result<()> {
     self
       .load_plugin_fn
-      .call_with_return_serde(opts)
+      .call_serde(opts)
       .map_err(anyhow_from_napi)
   }
 }

--- a/crates/node-bindings/src/atlaspack/file_system_napi.rs
+++ b/crates/node-bindings/src/atlaspack/file_system_napi.rs
@@ -23,15 +23,13 @@ pub struct FileSystemNapi {
 impl FileSystemNapi {
   pub fn new(env: &Env, js_file_system: &JsObject) -> napi::Result<Self> {
     Ok(Self {
-      canonicalize_fn: JsCallable::new_from_object_prop("canonicalize", &js_file_system)?
+      canonicalize_fn: JsCallable::new_method("canonicalize", &js_file_system)?.into_unref(env)?,
+      create_directory_fn: JsCallable::new_method("createDirectory", &js_file_system)?
         .into_unref(env)?,
-      create_directory_fn: JsCallable::new_from_object_prop("createDirectory", &js_file_system)?
-        .into_unref(env)?,
-      cwd_fn: JsCallable::new_from_object_prop("cwd", &js_file_system)?.into_unref(env)?,
-      read_file_fn: JsCallable::new_from_object_prop("readFile", &js_file_system)?
-        .into_unref(env)?,
-      is_file_fn: JsCallable::new_from_object_prop("isFile", &js_file_system)?.into_unref(env)?,
-      is_dir_fn: JsCallable::new_from_object_prop("isDir", &js_file_system)?.into_unref(env)?,
+      cwd_fn: JsCallable::new_method("cwd", &js_file_system)?.into_unref(env)?,
+      read_file_fn: JsCallable::new_method("readFile", &js_file_system)?.into_unref(env)?,
+      is_file_fn: JsCallable::new_method("isFile", &js_file_system)?.into_unref(env)?,
+      is_dir_fn: JsCallable::new_method("isDir", &js_file_system)?.into_unref(env)?,
     })
   }
 }
@@ -40,28 +38,28 @@ impl FileSystem for FileSystemNapi {
   fn canonicalize_base(&self, path: &Path) -> io::Result<PathBuf> {
     self
       .canonicalize_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e))
   }
 
   fn create_directory(&self, path: &Path) -> std::io::Result<()> {
     self
       .create_directory_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e))
   }
 
   fn cwd(&self) -> io::Result<PathBuf> {
     self
       .cwd_fn
-      .call_with_return_serde(None::<bool>)
+      .call_serde(None::<bool>)
       .map_err(|e| io::Error::other(e))
   }
 
   fn read(&self, path: &Path) -> std::io::Result<Vec<u8>> {
     let result = self
       .read_file_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .map_err(|e| io::Error::other(e));
 
     result
@@ -70,21 +68,21 @@ impl FileSystem for FileSystemNapi {
   fn read_to_string(&self, path: &Path) -> io::Result<String> {
     self
       .read_file_fn
-      .call_with_return_serde((path.to_path_buf(), "utf8"))
+      .call_serde((path.to_path_buf(), "utf8"))
       .map_err(|e| io::Error::other(e))
   }
 
   fn is_file(&self, path: &Path) -> bool {
     self
       .is_file_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .expect("TODO handle error case")
   }
 
   fn is_dir(&self, path: &Path) -> bool {
     self
       .is_dir_fn
-      .call_with_return_serde(path.to_path_buf())
+      .call_serde(path.to_path_buf())
       .expect("TODO handle error case")
   }
 }

--- a/crates/node-bindings/src/atlaspack/package_manager_napi.rs
+++ b/crates/node-bindings/src/atlaspack/package_manager_napi.rs
@@ -13,8 +13,7 @@ pub struct PackageManagerNapi {
 impl PackageManagerNapi {
   pub fn new(env: &Env, js_file_system: &JsObject) -> napi::Result<Self> {
     Ok(Self {
-      resolve_fn: JsCallable::new_from_object_prop_bound("resolveSync", &js_file_system)?
-        .into_unref(env)?,
+      resolve_fn: JsCallable::new_method_bound("resolveSync", &js_file_system)?.into_unref(env)?,
     })
   }
 }
@@ -23,7 +22,7 @@ impl PackageManager for PackageManagerNapi {
   fn resolve(&self, specifier: &str, from: &Path) -> anyhow::Result<Resolution> {
     self
       .resolve_fn
-      .call_with_return_serde((specifier.to_owned(), from.to_path_buf()))
+      .call_serde((specifier.to_owned(), from.to_path_buf()))
       .map_err(|e| anyhow!(e))
   }
 }


### PR DESCRIPTION
- Handling `.unwrap()` in `JsCallable` by throwing the Rust error back to JavaScript
- Removed the `JsCallable::call` (without return) methods because they are unused and shouldn't be used due to footguns
- Renamed `JsCallable::call_with_return` to `JsCallable::call`