### PR TITLE
Clean-up cache optimization feature-flag

### DIFF
--- a/packages/core/cli/src/cli.js
+++ b/packages/core/cli/src/cli.js
@@ -300,7 +300,6 @@ function makeDebugCommand() {
           watchBackend: 'watchman',
           featureFlags: {
             ...options.featureFlags,
-            fixQuadraticCacheInvalidation: 'NEW',
             useLmdbJsLite: true,
           },
         });

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -509,10 +509,7 @@ export default class Atlaspack {
           message: `File watch event emitted with ${events.length} events. Sample event: [${events[0]?.type}] ${events[0]?.path}`,
         });
 
-        let isInvalid = await this.#requestTracker.respondToFSEvents(
-          events,
-          Number.POSITIVE_INFINITY,
-        );
+        let isInvalid = await this.#requestTracker.respondToFSEvents(events);
         if (isInvalid && this.#watchQueue.getNumWaiting() === 0) {
           if (this.#watchAbortController) {
             this.#watchAbortController.abort();

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -827,52 +827,27 @@ export class RequestGraph extends ContentGraph<
     let nodeId = this.getNodeIdByContentKey(node.id);
     let dirname = path.dirname(fromProjectPathRelative(filePath));
 
-    if (getFeatureFlag('fixQuadraticCacheInvalidation')) {
-      while (dirname !== '/') {
-        if (!this.hasContentKey(dirname)) break;
-        const matchNodeId = this.getNodeIdByContentKey(dirname);
-        if (
-          !this.hasEdge(
-            nodeId,
-            matchNodeId,
-            requestGraphEdgeTypes.invalidated_by_create_above,
-          )
-        )
-          break;
-
-        const connectedNodes = this.getNodeIdsConnectedTo(
+    while (dirname !== '/') {
+      if (!this.hasContentKey(dirname)) break;
+      const matchNodeId = this.getNodeIdByContentKey(dirname);
+      if (
+        !this.hasEdge(
+          nodeId,
           matchNodeId,
-          requestGraphEdgeTypes.invalidated_by_create,
-        );
-        for (let connectedNode of connectedNodes) {
-          invalidateNode(connectedNode, FILE_CREATE);
-        }
+          requestGraphEdgeTypes.invalidated_by_create_above,
+        )
+      )
+        break;
 
-        dirname = path.dirname(dirname);
+      const connectedNodes = this.getNodeIdsConnectedTo(
+        matchNodeId,
+        requestGraphEdgeTypes.invalidated_by_create,
+      );
+      for (let connectedNode of connectedNodes) {
+        invalidateNode(connectedNode, FILE_CREATE);
       }
-    } else {
-      for (let matchNode of matchNodes) {
-        let matchNodeId = this.getNodeIdByContentKey(matchNode.id);
-        if (
-          this.hasEdge(
-            nodeId,
-            matchNodeId,
-            requestGraphEdgeTypes.invalidated_by_create_above,
-          ) &&
-          isDirectoryInside(
-            fromProjectPathRelative(toProjectPathUnsafe(matchNode.id)),
-            dirname,
-          )
-        ) {
-          let connectedNodes = this.getNodeIdsConnectedTo(
-            matchNodeId,
-            requestGraphEdgeTypes.invalidated_by_create,
-          );
-          for (let connectedNode of connectedNodes) {
-            this.invalidateNode(connectedNode, FILE_CREATE);
-          }
-        }
-      }
+
+      dirname = path.dirname(dirname);
     }
 
     // Find the `file_name` node for the parent directory and
@@ -902,18 +877,13 @@ export class RequestGraph extends ContentGraph<
   async respondToFSEvents(
     events: Array<Event>,
     options: AtlaspackOptions,
-    threshold: number,
   ): Async<boolean> {
     let didInvalidate = false;
-    let count = 0;
-    let predictedTime = 0;
     let startTime = Date.now();
-    const enableOptimization = getFeatureFlag('fixQuadraticCacheInvalidation');
-    const removeOrphans = !enableOptimization;
 
     const invalidatedNodes = new Set();
     const invalidateNode = (nodeId, reason) => {
-      if (enableOptimization && invalidatedNodes.has(nodeId)) {
+      if (invalidatedNodes.has(nodeId)) {
         return;
       }
       invalidatedNodes.add(nodeId);
@@ -922,7 +892,7 @@ export class RequestGraph extends ContentGraph<
     const aboveCache = new Map();
     const getAbove = (fileNameNodeId) => {
       const cachedResult = aboveCache.get(fileNameNodeId);
-      if (enableOptimization && cachedResult) {
+      if (cachedResult) {
         return cachedResult;
       }
 
@@ -942,30 +912,6 @@ export class RequestGraph extends ContentGraph<
     };
 
     for (let {path: _path, type} of events) {
-      if (
-        !enableOptimization &&
-        process.env.ATLASPACK_DISABLE_CACHE_TIMEOUT !== 'true' &&
-        ++count === 256
-      ) {
-        let duration = Date.now() - startTime;
-        predictedTime = duration * (events.length >> 8);
-        if (predictedTime > threshold) {
-          logger.warn({
-            origin: '@atlaspack/core',
-            message:
-              'Building with clean cache. Cache invalidation took too long.',
-            meta: {
-              trackableEvent: 'cache_invalidation_timeout',
-              watcherEventCount: events.length,
-              predictedTime,
-            },
-          });
-          throw new FSBailoutError(
-            'Responding to file system events exceeded threshold, start with empty cache.',
-          );
-        }
-      }
-
       let _filePath = toProjectPath(options.projectRoot, _path);
       let filePath = fromProjectPathRelative(_filePath);
       let hasFileRequest = this.hasContentKey(filePath);
@@ -1064,7 +1010,7 @@ export class RequestGraph extends ContentGraph<
         // Delete the file node since it doesn't exist anymore.
         // This ensures that files that don't exist aren't sent
         // to requests as invalidations for future requests.
-        this.removeNode(nodeId, removeOrphans);
+        this.removeNode(nodeId, false);
       }
 
       let configKeyNodes = this.configKeyNodes.get(_filePath);
@@ -1096,15 +1042,13 @@ export class RequestGraph extends ContentGraph<
               );
             }
             didInvalidate = true;
-            this.removeNode(nodeId, removeOrphans);
+            this.removeNode(nodeId, false);
           }
         }
       }
     }
 
-    if (getFeatureFlag('fixQuadraticCacheInvalidation')) {
-      cleanUpOrphans(this);
-    }
+    cleanUpOrphans(this);
 
     let duration = Date.now() - startTime;
     logger.verbose({
@@ -1113,7 +1057,6 @@ export class RequestGraph extends ContentGraph<
       meta: {
         trackableEvent: 'fsevent_response_time',
         duration,
-        predictedTime,
         numberOfEvents: events.length,
         numberOfInvalidatedNodes: invalidatedNodes.size,
       },

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -5,7 +5,6 @@ import path from 'path';
 
 import {deserialize, serialize} from '@atlaspack/build-cache';
 import type {Cache} from '@atlaspack/cache';
-import {getFeatureFlag} from '@atlaspack/feature-flags';
 import {ContentGraph} from '@atlaspack/graph';
 import type {
   ContentGraphOpts,
@@ -20,7 +19,6 @@ import type {Async, EnvMap} from '@atlaspack/types';
 import {
   type Deferred,
   isGlobMatch,
-  isDirectoryInside,
   makeDeferredWithPromise,
   PromiseQueue,
 } from '@atlaspack/utils';
@@ -1196,8 +1194,8 @@ export default class RequestTracker {
     }
   }
 
-  respondToFSEvents(events: Array<Event>, threshold: number): Async<boolean> {
-    return this.graph.respondToFSEvents(events, this.options, threshold);
+  respondToFSEvents(events: Array<Event>): Async<boolean> {
+    return this.graph.respondToFSEvents(events, this.options);
   }
 
   hasInvalidRequests(): boolean {
@@ -1668,7 +1666,6 @@ async function loadRequestGraph(options): Async<RequestGraph> {
       await requestGraph.respondToFSEvents(
         options.unstableFileInvalidations || events,
         options,
-        10000,
       );
       return requestGraph;
     } catch (e) {

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -12,7 +12,6 @@ import {DEFAULT_OPTIONS} from './test-utils';
 import {FILE_CREATE, FILE_UPDATE, INITIAL_BUILD} from '../src/constants';
 import {makeDeferredWithPromise} from '@atlaspack/utils';
 import {toProjectPath} from '../src/projectPath';
-import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
 
 const options = DEFAULT_OPTIONS;
 const farm = new WorkerFarm({workerPath: require.resolve('../src/worker')});
@@ -467,15 +466,12 @@ describe('RequestTracker', () => {
         input: null,
       });
       const requestId = tracker.graph.getNodeIdByContentKey('abc');
-      const invalidated = await tracker.respondToFSEvents(
-        [
-          {
-            type: 'update',
-            path: 'my-file',
-          },
-        ],
-        Number.MAX_VALUE,
-      );
+      const invalidated = await tracker.respondToFSEvents([
+        {
+          type: 'update',
+          path: 'my-file',
+        },
+      ]);
       assert.equal(invalidated, true);
       assert.equal(
         tracker.graph.getNode(requestId)?.invalidateReason,
@@ -504,15 +500,12 @@ describe('RequestTracker', () => {
         input: null,
       });
       const requestId = tracker.graph.getNodeIdByContentKey('abc');
-      const invalidated = await tracker.respondToFSEvents(
-        [
-          {
-            type: 'create',
-            path: './package.json',
-          },
-        ],
-        Number.MAX_VALUE,
-      );
+      const invalidated = await tracker.respondToFSEvents([
+        {
+          type: 'create',
+          path: './package.json',
+        },
+      ]);
       assert.equal(invalidated, true);
       assert.equal(
         tracker.graph.getNode(requestId)?.invalidateReason,

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -11,7 +11,6 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   atlaspackV3: false,
   useWatchmanWatcher: false,
   importRetry: false,
-  fixQuadraticCacheInvalidation: 'OLD',
   fastOptimizeInlineRequires: false,
   useLmdbJsLite: false,
   conditionalBundlingApi: false,

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -21,10 +21,6 @@ export type FeatureFlags = {|
    */
   useLmdbJsLite: boolean,
   /**
-   * Fixes quadratic cache invalidation issue
-   */
-  fixQuadraticCacheInvalidation: ConsistencyCheckFeatureFlagValue,
-  /**
    * Enable rust based inline requires optimization
    */
   fastOptimizeInlineRequires: boolean,


### PR DESCRIPTION
This change, added in https://github.com/atlassian-labs/atlaspack/pull/105, has been rolled-out.

It improves cache invalidation time by several orders of magnitude on the worst case, after changing branches or reinstalling dependencies.