### PR TITLE
V3: Simplify asset and dependency processing

### DIFF
--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -146,6 +146,7 @@ impl AssetGraphBuilder {
       requested_symbols,
       state,
     } = &mut self.graph.dependencies[dep_index];
+
     let asset_request = match result {
       PathRequestOutput::Resolved {
         path,

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -93,7 +93,7 @@ impl Request for AssetRequest {
         if let Ok(source_map) = load_sourcemap_url(
           request_context.file_system(),
           &self.project_root,
-          &asset.file_path,
+          &self.file_path,
           &url_match.url,
         ) {
           asset.map = Some(source_map);
@@ -105,6 +105,9 @@ impl Request for AssetRequest {
     let transform_context = TransformContext::new(self.env.clone());
     let mut result =
       run_pipelines(transform_context, asset, request_context.plugins().clone()).await?;
+
+    // TODO: Commit the asset with a project path now, as transformers rely on an absolute path
+    // result.asset.file_path = to_project_path(&self.project_root, &result.asset.file_path);
 
     result.asset.stats = AssetStats {
       size: result.asset.code.size(),

--- a/crates/atlaspack_core/src/lib.rs
+++ b/crates/atlaspack_core/src/lib.rs
@@ -4,4 +4,5 @@ pub mod cache;
 pub mod config_loader;
 pub mod hash;
 pub mod plugin;
+pub mod project_path;
 pub mod types;

--- a/crates/atlaspack_core/src/project_path.rs
+++ b/crates/atlaspack_core/src/project_path.rs
@@ -1,0 +1,39 @@
+use std::path::{Path, PathBuf};
+
+/// Converts the path so that it is relative to the project root
+pub fn to_project_path(project_root: &Path, file_path: &Path) -> PathBuf {
+  file_path
+    .strip_prefix(project_root)
+    .unwrap_or(file_path)
+    .to_path_buf()
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  mod to_project_path {
+    use super::*;
+
+    #[test]
+    fn returns_file_path_when_outside_project_root() {
+      let file_path = Path::new("test").join("a.js");
+
+      assert_eq!(
+        to_project_path(Path::new("project-root"), &file_path),
+        file_path
+      );
+    }
+
+    #[test]
+    fn returns_project_path_when_inside_project_root() {
+      let project_root = Path::new("project-root");
+      let project_path = Path::new("test").join("a.js");
+
+      assert_eq!(
+        to_project_path(&project_root, &project_root.join(project_path.clone())),
+        project_path
+      );
+    }
+  }
+}

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -11,6 +11,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use serde_json::json;
 
+use crate::project_path::to_project_path;
+
 use super::bundle::MaybeBundleBehavior;
 use super::environment::Environment;
 use super::file_type::FileType;
@@ -276,7 +278,7 @@ impl Asset {
     let id = create_asset_id(CreateAssetIdParams {
       code: None,
       environment_id: &env.id(),
-      file_path: &project_path(project_root, &file_path).to_string_lossy(),
+      file_path: &to_project_path(project_root, &file_path).to_string_lossy(),
       file_type: &file_type,
       pipeline: pipeline.as_deref(),
       query: query.as_deref(),
@@ -313,7 +315,7 @@ impl Asset {
     let id = create_asset_id(CreateAssetIdParams {
       code: None,
       environment_id: &env.id(),
-      file_path: &project_path(project_root, &file_path).to_string_lossy(),
+      file_path: &to_project_path(project_root, &file_path).to_string_lossy(),
       file_type: &file_type,
       pipeline: None,
       query: None,
@@ -350,7 +352,7 @@ impl Asset {
     let id = create_asset_id(CreateAssetIdParams {
       code: Some(code.as_str()),
       environment_id: &source_asset.env.id(),
-      file_path: &project_path(project_root, &source_asset.file_path).to_string_lossy(),
+      file_path: &to_project_path(project_root, &source_asset.file_path).to_string_lossy(),
       file_type: &file_type,
       pipeline: None,
       query: None,
@@ -406,13 +408,6 @@ impl Asset {
     self.conditions = conditions.clone();
     self.meta.insert("conditions".into(), json!(conditions));
   }
-}
-
-fn project_path(project_root: &Path, file_path: &Path) -> PathBuf {
-  file_path
-    .strip_prefix(project_root)
-    .unwrap_or(file_path)
-    .to_path_buf()
 }
 
 /// Statistics that pertain to an asset

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -9,7 +9,6 @@ import type {Async} from '@atlaspack/types';
 import AssetGraph, {nodeFromAssetGroup} from '../AssetGraph';
 import type {AtlaspackV3} from '../atlaspack-v3';
 import {ATLASPACK_VERSION} from '../constants';
-import {toProjectPath} from '../projectPath';
 import {requestTypes, type StaticRunOpts} from '../RequestTracker';
 import {propagateSymbols} from '../SymbolPropagation';
 import type {Environment} from '../types';
@@ -166,36 +165,13 @@ function getAssetGraph(serializedGraph, options) {
       let asset = node.value;
       let id = asset.id;
 
+      asset.committed = true;
+      asset.contentKey = id;
+      asset.env.id = getEnvId(asset.env);
       asset.meta.id = id;
-
-      asset = {
-        ...asset,
-        uniqueKey: asset.uniqueKey ?? undefined,
-        pipeline: asset.pipeline ?? undefined,
-        range: asset.range ?? undefined,
-        resolveFrom: asset.resolveFrom ?? undefined,
-        target: asset.target ?? undefined,
-        plugin: asset.plugin ?? undefined,
-        query: asset.query ?? undefined,
-        configPath: asset.configPath ?? undefined,
-        configKeyPath: asset.configKeyPath ?? undefined,
-        isLargeBlob: asset.isLargeBlob ?? false,
-        isSource: asset.isSource ?? false,
-        sourcePath: asset.sourcePath ?? undefined,
-        env: {
-          ...asset.env,
-          loc: asset.env.loc ?? undefined,
-          id: getEnvId(asset.env),
-          sourceType: asset.env.sourceType,
-        },
-        bundleBehavior:
-          asset.bundleBehavior === 255 ? null : asset.bundleBehavior,
-        committed: true,
-        contentKey: id,
-        filePath: toProjectPath(options.projectRoot, asset.filePath),
-        symbols:
-          asset.symbols != null ? new Map(asset.symbols.map(mapSymbols)) : null,
-      };
+      if (asset.symbols != null) {
+        asset.symbols = new Map(asset.symbols.map(mapSymbols));
+      }
 
       if (asset.map) {
         let mapKey = hashString(`${ATLASPACK_VERSION}:map:${asset.id}`);
@@ -222,42 +198,16 @@ function getAssetGraph(serializedGraph, options) {
       let id = node.value.id;
       let dependency = node.value.dependency;
 
-      dependency = {
-        ...dependency,
-        id,
-        env: {
-          ...dependency.env,
-          id: getEnvId(dependency.env),
-          sourceType: dependency.env.sourceType,
-          loc: dependency.env.loc ?? undefined,
-        },
-        pipeline: dependency.pipeline ?? undefined,
-        range: dependency.range ?? undefined,
-        resolveFrom: dependency.resolveFrom ?? undefined,
-        target: dependency.target ?? undefined,
-        bundleBehavior:
-          dependency.bundleBehavior === 255 ? null : dependency.bundleBehavior,
-        contentKey: id,
-        loc: dependency.loc
-          ? {
-              ...dependency.loc,
-              filePath: toProjectPath(
-                options.projectRoot,
-                dependency.loc.filePath,
-              ),
-            }
-          : undefined,
-        sourcePath: dependency.sourcePath
-          ? toProjectPath(options.projectRoot, dependency.sourcePath)
-          : undefined,
-        symbols:
-          // Dependency.symbols are always set to an empty map when scope hoisting
-          // is enabled. Some tests will fail if this is not the case. We should
-          // make this consistant when we re-visit packaging.
-          dependency.symbols != null || dependency.env.shouldScopeHoist
-            ? new Map(dependency.symbols?.map(mapSymbols))
-            : undefined,
-      };
+      dependency.id = id;
+      dependency.env.id = getEnvId(dependency.env);
+
+      // Dependency.symbols are always set to an empty map when scope hoisting
+      // is enabled. Some tests will fail if this is not the case. We should
+      // make this consistant when we re-visit packaging.
+      if (dependency.symbols != null || dependency.env.shouldScopeHoist) {
+        dependency.symbols = new Map(dependency.symbols?.map(mapSymbols));
+      }
+
       let usedSymbolsDown = new Set();
       let usedSymbolsUp = new Map();
       if (dependency.isEntry && dependency.isLibrary) {


### PR DESCRIPTION
## Motivation

Once the rust based asset graph is returned, adding all the nodes to the JavaScript based asset graph is quite slow. These changes reduce the amount of fields that are changed to what is necessary. Both the three-js benchmarks and an internal product build show a ~45-65% improvement on the `getAssetGraph` function with these changes.

| Benchmark  | Before | After | Improvement
| - | - | - | - |
| internal | 11.40s | 4.09s | -7.31s (64.14%) |
| three-js | 1.28s  | 0.68s  | -0.6s (46.88%) |

## Changes

* Mutate asset and dependency values
* Only change what is needed

## Checklist

- [x] Existing or new tests cover this change
