### PR TITLE
´Fix PromiseQueue to remove unhandled rejections

### DIFF
--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1514,11 +1514,7 @@ export default class RequestTracker {
         resultCacheKey != null &&
         node?.result != null
       ) {
-        queue
-          .add(() => serialiseAndSet(resultCacheKey, node.result))
-          .catch(() => {
-            // Handle promise rejection
-          });
+        queue.add(() => serialiseAndSet(resultCacheKey, node.result));
 
         // eslint-disable-next-line no-unused-vars
         let {result: _, ...newNode} = node;
@@ -1547,19 +1543,15 @@ export default class RequestTracker {
         // We assume the request graph nodes are immutable and won't change
         let nodesToCache = cacheableNodes.slice(nodesStartIndex, nodesEndIndex);
 
-        queue
-          .add(() =>
-            serialiseAndSet(
-              getRequestGraphNodeKey(i, cacheKey),
-              nodesToCache,
-            ).then(() => {
-              // Succeeded in writing to disk, save that we have completed this chunk
-              this.graph.setCachedRequestChunk(i);
-            }),
-          )
-          .catch(() => {
-            // Handle promise rejection
-          });
+        queue.add(() =>
+          serialiseAndSet(
+            getRequestGraphNodeKey(i, cacheKey),
+            nodesToCache,
+          ).then(() => {
+            // Succeeded in writing to disk, save that we have completed this chunk
+            this.graph.setCachedRequestChunk(i);
+          }),
+        );
       }
     }
 

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -434,7 +434,7 @@ export class AssetGraphBuilder {
   queueCorrespondingRequest(
     nodeId: NodeId,
     errors: Array<Error>,
-  ): Promise<mixed> {
+  ): Promise<null> {
     let promise;
     let node = nullthrows(this.assetGraph.getNode(nodeId));
     switch (node.type) {
@@ -455,9 +455,16 @@ export class AssetGraphBuilder {
           `Can not queue corresponding request of node with type ${node.type}`,
         );
     }
-    return this.queue.add(() =>
-      promise.then(null, (error) => errors.push(error)),
-    );
+    return new Promise((resolve) => {
+      this.queue.add(() =>
+        promise.then(
+          () => {
+            resolve(null);
+          },
+          (error) => errors.push(error),
+        ),
+      );
+    });
   }
 
   async runEntryRequest(input: ProjectPath) {

--- a/packages/core/package-manager/src/installPackage.js
+++ b/packages/core/package-manager/src/installPackage.js
@@ -222,25 +222,20 @@ export function _addToInstallQueue(
       modulesInstalling.add(getModuleRequestKey(m));
     }
 
-    queue
-      .add(() =>
-        install(
-          fs,
-          packageManager,
-          modulesToInstall,
-          filePath,
-          projectRoot,
-          options,
-        ).then(() => {
-          for (let m of modulesToInstall) {
-            modulesInstalling.delete(getModuleRequestKey(m));
-          }
-        }),
-      )
-      .then(
-        () => {},
-        () => {},
-      );
+    queue.add(() =>
+      install(
+        fs,
+        packageManager,
+        modulesToInstall,
+        filePath,
+        projectRoot,
+        options,
+      ).then(() => {
+        for (let m of modulesToInstall) {
+          modulesInstalling.delete(getModuleRequestKey(m));
+        }
+      }),
+    );
   }
 
   return queue.run();

--- a/packages/core/utils/src/PromiseQueue.js
+++ b/packages/core/utils/src/PromiseQueue.js
@@ -27,8 +27,8 @@ export default class PromiseQueue<T> {
     return this._queue.length;
   }
 
-  add(fn: () => Promise<T>): Promise<T> {
-    return new Promise((resolve, reject) => {
+  add(fn: () => Promise<T>): void {
+    new Promise((resolve, reject) => {
       let i = this._count++;
       let wrapped = () =>
         fn().then(
@@ -51,7 +51,7 @@ export default class PromiseQueue<T> {
       if (this._numRunning > 0 && this._numRunning < this._maxConcurrent) {
         this._next();
       }
-    });
+    }).catch(() => {});
   }
 
   subscribeToAdd(fn: () => void): () => void {

--- a/packages/core/utils/test/PromiseQueue.test.js
+++ b/packages/core/utils/test/PromiseQueue.test.js
@@ -19,11 +19,24 @@ describe('PromiseQueue', () => {
     assert(someBooleanToBeChanged);
   });
 
-  it('run() should reject if the function throws a sync exception', async () => {
+  it('run() should reject if any of the async functions in the queue failed', async () => {
     let error = new Error('some failure');
     try {
       let queue = new PromiseQueue();
       queue.add(() => Promise.reject(error));
+      await queue.run();
+    } catch (e) {
+      assert.equal(e, error);
+    }
+  });
+
+  it('run() should reject if any of the async functions in the queue throwo', async () => {
+    let error = new Error('some failure');
+    try {
+      let queue = new PromiseQueue();
+      queue.add(() => {
+        throw error;
+      });
       await queue.run();
     } catch (e) {
       assert.equal(e, error);
@@ -36,7 +49,7 @@ describe('PromiseQueue', () => {
     // no need to assert, test will hang or throw an error if condition fails
   });
 
-  it(".add() should resolve with the same result when the passed in function's promise resolves", async () => {
+  it('.add() result should bubble into the run results', async () => {
     let queue = new PromiseQueue();
     queue.add(() => Promise.resolve(42));
     const result = await queue.run();

--- a/packages/core/utils/test/PromiseQueue.test.js
+++ b/packages/core/utils/test/PromiseQueue.test.js
@@ -19,15 +19,11 @@ describe('PromiseQueue', () => {
     assert(someBooleanToBeChanged);
   });
 
-  it('run() should reject if any of the async functions in the queue failed', async () => {
+  it('run() should reject if the function throws a sync exception', async () => {
     let error = new Error('some failure');
     try {
       let queue = new PromiseQueue();
-      queue
-        .add(() => Promise.reject(error))
-        .catch(
-          /* catch this to prevent an unhandled promise rejection*/ () => {},
-        );
+      queue.add(() => Promise.reject(error));
       await queue.run();
     } catch (e) {
       assert.equal(e, error);
@@ -42,18 +38,9 @@ describe('PromiseQueue', () => {
 
   it(".add() should resolve with the same result when the passed in function's promise resolves", async () => {
     let queue = new PromiseQueue();
-    let promise = queue.add(() => Promise.resolve(42));
-    await queue.run();
-    let result = await promise;
-    assert.equal(result, 42);
-  });
-
-  it(".add() should reject with the same error when the passed in function's promise rejects", async () => {
-    let queue = new PromiseQueue();
-    let error = new Error('Oh no!');
-    let promise = queue.add(() => Promise.reject(error));
-    await queue.run().catch(() => null);
-    await promise.then(null, (e) => assert.equal(e, error));
+    queue.add(() => Promise.resolve(42));
+    const result = await queue.run();
+    assert.deepEqual(result, [42]);
   });
 
   it('constructor() should allow for configuration of max concurrent running functions', async () => {


### PR DESCRIPTION
The current `PromiseQueue` API is build such that the following code will raise an unhandled rejection error:

```js
const queue = new PromiseQueue();
queue.add(() => Promise.reject(new Error('foo')));
await queue.run();
```

For this reason, most of the codebase uses `PromiseQueue#add` with a catch block around the promise, including its own tests.

As such, the correct usage of the API is:
```js
const queue = new PromiseQueue();
queue.add(() => Promise.reject(new Error('foo'))).catch((err) => {});
await queue.run();
```

All the other usages, that haven't been modified by this commit, were missing this handling and may lead to unhandled rejections crashing threads/workers.

This commit changes the API so that this can't happen, the API can't trigger unhandled exceptions anymore, and the promise is not returned.

The only case that did require a promise to be returned was the `AssetGraphRequest` which is updated to use the new API.

- [x] Existing or new tests cover this change
