### PR TITLE
Add CLI debug build asset graph command

### DIFF
--- a/packages/core/cli/src/cli.js
+++ b/packages/core/cli/src/cli.js
@@ -298,6 +298,11 @@ function makeDebugCommand() {
           ...options,
           shouldBuildLazily: true,
           watchBackend: 'watchman',
+          featureFlags: {
+            ...options.featureFlags,
+            fixQuadraticCacheInvalidation: 'NEW',
+            useLmdbJsLite: true,
+          },
         });
         console.log('Created atlaspack instance');
 

--- a/packages/core/cli/src/cli.js
+++ b/packages/core/cli/src/cli.js
@@ -248,12 +248,11 @@ function makeDebugCommand() {
         entries = entries.map((entry) => path.resolve(entry));
 
         Object.assign(command, opts);
-
-        const Atlaspack = require('@atlaspack/core').default;
         const fs = new NodeFS();
         const options = await normalizeOptions(command, fs);
 
-        console.log(command.featureFlag);
+        const Atlaspack = require('@atlaspack/core').default;
+
         const atlaspack = new Atlaspack({
           entries,
           defaultConfig: require.resolve('@atlaspack/config-default', {
@@ -273,6 +272,43 @@ function makeDebugCommand() {
       }
     });
   applyOptions(invalidate, commonOptions);
+
+  const buildAssetGraph = debug
+    .command('build-asset-graph [input...]')
+    .description('Build the asset graph then exit')
+    .action(async (entries, opts, command: any) => {
+      try {
+        if (entries.length === 0) {
+          entries = ['.'];
+        }
+        entries = entries.map((entry) => path.resolve(entry));
+
+        Object.assign(command, opts);
+        const fs = new NodeFS();
+        const options = await normalizeOptions(command, fs);
+
+        const Atlaspack = require('@atlaspack/core').default;
+
+        const atlaspack = new Atlaspack({
+          entries,
+          defaultConfig: require.resolve('@atlaspack/config-default', {
+            paths: [fs.cwd(), __dirname],
+          }),
+          shouldPatchConsole: false,
+          ...options,
+          shouldBuildLazily: true,
+          watchBackend: 'watchman',
+        });
+        console.log('Created atlaspack instance');
+
+        await atlaspack.unstable_buildAssetGraph();
+        console.log('Done building asset graph');
+        process.exit(0);
+      } catch (err) {
+        handleUncaughtException(err);
+      }
+    });
+  applyOptions(buildAssetGraph, commonOptions);
 
   return debug;
 }

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -575,9 +575,12 @@ export default class Atlaspack {
         ? createAssetGraphRequestRust(this.rustAtlaspack)(input)
         : createAssetGraphRequestJS(input),
     );
+    // eslint-disable-next-line no-console
     console.log('Done building asset graph!');
+    // eslint-disable-next-line no-console
     console.log('Write request tracker to cache');
     await this.writeRequestTrackerToCache();
+    // eslint-disable-next-line no-console
     console.log('Done writing request tracker to cache');
   }
 

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -58,6 +58,7 @@ import {
 import {tracer} from '@atlaspack/profiler';
 import {setFeatureFlags, DEFAULT_FEATURE_FLAGS} from '@atlaspack/feature-flags';
 import {AtlaspackV3, FileSystemV3} from './atlaspack-v3';
+import createAssetGraphRequestJS from './requests/AssetGraphRequest';
 
 registerCoreWithSerializer();
 
@@ -550,6 +551,28 @@ export default class Atlaspack {
 
   async unstable_invalidate(): Promise<void> {
     await this._init();
+  }
+
+  /**
+   * Build the asset graph
+   */
+  async unstable_buildAssetGraph(): Promise<void> {
+    await this._init();
+    await this.#requestTracker.runRequest(
+      createAssetGraphRequestJS({
+        optionsRef: this.#optionsRef,
+        name: 'Main',
+        entries: this.#config.options.entries,
+        shouldBuildLazily: false,
+        lazyIncludes: [],
+        lazyExcludes: [],
+        requestedAssetIds: this.#requestedAssetIds,
+      }),
+    );
+    console.log('Done building asset graph!');
+    console.log('Write request tracker to cache');
+    await this.writeRequestTrackerToCache();
+    console.log('Done writing request tracker to cache');
   }
 
   async unstable_transform(

--- a/packages/core/core/src/requests/AssetRequest.js
+++ b/packages/core/core/src/requests/AssetRequest.js
@@ -48,8 +48,6 @@ export default function createAssetRequest(
 const type = 'asset_request';
 
 function getId(input: AssetRequestInput) {
-  // eslint-disable-next-line no-unused-vars
-  let {optionsRef, ...hashInput} = input;
   return hashString(
     type +
       fromProjectPathRelative(input.filePath) +

--- a/packages/core/utils/test/PromiseQueue.test.js
+++ b/packages/core/utils/test/PromiseQueue.test.js
@@ -4,6 +4,7 @@ import randomInt from 'random-int';
 
 import PromiseQueue from '../src/PromiseQueue';
 import sinon from 'sinon';
+import resolve from 'resolve';
 
 describe('PromiseQueue', () => {
   it('run() should resolve when all async functions in queue have completed', async () => {
@@ -85,6 +86,31 @@ describe('PromiseQueue', () => {
     await promise;
 
     assert(subscribedFn.called);
+  });
+
+  it('runs functions concurrently', () => {
+    const queue = new PromiseQueue();
+
+    const fn1 = sinon
+      .stub()
+      .returns(new Promise((resolve) => setTimeout(resolve, 5000)));
+
+    queue.add(fn1); // queue does not work if nothing is running, this is broken behaviour
+    queue.run();
+
+    const fn2 = sinon
+      .stub()
+      .returns(new Promise((resolve) => setTimeout(resolve, 5000)));
+    const fn3 = sinon
+      .stub()
+      .returns(new Promise((resolve) => setTimeout(resolve, 5000)));
+
+    queue.add(fn2);
+    queue.add(fn3);
+
+    assert(fn1.calledOnce);
+    assert(fn2.calledOnce);
+    assert(fn3.calledOnce);
   });
 
   it('.subscribeToAdd() should allow unsubscribing', async () => {

--- a/packages/core/utils/test/PromiseQueue.test.js
+++ b/packages/core/utils/test/PromiseQueue.test.js
@@ -4,7 +4,6 @@ import randomInt from 'random-int';
 
 import PromiseQueue from '../src/PromiseQueue';
 import sinon from 'sinon';
-import resolve from 'resolve';
 
 describe('PromiseQueue', () => {
   it('run() should resolve when all async functions in queue have completed', async () => {


### PR DESCRIPTION
Adds a command to build asset graph from the command-line and write to the cache.

This can be used for testing or benchmarking this section of the tool.