### PR TITLE
V3: Improve resolver and transformer debug

### DIFF
--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_resolver.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_resolver.rs
@@ -36,7 +36,11 @@ pub struct RpcNodejsResolverPlugin {
 
 impl Debug for RpcNodejsResolverPlugin {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "RpcNodejsResolverPlugin")
+    write!(
+      f,
+      "RpcNodejsResolverPlugin({})",
+      self.plugin_node.package_name
+    )
   }
 }
 

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer.rs
@@ -41,7 +41,7 @@ pub struct NodejsRpcTransformerPlugin {
 
 impl Debug for NodejsRpcTransformerPlugin {
   fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-    write!(f, "RpcTransformerPlugin")
+    write!(f, "RpcTransformerPlugin({})", self.plugin_node.package_name)
   }
 }
 


### PR DESCRIPTION
## Motivation

When encountering errors in the native rewrite, seeing `RpcNodejsResolverPlugin` or `RpcTransformerPlugin` is not useful in the stack trace as it is missing the actual plugin name it has loaded.

## Changes

Update the `Debug` implementations in the rpc transformer and resolver to include the package name

## Checklist

- [x] Existing or new tests cover this change
