### PR TITLE
V3: Fix resolveFrom value

### DIFF
--- a/packages/core/core/src/atlaspack-v3/worker/compat/dependency.js
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/dependency.js
@@ -76,7 +76,7 @@ export class Dependency implements IDependency {
     this.sourceAssetId = inner.sourceAssetId;
     this.sourcePath = inner.sourcePath;
     this.sourceAssetType = inner.sourceAssetType;
-    this.resolveFrom = inner.resolveFrom;
+    this.resolveFrom = inner.resolveFrom ?? inner.sourcePath;
     this.range = inner.range;
     this.pipeline = inner.pipeline;
   }


### PR DESCRIPTION
## Motivation

The compatibility layer for a dependency uses the incorrect `resolveFrom` value that gets set at the start of a resolver in JavaScript.

```javascript
export class ResolverRunner {
  async resolve(dependency: Dependency): Promise<ResolverResult> {
    let dep = getPublicDependency(dependency, this.options);
    // ...
  }
}
```

```javascript
export class Dependency implements IDependency {
 get resolveFrom(): ?string {
    return fromProjectPath(
      this.#options.projectRoot,
      this.#dep.resolveFrom ?? this.#dep.sourcePath,
    );
  }
}
```

Rust plugins currently fallback to the correct resolve from value, and thus do not need to have any of this logic for the time being.

## Changes

Fallback to `sourcePath` for dependency `resolveFrom`

## Checklist

- [x] Existing or new tests cover this change
