### PR TITLE
[V3] Fix transform resolve function

### DIFF
--- a/packages/core/core/src/atlaspack-v3/worker/worker.js
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.js
@@ -174,8 +174,12 @@ export class AtlaspackWorker {
     }
 
     const transformer: Transformer<any> = state.transformer;
-    const resolveFunc = (from: string, to: string): Promise<any> =>
-      Promise.resolve(require.resolve(to, {paths: [from]}));
+    const resolveFunc = (from: string, to: string): Promise<any> => {
+      let customRequire = module.createRequire(from);
+      let resolvedPath = customRequire.resolve(to);
+
+      return Promise.resolve(resolvedPath);
+    };
     const env = new Environment(napiEnv);
     const mutableAsset = new MutableAsset(innerAsset, this.#fs, env);
     const defaultOptions = {


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Ideally, we'd use the real resolve pipeline for transformers that call the `resolve` API, however this is a bit of work and it's not clear if we really need it going forward. Moving to `module.createRequire` fixes some broken cases in Jira builds in the meantime though. 

## Checklist

- [ ] Existing or new tests cover this change
