### PR TITLE
Fix inline requires problem with (0, ...)

### DIFF
--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/inlining_visitor.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/inlining_visitor.rs
@@ -42,7 +42,7 @@ impl VisitMut for IdentifierReplacementVisitor {
     // new getValue().default() // => this fails because `getValue` is not a constructor
     //
     // // and
-    // new (0, getValue)().default() // => this works and uses `default` as the constructor
+    // new (0, getValue()).default() // => this works and uses `default` as the constructor
     // ```
     *n = swc_core::quote!("(0, $expr)" as Expr, expr: Expr = replacement_expression.clone());
   }

--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/inlining_visitor.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/inlining_visitor.rs
@@ -28,6 +28,22 @@ impl VisitMut for IdentifierReplacementVisitor {
     let Some(replacement_expression) = self.id_replacement.get(&ident.to_id()) else {
       return;
     };
-    *n = replacement_expression.clone();
+
+    // Expressions are wrapped in (0, require(...))
+    // The reason this is required is due to the following output being treated
+    // differently:
+    //
+    // ```
+    // const value = { default: class Something {} };
+    // new value.default() // => this is instance of Something
+    //
+    // // however
+    // const getValue = () => value;
+    // new getValue().default() // => this fails because `getValue` is not a constructor
+    //
+    // // and
+    // new (0, getValue)().default() // => this works and uses `default` as the constructor
+    // ```
+    *n = swc_core::quote!("(0, $expr)" as Expr, expr: Expr = replacement_expression.clone());
   }
 }

--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
@@ -220,6 +220,10 @@ impl InlineRequiresOptimizerBuilder {
 /// After replacement has been executed, `InlineRequiresOptimizer::require_initializers()` may be
 /// used to retrieve which statements have been matched against. This would be used for diagnostics
 /// purposes only.
+///
+/// The replacements are wrapped with `(0, $expr)`. This is to avoid issues when rewriting
+/// `new ...` expressions, where inserting a bare function like symbol will cause different
+/// treatment when instantiating classes. See [`IdentifierReplacementVisitor`].
 #[non_exhaustive]
 pub struct InlineRequiresOptimizer {
   unresolved_mark: Mark,
@@ -354,7 +358,7 @@ function doWork() {
     let expected_output = r#"
 const fs;
 function doWork() {
-    return require('fs').readFileSync('./something');
+    return (0, require('fs')).readFileSync('./something');
 }
     "#
     .trim();
@@ -384,7 +388,7 @@ parcelRequire.register('moduleId', function(require, module, exports) {
 parcelRequire.register('moduleId', function(require, module, exports) {
     const fs;
     function doWork() {
-        return require('fs').readFileSync('./something');
+        return (0, require('fs')).readFileSync('./something');
     }
 });
     "#
@@ -452,7 +456,7 @@ function run() {
 const app;
 const appDefault;
 function run() {
-    return parcelHelpers.interopDefault(require("./App")).test();
+    return (0, parcelHelpers.interopDefault((0, require("./App")))).test();
 }
     "#
     .trim();

--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -89,29 +89,16 @@ import {
       const contents = cleanRequires(bundleContents);
       const otherContents = cleanRequires(otherContentsRaw);
 
-      if (implementation === 'js') {
-        expect(otherContents).toContain(
-          `console.log((0, (0, parcelRequire(...)).exportedFunction)())`,
-        );
-        expect(contents).toContain(
-          `
+      expect(otherContents).toContain(
+        `console.log((0, (0, parcelRequire(...)).exportedFunction)())`,
+      );
+      expect(contents).toContain(
+        `
     setTimeout(()=>{
         (0, (0, parcelRequire(...)).exportedFunction)();
     }, 5000);
       `.trim(),
-        );
-      } else {
-        expect(otherContents).toContain(
-          `console.log((0, parcelRequire(...).exportedFunction)())`,
-        );
-        expect(contents).toContain(
-          `
-    setTimeout(()=>{
-        (0, parcelRequire(...).exportedFunction)();
-    }, 5000);
-      `.trim(),
-        );
-      }
+      );
     });
   });
 });

--- a/packages/core/rust/test/InlineRequiresNative.test.js
+++ b/packages/core/rust/test/InlineRequiresNative.test.js
@@ -21,7 +21,7 @@ function main() {
       `
 const fs;
 function main() {
-    return require('fs').readFile('./something');
+    return (0, require('fs')).readFile('./something');
 }
 `.trimStart(),
     );


### PR DESCRIPTION
When adding rust inline requires I choose not to include `(0, ...)` wrappers as we didn't understand where that would cause problems.

Apparently this is required due to handling of `new ...` expressions.

The reason this is required is due to the following output being treated
differently:

```js
const value = { default: class Something {} };
new value.default()
// => this is instance of Something
```

However:
```js
const getValue = () => value;
new getValue().default()
// => this fails because `getValue` is not a constructor
```

And:
```js
new (0, getValue()).default()
// => this works and uses `default` as the constructor
```