### PR TITLE
V3: Reject worker errors

### DIFF
--- a/packages/core/core/test/atlaspack-v3/worker-error.js
+++ b/packages/core/core/test/atlaspack-v3/worker-error.js
@@ -1,0 +1,18 @@
+const {parentPort, workerData} = require('worker_threads');
+
+parentPort.on('message', (message) => {
+  if (message.type === 'registerWorker') {
+    if (workerData.attempt === 1) {
+      throw new Error('Failed to register worker');
+    } else {
+      parentPort.postMessage({
+        type: 'workerRegistered',
+      });
+    }
+  } else if (message.type === 'probeStatus') {
+    parentPort.postMessage({
+      type: 'status',
+      status: 'ok',
+    });
+  }
+});


### PR DESCRIPTION
## Motivation

The worker pool does not log errors when the worker fails to startup, which makes debugging / running inspectors difficult when they timeout for other reasons

## Changes

* Listen to worker errors when creating a worker
* Recreate worker from passed in worker path

## Checklist

- [x] Existing or new tests cover this change
