### PR TITLE
Fix default engines handling

### DIFF
--- a/benchmarks/three-js/scripts/build.mjs
+++ b/benchmarks/three-js/scripts/build.mjs
@@ -211,11 +211,17 @@ async function main() {
       await atlaspack[FUNCTION]();
 
       const buildTime = Date.now() - startTime;
-      console.log(`Build ${i + 1} took ${buildTime}ms`);
+      console.log(`Build ${i + 1}: ${buildTime}ms`);
       buildTimes.push(buildTime);
     }
 
+    const average =
+      buildTimes.reduce((total, time) => total + time, 0) / buildTimes.length;
+
+    console.log(`Benchmarks completed with an average time of ${average}ms`);
+
     await writeJson(join(benchDir, 'report.json'), {
+      average,
       buildTimes,
     });
   } catch (err) {

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -64,16 +64,22 @@ impl Request for AssetRequest {
 
     let start = Instant::now();
 
+    let code = if let Some(code) = self.code.as_ref() {
+      Code::from(code.to_owned())
+    } else {
+      let code_from_disk = request_context.file_system().read(&self.file_path)?;
+      Code::new(code_from_disk)
+    };
+
     let mut asset = Asset::new(
+      code,
       self.env.clone(),
       self.file_path.clone(),
-      request_context.file_system().clone(),
       self.pipeline.clone(),
       &self.project_root,
-      self.code.clone(),
-      self.side_effects,
       self.query.clone(),
-    )?;
+      self.side_effects,
+    );
 
     // Load an existing sourcemap if available for valid file types
     if matches!(

--- a/crates/atlaspack_core/src/plugin/resolver_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/resolver_plugin.rs
@@ -16,6 +16,7 @@ use crate::types::Priority;
 
 // TODO Diagnostics and invalidations
 
+#[derive(Debug)]
 pub struct ResolveContext {
   pub dependency: Arc<Dependency>,
   pub pipeline: Option<String>,

--- a/crates/atlaspack_core/src/types/environment/engines.rs
+++ b/crates/atlaspack_core/src/types/environment/engines.rs
@@ -16,7 +16,11 @@ pub enum EnginesBrowsers {
 
 impl Default for EnginesBrowsers {
   fn default() -> Self {
-    Self::List(vec![String::from("> 0.25%")])
+    Self::List(vec![
+      String::from("last 2 versions"),
+      String::from("> 0.25%"),
+      String::from("not dead"),
+    ])
   }
 }
 

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -292,8 +292,7 @@ impl TransformerPlugin for AtlaspackJsTransformerPlugin {
         },
         supports_module_workers: env.should_scope_hoist
           && env.engines.supports(EnvironmentFeature::WorkerModule),
-        // TODO: Update transformer to use engines directly
-        targets: Some(targets),
+        targets: (!targets.is_empty()).then_some(targets),
         trace_bailouts: self.options.log_level == LogLevel::Verbose,
         use_define_for_class_fields: compiler_options
           .map(|co| {
@@ -332,7 +331,10 @@ mod tests {
   use atlaspack_core::{
     config_loader::ConfigLoader,
     plugin::PluginLogger,
-    types::{Code, Dependency, Environment, Location, SourceLocation, SpecifierType, Symbol},
+    types::{
+      Code, Dependency, Environment, EnvironmentContext, Location, SourceLocation, SpecifierType,
+      Symbol,
+    },
   };
   use atlaspack_filesystem::in_memory_file_system::InMemoryFileSystem;
 
@@ -348,38 +350,24 @@ mod tests {
   }
 
   fn create_asset(project_root: &Path, file_path: &str, code: &str) -> Asset {
-    let file_system = Arc::new(InMemoryFileSystem::default());
     let env = Arc::new(Environment::default());
 
     Asset::new(
+      Code::from(code),
       env.clone(),
       file_path.into(),
-      file_system.clone(),
       None,
       project_root,
-      Some(String::from(code)),
-      false,
       None,
+      false,
     )
-    .unwrap()
-  }
-
-  #[test]
-  fn test_asset_id_is_stable() {
-    let project_root = Path::new("/root");
-    let asset_1 = create_asset(project_root, "mock_path", "function hello() {}");
-    let asset_2 = create_asset(project_root, "mock_path", "function helloButDifferent() {}");
-
-    // This nº should not change across runs / compilation
-    assert_eq!(asset_1.id, "4711cac63cb78f2f");
-    assert_eq!(asset_1.id, asset_2.id);
   }
 
   #[tokio::test(flavor = "multi_thread")]
-  async fn test_transformer_on_noop_asset() {
+  async fn test_transformer_on_noop_asset() -> anyhow::Result<()> {
     let project_root = Path::new("/root");
     let target_asset = create_asset(project_root, "mock_path.js", "function hello() {}");
-    let result = run_test(target_asset.clone()).await.unwrap();
+    let result = run_test(&project_root, target_asset.clone()).await?;
 
     assert_eq!(
       result,
@@ -390,7 +378,6 @@ mod tests {
           // SWC inserts a newline here
           code: Code::from(String::from("function hello() {}\n")),
           symbols: Some(Vec::new()),
-          unique_key: None,
           ..target_asset
         },
         discovered_assets: vec![],
@@ -398,6 +385,38 @@ mod tests {
         invalidate_on_file_change: vec![]
       }
     );
+
+    Ok(())
+  }
+
+  #[tokio::test(flavor = "multi_thread")]
+  async fn uses_latest_node_when_no_node_target() -> anyhow::Result<()> {
+    let project_root = Path::new("/root");
+    let target_asset = Asset {
+      env: Arc::new(Environment {
+        context: EnvironmentContext::Node,
+        ..Environment::default()
+      }),
+      ..create_asset(project_root, "index.js", "const test = () => {};")
+    };
+
+    assert_eq!(
+      run_test(&project_root, target_asset.clone()).await?,
+      TransformResult {
+        asset: Asset {
+          // This asserts that the code has not been downlevelled into `var test = function() {}`
+          code: Code::from(String::from("const test = ()=>{};\n")),
+          file_path: "index.js".into(),
+          symbols: Some(Vec::new()),
+          ..target_asset
+        },
+        discovered_assets: vec![],
+        dependencies: vec![],
+        invalidate_on_file_change: vec![]
+      }
+    );
+
+    Ok(())
   }
 
   #[tokio::test(flavor = "multi_thread")]
@@ -410,7 +429,7 @@ mod tests {
     let project_root = Path::new("/root");
     let target_asset = create_asset(project_root, "mock_path.js", source_code);
     let asset_id = target_asset.id.clone();
-    let result = run_test(target_asset).await.unwrap();
+    let result = run_test(&project_root, target_asset).await.unwrap();
 
     let mut expected_dependencies = vec![Dependency {
       loc: Some(SourceLocation {
@@ -452,7 +471,7 @@ mod tests {
           file_type: FileType::Js,
           // SWC inserts a newline here
           code: Code::from(String::from(
-            "var x = require(\"e83f3db3d6f57ea6\");\nexports.hello = function() {};\n"
+            "const x = require(\"e83f3db3d6f57ea6\");\nexports.hello = function() {};\n"
           )),
           symbols: Some(vec![
             Symbol {
@@ -498,24 +517,23 @@ mod tests {
     );
   }
 
-  async fn run_test(asset: Asset) -> anyhow::Result<TransformResult> {
+  async fn run_test(project_root: &Path, asset: Asset) -> anyhow::Result<TransformResult> {
     let file_system = Arc::new(InMemoryFileSystem::default());
-    let project_root = PathBuf::default();
 
     file_system.write_file(&project_root.join("package.json"), String::from("{}"));
 
     let ctx = PluginContext {
       config: Arc::new(ConfigLoader {
         fs: file_system.clone(),
-        project_root: project_root.clone(),
-        search_path: project_root.clone(),
+        project_root: project_root.to_path_buf(),
+        search_path: project_root.to_path_buf(),
       }),
       file_system,
       logger: PluginLogger::default(),
       options: Arc::new(PluginOptions::default()),
     };
 
-    let transformer = AtlaspackJsTransformerPlugin::new(&ctx).expect("Expected transformer");
+    let transformer = AtlaspackJsTransformerPlugin::new(&ctx)?;
     let context = TransformContext::default();
 
     let result = transformer.transform(context, asset).await?;

--- a/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
+++ b/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
@@ -33,10 +33,8 @@ export class AtlaspackV3 {
     options.logLevel = options.logLevel || 'error';
     options.defaultTargetOptions = options.defaultTargetOptions || {};
     // $FlowFixMe "engines" are readonly
-    options.defaultTargetOptions.engines = options.defaultTargetOptions
-      .engines || {
-      browsers: [],
-    };
+    options.defaultTargetOptions.engines =
+      options.defaultTargetOptions.engines || {};
 
     this._internal = AtlaspackNapi.create(
       {

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -2108,6 +2108,10 @@ describe.v2('bundler', function () {
           shouldScopeHoist: false,
           shouldOptimize: false,
           sourceMaps: false,
+          // TODO: The default engines should split into 3 bundles, this might be a bug?
+          engines: {
+            browsers: ['last 1 Chrome version'],
+          },
         },
         inputFS: overlayFS,
       });

--- a/packages/core/integration-tests/test/integration/formats/commonjs-helpers/package.json
+++ b/packages/core/integration-tests/test/integration/formats/commonjs-helpers/package.json
@@ -2,6 +2,6 @@
   "main": "dist/main.js",
   "browserslist": "Chrome 70",
   "dependencies": {
-    "@swc/helpers": "^0.5.0"
+    "@swc/helpers": "^0.5.15"
   }
 }

--- a/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
+++ b/packages/core/integration-tests/test/integration/swc-helpers-library/package.json
@@ -3,6 +3,6 @@
   "module": "dist/module.js",
   "browserslist": "IE >= 11",
   "dependencies": {
-    "@swc/helpers": "^0.5.0"
+    "@swc/helpers": "^0.5.15"
   }
 }

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1073,6 +1073,10 @@ describe('output formats', function () {
           mode: 'production',
           defaultTargetOptions: {
             shouldOptimize: false,
+            // TODO: The default engines should support workers of type module, this might be a bug
+            engines: {
+              browsers: ['last 1 Chrome version'],
+            },
           },
         },
       );

--- a/packages/core/integration-tests/test/workers.js
+++ b/packages/core/integration-tests/test/workers.js
@@ -259,6 +259,10 @@ describe('atlaspack', function () {
         defaultTargetOptions: {
           shouldOptimize: false,
           shouldScopeHoist: true,
+          // TODO: The default engines should support workers of type module, this might be a bug
+          engines: {
+            browsers: ['last 1 Chrome version'],
+          },
         },
       },
     );

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -129,10 +129,6 @@ export function getParcelOptions(
       shouldContentHash: true,
       defaultTargetOptions: {
         distDir,
-        engines: {
-          browsers: ['last 1 Chrome version'],
-          node: '8',
-        },
       },
       featureFlags: {
         atlaspackV3: isAtlaspackV3,

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -7,7 +7,7 @@
     "start": "atlaspack src/index.html --https --open"
   },
   "dependencies": {
-    "@swc/helpers": "^0.5.0",
+    "@swc/helpers": "^0.5.15",
     "lodash": "^4.17.11",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -30,7 +30,7 @@
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/utils": "2.12.0",
     "@atlaspack/workers": "2.12.0",
-    "@swc/helpers": "^0.5.0",
+    "@swc/helpers": "^0.5.15",
     "browserslist": "^4.6.6",
     "nullthrows": "^1.1.1",
     "regenerator-runtime": "^0.13.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3383,12 +3383,12 @@
   dependencies:
     tslib "^2.4.0"
 
-"@swc/helpers@^0.5.0":
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.3.tgz#98c6da1e196f5f08f977658b80d6bd941b5f294f"
-  integrity sha512-FaruWX6KdudYloq1AHD/4nU+UsMTdNE8CKyrseXWEcgjDAbvkwJg2QGPAnfIJLIWsjZOSPLOAykK6fuYp4vp4A==
+"@swc/helpers@^0.5.15":
+  version "0.5.15"
+  resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.15.tgz#79efab344c5819ecf83a43f3f9f811fc84b516d7"
+  integrity sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==
   dependencies:
-    tslib "^2.4.0"
+    tslib "^2.8.0"
 
 "@swc/types@^0.1.12":
   version "0.1.12"
@@ -15603,6 +15603,11 @@ tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.2.tgz#703ac29425e7b37cd6fd456e92404d46d1f3e4ae"
   integrity sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==
+
+tslib@^2.8.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
## Motivation

During the recent [swc bump](https://github.com/atlassian-labs/atlaspack/pull/171), v3 broke running internally as the `@swc/helpers/_/_call_super` module could not be found. This issue occurred for a few reasons that these changes try to rectify:
* The `@swc/helpers` dependency was not updated to the latest version in the js transformer
* Integration tests default to the latest features, so any polyfills and modules added by swc are not accurately verified in the test suite
* The rust default browser engines specified `> 0.25%` browsers which is the same as the v2 environment defaults, however usually the defaults from the v2 target request are used and these are different

## Changes

* Add a test case that replicates the issue encountered internally with missing helpers
* Bump `@swc/helpers` dependency to latest
* Update the text in benchmarks to include average (note that this change did not meaningfully impact performance)
* Extract fs out of asset for easier asset creation and to reduce coupling with the resolver code
* Move the asset stable id test to the asset file instead of the js transformer
* Update target request to better handle default engines browsers, and modify relevant tests with the expected output
* Update default engines browsers to what is recommended by browserslist, which is roughly equivalent to the internally Atlassian supported browsers
* Fix js transformer so `targets` is None when the processed object is empty to ensure node is not down levelled unnecessarily, and add corresponding test
* Fix default target options engines defaults for browsers when constructing rust v3
* Remove default target options for all integration tests to prevent this issue from reoccurring, as it will unmask errors that occur with default engines
* Skip or update relevant tests with comments

## Checklist

- [x] Existing or new tests cover this change
