### PR TITLE
Fix dev dep request missing 'invalidateOnCreate'

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -55,12 +55,14 @@ import {
   toProjectPath,
   fromProjectPathRelative,
 } from './projectPath';
+import {clearBuildCaches} from '@atlaspack/build-cache';
 import {LMDBLiteCache} from '@atlaspack/cache';
 import {tracer} from '@atlaspack/profiler';
 import {setFeatureFlags, DEFAULT_FEATURE_FLAGS} from '@atlaspack/feature-flags';
 import {AtlaspackV3, FileSystemV3} from './atlaspack-v3';
 import createAssetGraphRequestJS from './requests/AssetGraphRequest';
 import {createAssetGraphRequestRust} from './requests/AssetGraphRequestRust';
+import type {AssetGraphRequestResult} from './requests/AssetGraphRequest';
 
 registerCoreWithSerializer();
 
@@ -276,7 +278,7 @@ export default class Atlaspack {
 
   async _startNextBuild(): Promise<?BuildEvent> {
     this.#watchAbortController = new AbortController();
-    await this.#farm.callAllWorkers('clearConfigCache', []);
+    await this.clearBuildCaches();
 
     try {
       let buildEvent = await this._build({
@@ -484,7 +486,7 @@ export default class Atlaspack {
         await this.stopProfiling();
       }
 
-      await this.#farm.callAllWorkers('clearConfigCache', []);
+      await this.clearBuildCaches();
     }
   }
 
@@ -563,6 +565,15 @@ export default class Atlaspack {
     return this.#farm.takeHeapSnapshot();
   }
 
+  /**
+   * Must be called between builds otherwise there is global state that will
+   * break things unexpectedly.
+   */
+  async clearBuildCaches(): Promise<void> {
+    clearBuildCaches();
+    await this.#farm?.callAllWorkers('clearWorkerBuildCaches', []);
+  }
+
   async unstable_invalidate(): Promise<void> {
     await this._init();
   }
@@ -570,7 +581,9 @@ export default class Atlaspack {
   /**
    * Build the asset graph
    */
-  async unstable_buildAssetGraph(): Promise<void> {
+  async unstable_buildAssetGraph(
+    writeToCache: boolean = true,
+  ): Promise<AssetGraphRequestResult> {
     await this._init();
     const input = {
       optionsRef: this.#optionsRef,
@@ -581,18 +594,20 @@ export default class Atlaspack {
       lazyExcludes: [],
       requestedAssetIds: this.#requestedAssetIds,
     };
-    await this.#requestTracker.runRequest(
+    const result = await this.#requestTracker.runRequest(
       this.rustAtlaspack != null
         ? createAssetGraphRequestRust(this.rustAtlaspack)(input)
         : createAssetGraphRequestJS(input),
     );
-    // eslint-disable-next-line no-console
-    console.log('Done building asset graph!');
-    // eslint-disable-next-line no-console
-    console.log('Write request tracker to cache');
-    await this.writeRequestTrackerToCache();
-    // eslint-disable-next-line no-console
-    console.log('Done writing request tracker to cache');
+    logger.info({message: 'Done building asset graph!'});
+
+    if (writeToCache) {
+      logger.info({message: 'Write request tracker to cache'});
+      await this.writeRequestTrackerToCache();
+      logger.info({message: 'Done writing request tracker to cache'});
+    }
+
+    return result;
   }
 
   async unstable_transform(

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -17,6 +17,7 @@ import type {
   AtlaspackOptions,
   ReportFn,
   RequestInvalidation,
+  DevDepRequestRef,
 } from './types';
 import type {AtlaspackConfig, LoadedPlugin} from './AtlaspackConfig';
 import type InternalBundleGraph from './BundleGraph';
@@ -74,7 +75,7 @@ type Opts = {|
 export type RunPackagerRunnerResult = {|
   bundleInfo: BundleInfo,
   configRequests: Array<ConfigRequest>,
-  devDepRequests: Array<DevDepRequest>,
+  devDepRequests: Array<DevDepRequest | DevDepRequestRef>,
   invalidations: Array<RequestInvalidation>,
 |};
 
@@ -108,7 +109,7 @@ export default class PackagerRunner {
   distExists: Set<FilePath>;
   report: ReportFn;
   previousDevDeps: Map<string, string>;
-  devDepRequests: Map<string, DevDepRequest>;
+  devDepRequests: Map<string, DevDepRequest | DevDepRequestRef>;
   invalidations: Map<string, RequestInvalidation>;
   previousInvalidations: Array<RequestInvalidation>;
 

--- a/packages/core/core/src/Transformation.js
+++ b/packages/core/core/src/Transformation.js
@@ -18,6 +18,7 @@ import type {
   AtlaspackOptions,
   InternalDevDepOptions,
   Invalidations,
+  DevDepRequestRef,
 } from './types';
 import type {LoadedPlugin} from './AtlaspackConfig';
 
@@ -88,13 +89,13 @@ export type TransformationResult = {|
   error?: Array<Diagnostic>,
   configRequests: Array<ConfigRequest>,
   invalidations: Invalidations,
-  devDepRequests: Array<DevDepRequest>,
+  devDepRequests: Array<DevDepRequest | DevDepRequestRef>,
 |};
 
 export default class Transformation {
   request: TransformationRequest;
   configs: Map<string, Config>;
-  devDepRequests: Map<string, DevDepRequest>;
+  devDepRequests: Map<string, DevDepRequest | DevDepRequestRef>;
   pluginDevDeps: Array<InternalDevDepOptions>;
   options: AtlaspackOptions;
   pluginOptions: PluginOptions;

--- a/packages/core/core/src/applyRuntimes.js
+++ b/packages/core/core/src/applyRuntimes.js
@@ -10,6 +10,7 @@ import type {
   Config,
   DevDepRequest,
   AtlaspackOptions,
+  DevDepRequestRef,
 } from './types';
 import type {AtlaspackConfig} from './AtlaspackConfig';
 import type PluginOptions from './public/PluginOptions';
@@ -87,7 +88,7 @@ export default async function applyRuntimes<TResult: RequestResult>({
   pluginOptions: PluginOptions,
   api: RunAPI<TResult>,
   previousDevDeps: Map<string, string>,
-  devDepRequests: Map<string, DevDepRequest>,
+  devDepRequests: Map<string, DevDepRequest | DevDepRequestRef>,
   configs: Map<string, Config>,
 |}): Promise<Map<string, Asset>> {
   let runtimes = await config.getRuntimes();

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -11,6 +11,7 @@ import type {
   Config,
   DevDepRequest,
   AtlaspackOptions,
+  DevDepRequestRef,
 } from '../types';
 import type {ConfigAndCachePath} from './AtlaspackConfigRequest';
 
@@ -199,7 +200,7 @@ class BundlerRunner {
   pluginOptions: PluginOptions;
   api: RunAPI<BundleGraphResult>;
   previousDevDeps: Map<string, string>;
-  devDepRequests: Map<string, DevDepRequest>;
+  devDepRequests: Map<string, DevDepRequest | DevDepRequestRef>;
   configs: Map<string, Config>;
   cacheKey: string;
 
@@ -262,11 +263,13 @@ class BundlerRunner {
     this.configs.set(plugin.name, config);
   }
 
-  async runDevDepRequest(devDepRequest: DevDepRequest) {
+  async runDevDepRequest(devDepRequest: DevDepRequest | DevDepRequestRef) {
     let {specifier, resolveFrom} = devDepRequest;
     let key = `${specifier}:${fromProjectPathRelative(resolveFrom)}`;
-    this.devDepRequests.set(key, devDepRequest);
-    await runDevDepRequest(this.api, devDepRequest);
+    if (devDepRequest.type !== 'ref') {
+      this.devDepRequests.set(key, devDepRequest);
+      await runDevDepRequest(this.api, devDepRequest);
+    }
   }
 
   async bundle({

--- a/packages/core/core/src/requests/PathRequest.js
+++ b/packages/core/core/src/requests/PathRequest.js
@@ -13,6 +13,7 @@ import type {
   Dependency,
   DevDepRequest,
   AtlaspackOptions,
+  DevDepRequestRef,
 } from '../types';
 import type {ConfigAndCachePath} from './AtlaspackConfigRequest';
 
@@ -238,10 +239,12 @@ export class ResolverRunner {
     }
   }
 
-  runDevDepRequest(devDepRequest: DevDepRequest) {
-    let {specifier, resolveFrom} = devDepRequest;
-    let key = `${specifier}:${fromProjectPathRelative(resolveFrom)}`;
-    this.devDepRequests.set(key, devDepRequest);
+  runDevDepRequest(devDepRequest: DevDepRequest | DevDepRequestRef) {
+    if (devDepRequest.type !== 'ref') {
+      let {specifier, resolveFrom} = devDepRequest;
+      let key = `${specifier}:${fromProjectPathRelative(resolveFrom)}`;
+      this.devDepRequests.set(key, devDepRequest);
+    }
   }
 
   async resolve(dependency: Dependency): Promise<ResolverResult> {

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -255,13 +255,20 @@ export type Invalidations = {|
   invalidateOnBuild: boolean,
 |};
 
+export type DevDepRequestRef = {|
+  type: 'ref',
+  specifier: DependencySpecifier,
+  resolveFrom: ProjectPath,
+  hash: string,
+|};
+
 export type DevDepRequest = {|
   specifier: DependencySpecifier,
   resolveFrom: ProjectPath,
   hash: string,
-  invalidateOnFileCreate?: Array<InternalFileCreateInvalidation>,
-  invalidateOnFileChange?: Set<ProjectPath>,
-  invalidateOnStartup?: boolean,
+  invalidateOnFileCreate: Array<InternalFileCreateInvalidation>,
+  invalidateOnFileChange: Set<ProjectPath>,
+  invalidateOnStartup: boolean,
   additionalInvalidations?: Array<{|
     specifier: DependencySpecifier,
     resolveFrom: ProjectPath,

--- a/packages/core/core/src/worker.js
+++ b/packages/core/core/src/worker.js
@@ -85,7 +85,7 @@ async function loadConfig(cachePath, options) {
   return config;
 }
 
-export function clearConfigCache() {
+export function clearWorkerBuildCaches() {
   configCache.clear();
   clearBuildCaches();
 }
@@ -186,4 +186,11 @@ export function invalidateRequireCache(workerApi: WorkerApi, file: string) {
   }
 
   throw new Error('invalidateRequireCache is only for tests');
+}
+
+/**
+ * This is used to wait until workers are responding to messages.
+ */
+export function ping(): boolean {
+  return true;
 }


### PR DESCRIPTION
This commit fixes a long-standing bug in the dev dep request where the 'invalidateOnCreate' property was missing.

The reason this happened was due to an optimisation in the worker to main-thread communication, which ommitted certain fields from the DevDepRequest type when the values were thought to be unnecessary.

This decision was based on a build cache present on the workers. However, at times, this cache was also set on the main-thread.

These build caches were not being cleared on the main-thread, only on the worker threads. This caused the main-thread to sometimes use stale dev-dep requests from a previous build and then throw an exception since those dev-dep requests would execute but be missing the field.

This commit fixes the issue by:

* Ensuring the value exists at a type-level more clearly
* Clearing the build cache on the main-thread between builds

Tests that reproduce this can be found on the experimental bundler branch:

* https://github.com/atlassian-labs/atlaspack/compare/issue/dominators-bundler?expand=1

## Checklist

- [ ] Existing or new tests cover this change
