### PR TITLE
Add support for CSS modules composes

### DIFF
--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -295,6 +295,9 @@ impl TransformerPlugin for AtlaspackCssTransformerPlugin {
         });
 
         let mut code = format!("module.exports[\"{}\"] = `{}", key, export.name);
+        let unique_key = asset.unique_key.as_ref().ok_or(anyhow!(
+          "CSS modules asset missing unique_key. This should never happen!"
+        ))?;
 
         for reference in export.composes.iter() {
           code.push(' ');
@@ -326,9 +329,10 @@ impl TransformerPlugin for AtlaspackCssTransformerPlugin {
                   self_referenced: true,
                   loc: None,
                 }];
+
                 dependencies.push(Dependency {
                   // Point this at the root asset
-                  specifier: asset.unique_key.as_ref().unwrap().clone(),
+                  specifier: unique_key.clone(),
                   specifier_type: SpecifierType::Esm,
                   symbols: Some(symbols),
                   env: asset.env.clone(),
@@ -370,7 +374,7 @@ impl TransformerPlugin for AtlaspackCssTransformerPlugin {
 
           dependencies.push(Dependency {
             // Point this at the root asset
-            specifier: asset.unique_key.as_ref().unwrap().clone(),
+            specifier: unique_key.clone(),
             specifier_type: SpecifierType::Esm,
             symbols: Some(symbols),
             env: asset.env.clone(),

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -262,6 +262,15 @@ impl TransformerPlugin for AtlaspackCssTransformerPlugin {
         loc: None,
       });
 
+      /// This function handles each CSS export as it is discovered. It runs recursively in cases
+      /// where we discover a CSS module export that is being composed but hasn't been
+      /// registered yet, and hence can't be written as a closure. There is a seen HashSet
+      /// to make sure we only process each export once.
+      ///
+      /// I could refactor this to use a struct but I wanted to keep the code closer to the
+      /// original JS implementation for now as it makes it easier to find any accidental
+      /// divergences
+      #[allow(clippy::too_many_arguments)]
       fn add_css_module_export(
         key: &String,
         export: &CssModuleExport,

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -296,6 +296,8 @@ impl TransformerPlugin for AtlaspackCssTransformerPlugin {
                 .iter()
                 .find(|(_, export)| name == &export.name)
               {
+                // This ensures that the local being referenced is added before
+                // the one composing it
                 add_css_module_export(
                   exported,
                   referenced,

--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -859,4 +859,29 @@ describe('css modules', () => {
       assert(contents.includes('.baz'));
     },
   );
+
+  it('should handle css composes', async function () {
+    await fsFixture(overlayFS, __dirname)`
+      css-composes
+        css-one.module.css:
+          .composed {
+            background: pink;
+          }
+          .foo {
+            composes: composed;
+            color: white;
+          }
+        index.js:
+          import {foo} from './css-one.module.css';
+          export {foo};
+    `;
+
+    let b = await bundle(path.join(__dirname, 'css-composes/index.js'), {
+      inputFS: overlayFS,
+    });
+
+    let result = await run(b);
+
+    assert.equal(result.foo, 'lRcZhq_foo lRcZhq_composed');
+  });
 });


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR adds supports for CSS composes of local and global variables. Note I have not yet added support for the more complex composing of classes from dependencies which is not known to be used internally. 

## Checklist

- [x] Existing or new tests cover this change
