### PR TITLE
Add manifest path support to conditional reporter

### DIFF
--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -378,6 +378,9 @@ export default class BundleGraph<TBundle: IBundle>
               dep,
               bundleToInternalBundle(bundle),
             ),
+            `Failed to load depenendency for '${
+              dep.specifier
+            }' specifier from '${String(dep.sourcePath)}'`,
           );
           if (resolvedAsync?.type === 'asset') {
             // Single bundle to load dynamically
@@ -390,6 +393,9 @@ export default class BundleGraph<TBundle: IBundle>
                       dep,
                       bundleToInternalBundle(bundle),
                     ),
+                    `Failed to load referenced bundle for '${
+                      dep.specifier
+                    }' specifier from '${String(dep.sourcePath)}'`,
                   ),
                   this.#graph,
                   this.#options,

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -51,6 +51,8 @@ module.exports = {
     'no-return-await': 'error',
     'require-atomic-updates': 'off',
     'require-await': 'error',
+    'monorepo/no-relative-import': 'off',
+    '@atlaspack/no-relative-import': 'error',
   },
   settings: {
     flowtype: {

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -34,7 +34,7 @@ module.exports = {
       rules: {
         'import/no-extraneous-dependencies': 'off',
         'monorepo/no-internal-import': 'off',
-        'monorepo/no-relative-import': 'off',
+        '@atlaspack/no-relative-import': 'off',
         'mocha/no-exclusive-tests': 'error',
       },
     },
@@ -51,6 +51,7 @@ module.exports = {
     'no-return-await': 'error',
     'require-atomic-updates': 'off',
     'require-await': 'error',
+    // Use internal rule
     'monorepo/no-relative-import': 'off',
     '@atlaspack/no-relative-import': 'error',
   },

--- a/packages/dev/eslint-plugin/index.js
+++ b/packages/dev/eslint-plugin/index.js
@@ -4,5 +4,6 @@ module.exports = {
   rules: {
     'no-self-package-imports': require('./src/rules/no-self-package-imports'),
     'no-ff-module-level-eval': require('./src/rules/no-ff-module-level-eval'),
+    'no-relative-import': require('./src/rules/no-relative-import'),
   },
 };

--- a/packages/dev/eslint-plugin/package.json
+++ b/packages/dev/eslint-plugin/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "scripts": {},
   "dependencies": {
+    "eslint-module-utils": "^2.1.1",
+    "get-monorepo-packages": "^1.1.0",
+    "minimatch": "^3.0.4",
+    "path-is-inside": "^1.0.2",
     "read-pkg-up": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/dev/eslint-plugin/src/rules/no-relative-import.js
+++ b/packages/dev/eslint-plugin/src/rules/no-relative-import.js
@@ -1,0 +1,93 @@
+// Forked from https://github.com/azz/eslint-plugin-monorepo/blob/master/src/rules/no-relative-import.js
+
+/**
+ * MIT License
+
+  Copyright (c) 2017 Lucas Azzola
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
+ */
+
+const moduleVisitor = require('eslint-module-utils/moduleVisitor');
+
+const getPackages = require('get-monorepo-packages');
+const isInside = require('path-is-inside');
+const minimatch = require('minimatch');
+const _path = require('path');
+const resolve = require('eslint-module-utils/resolve');
+
+const getPackageDir = (filePath, packages) => {
+  const match = packages.find((pkg) =>
+    minimatch(filePath, _path.join(pkg.location, '**')),
+  );
+  if (match) {
+    return match.location;
+  }
+};
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Disallow usage of relative imports instead of package names in monorepo',
+    },
+    fixable: 'code',
+  },
+  create(context) {
+    const {
+      options: [moduleUtilOptions],
+    } = context;
+    const sourceFsPath = context.getFilename();
+    const packages = getPackages(process.cwd());
+
+    return moduleVisitor.default((node) => {
+      const resolvedPath = resolve.default(node.value, context);
+      const packageDir = getPackageDir(sourceFsPath, packages);
+
+      if (!packageDir || !resolvedPath || isInside(resolvedPath, packageDir)) {
+        return;
+      }
+
+      const pkg = packages.find((pkg) => isInside(resolvedPath, pkg.location));
+      if (!pkg) {
+        return;
+      }
+
+      const subPackagePath = _path.relative(pkg.location, resolvedPath);
+      context.report({
+        node,
+        message: `Import for monorepo package '${pkg.package.name}' should be absolute.`,
+        fix: (fixer) => {
+          const basePath =
+            '' +
+            pkg.package.name +
+            (subPackagePath !== '.' ? '/' + subPackagePath : '');
+          const path = _path.parse(basePath).dir;
+          const name = _path.parse(basePath).name;
+          return fixer.replaceText(
+            node,
+            "'" +
+              (name !== '.' && name !== 'index' ? path + '/' + name : path) +
+              "'",
+          );
+        },
+      });
+    }, moduleUtilOptions);
+  },
+};

--- a/packages/dev/eslint-plugin/src/rules/no-relative-import.js
+++ b/packages/dev/eslint-plugin/src/rules/no-relative-import.js
@@ -78,16 +78,19 @@ module.exports = {
         node,
         message: `Import for monorepo package '${pkg.package.name}' should be absolute.`,
         fix: (fixer) => {
-          const {dir, name} = parse(
+          let {dir, name} = parse(
             `${pkg.package.name}${
               subPackagePath !== '.' ? `/${subPackagePath}` : ''
             }`,
           );
 
-          return fixer.replaceText(
-            node,
-            `'${name !== '.' && name !== 'index' ? `${dir}/${name}` : dir}'`,
-          );
+          if (name !== '.' && name !== 'index') {
+            // Remove unneeded suffix
+            return fixer.replaceText(node, `'${dir}/${name}'`);
+          } else {
+            dir = dir.replace(/\/(src)|(lib)/, '');
+            return fixer.replaceText(node, `'${dir}'`);
+          }
         },
       });
     }, moduleUtilOptions);

--- a/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
+++ b/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
@@ -13,14 +13,14 @@ new RuleTester({
   valid: [{code: "import logger from '@atlaspack/logger';", filename}],
   invalid: [
     {
-      code: `import Logger from '../../../../core/logger';`,
+      code: `import Logger from '../../../../core/logger/src/Logger';`,
       errors: [
         {
           message: `Import for monorepo package '@atlaspack/logger' should be absolute.`,
         },
       ],
       filename,
-      output: "import Logger from '@atlaspack/logger/lib/Logger';",
+      output: "import Logger from '@atlaspack/logger/src/Logger';",
     },
     {
       code: `import type { PluginOptions } from '../../../../core/types-internal/src';`,

--- a/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
+++ b/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
@@ -1,4 +1,5 @@
 'use strict';
+// @flow
 
 const {RuleTester} = require('eslint');
 const rule = require('../../src/rules/no-relative-import');
@@ -12,14 +13,24 @@ new RuleTester({
   valid: [{code: "import logger from '@atlaspack/logger';", filename}],
   invalid: [
     {
-      code: "import logger from '../../../../core/logger';",
+      code: `import Logger from '../../../../core/logger';`,
       errors: [
         {
           message: `Import for monorepo package '@atlaspack/logger' should be absolute.`,
         },
       ],
       filename,
-      output: "import logger from '@atlaspack/logger/lib/Logger';",
+      output: "import Logger from '@atlaspack/logger/lib/Logger';",
+    },
+    {
+      code: `import type { PluginOptions } from '../../../../core/types-internal/src';`,
+      errors: [
+        {
+          message: `Import for monorepo package '@atlaspack/types-internal' should be absolute.`,
+        },
+      ],
+      filename,
+      output: "import type { PluginOptions } from '@atlaspack/types-internal';",
     },
   ],
 });

--- a/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
+++ b/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const {RuleTester} = require('eslint');
+const rule = require('../../src/rules/no-relative-import');
+
+const filename = __filename;
+
+new RuleTester({
+  parser: require.resolve('@babel/eslint-parser'),
+  parserOptions: {ecmaVersion: 2018, sourceType: 'module'},
+}).run('no-relative-import', rule, {
+  valid: [{code: "import logger from '@atlaspack/logger';", filename}],
+  invalid: [
+    {
+      code: "import logger from '../../../../core/logger';",
+      errors: [
+        {
+          message: `Import for monorepo package '@atlaspack/logger' should be absolute.`,
+        },
+      ],
+      filename,
+      output: "import logger from '@atlaspack/logger/Logger';",
+    },
+  ],
+});

--- a/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
+++ b/packages/dev/eslint-plugin/test/rules/no-relative-import.test.js
@@ -19,7 +19,7 @@ new RuleTester({
         },
       ],
       filename,
-      output: "import logger from '@atlaspack/logger/Logger';",
+      output: "import logger from '@atlaspack/logger/lib/Logger';",
     },
   ],
 });

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -1,62 +1,102 @@
 // @flow strict-local
 import {relative, join} from 'path';
 import {Reporter} from '@atlaspack/plugin';
+import type {
+  Async,
+  PluginLogger,
+  PluginOptions,
+  PluginTracer,
+  ReporterEvent,
+} from '@atlaspack/types-internal';
 
-export default (new Reporter({
-  async report({event, options, logger}) {
-    if (event.type === 'buildSuccess') {
-      const bundles = event.bundleGraph.getConditionalBundleMapping();
+type Config = {|
+  filename: string,
+|};
 
-      // Replace bundles with file paths
-      const mapBundles = (bundles) =>
-        bundles.map((bundle) =>
-          relative(bundle.target.distDir, bundle.filePath),
-        );
+// Exported for testing
+export async function getConfig({
+  env,
+  inputFS,
+  projectRoot,
+}: PluginOptions): Promise<Config> {
+  const packageJson = JSON.parse(
+    await inputFS.readFile(join(projectRoot, 'package.json'), 'utf8'),
+  );
 
-      const manifest = {};
-      for (const [bundle, conditions] of bundles.entries()) {
-        const bundleInfo = {};
-        for (const [key, cond] of conditions) {
-          bundleInfo[key] = {
-            ifTrueBundles: mapBundles(cond.ifTrueBundles).reverse(),
-            ifFalseBundles: mapBundles(cond.ifFalseBundles).reverse(),
-          };
-        }
+  const config = packageJson['@atlaspack/reporter-conditional-manifest'] ?? {};
+  for (const [key, value] of Object.entries(config)) {
+    // Replace values in the format of ${VARIABLE} with their corresponding env
+    if (typeof value === 'string') {
+      config[key] = value.replace(/\${([^}]+)}/g, (_, v) => env[v] ?? '');
+    }
+  }
 
-        manifest[bundle.target.name] ??= {};
-        manifest[bundle.target.name][
-          relative(bundle.target.distDir, bundle.filePath)
-        ] = bundleInfo;
+  const {filename} = config;
+
+  return {
+    filename: filename ?? 'conditional-manifest.json',
+  };
+}
+
+async function report({
+  event,
+  options,
+  logger,
+}: {|
+  event: ReporterEvent,
+  options: PluginOptions,
+  logger: PluginLogger,
+  tracer: PluginTracer,
+|}): Async<void> {
+  const {filename} = await getConfig(options);
+
+  if (event.type === 'buildSuccess') {
+    const bundles = event.bundleGraph.getConditionalBundleMapping();
+
+    // Replace bundles with file paths
+    const mapBundles = (bundles) =>
+      bundles.map((bundle) => relative(bundle.target.distDir, bundle.filePath));
+
+    const manifest = {};
+    for (const [bundle, conditions] of bundles.entries()) {
+      const bundleInfo = {};
+      for (const [key, cond] of conditions) {
+        bundleInfo[key] = {
+          ifTrueBundles: mapBundles(cond.ifTrueBundles).reverse(),
+          ifFalseBundles: mapBundles(cond.ifFalseBundles).reverse(),
+        };
       }
 
-      // Error if there are multiple targets in the build
-      const targets = new Set(
-        event.bundleGraph.getBundles().map((bundle) => bundle.target),
+      manifest[bundle.target.name] ??= {};
+      manifest[bundle.target.name][
+        relative(bundle.target.distDir, bundle.filePath)
+      ] = bundleInfo;
+    }
+
+    const targets = new Set(
+      event.bundleGraph.getBundles().map((bundle) => bundle.target),
+    );
+
+    for (const target of targets) {
+      const conditionalManifestFilename = join(target.distDir, filename);
+
+      const conditionalManifest = JSON.stringify(
+        manifest[target.name],
+        null,
+        2,
       );
 
-      for (const target of targets) {
-        const conditionalManifestFilename = join(
-          target.distDir,
-          'conditional-manifest.json',
-        );
+      await options.outputFS.writeFile(
+        conditionalManifestFilename,
+        conditionalManifest,
+        {mode: 0o666},
+      );
 
-        const conditionalManifest = JSON.stringify(
-          manifest[target.name],
-          null,
-          2,
-        );
-
-        await options.outputFS.writeFile(
-          conditionalManifestFilename,
-          conditionalManifest,
-          {mode: 0o666},
-        );
-
-        logger.info({
-          message:
-            'Wrote conditional manifest to ' + conditionalManifestFilename,
-        });
-      }
+      logger.info({
+        message: 'Wrote conditional manifest to ' + conditionalManifestFilename,
+      });
     }
-  },
-}): Reporter);
+  }
+}
+
+export default (new Reporter({report}): Reporter);

--- a/packages/reporters/conditional-manifest/src/Config.js
+++ b/packages/reporters/conditional-manifest/src/Config.js
@@ -1,0 +1,31 @@
+// @flow strict-local
+import {join} from 'path';
+import type {PluginOptions} from '@atlaspack/types-internal';
+
+type Config = {|
+  filename: string,
+|};
+
+export async function getConfig({
+  env,
+  inputFS,
+  projectRoot,
+}: PluginOptions): Promise<Config> {
+  const packageJson = JSON.parse(
+    await inputFS.readFile(join(projectRoot, 'package.json'), 'utf8'),
+  );
+
+  const config = packageJson['@atlaspack/reporter-conditional-manifest'] ?? {};
+  for (const [key, value] of Object.entries(config)) {
+    // Replace values in the format of ${VARIABLE} with their corresponding env
+    if (typeof value === 'string') {
+      config[key] = value.replace(/\${([^}]+)}/g, (_, v) => env[v] ?? '');
+    }
+  }
+
+  const {filename} = config;
+
+  return {
+    filename: filename ?? 'conditional-manifest.json',
+  };
+}

--- a/packages/reporters/conditional-manifest/test/ConditionalManifestReporter.test.js
+++ b/packages/reporters/conditional-manifest/test/ConditionalManifestReporter.test.js
@@ -1,0 +1,67 @@
+// @flow strict-local
+import type {PluginOptions, EnvMap} from '@atlaspack/types-internal';
+
+import {NodePackageManager} from '@atlaspack/package-manager';
+import {getConfig} from '../src/ConditionalManifestReporter';
+import {overlayFS, fsFixture} from '@atlaspack/test-utils';
+import assert from 'assert';
+import {DEFAULT_FEATURE_FLAGS} from '@atlaspack/feature-flags';
+
+function getPluginOptions({env}: {env?: EnvMap, ...}): PluginOptions {
+  return {
+    mode: 'development',
+    parcelVersion: 'version',
+    serveOptions: false,
+    shouldBuildLazily: false,
+    shouldAutoInstall: false,
+    logLevel: 'info',
+    cacheDir: '.parcel-cache/',
+    packageManager: new NodePackageManager(overlayFS, '/'),
+    instanceId: 'instance-id',
+    featureFlags: DEFAULT_FEATURE_FLAGS,
+    detailedReport: undefined,
+    hmrOptions: undefined,
+    inputFS: overlayFS,
+    outputFS: overlayFS,
+    projectRoot: '/project-root',
+    env: env ?? {},
+  };
+}
+
+describe('ConditionalManifestReporter', function () {
+  it('should load filename from config', async function () {
+    const pluginOptions = getPluginOptions({});
+    overlayFS.mkdirp(pluginOptions.projectRoot);
+
+    await fsFixture(overlayFS, pluginOptions.projectRoot)`
+      package.json:
+        {
+          "@atlaspack/reporter-conditional-manifest": {
+            "filename": "../some-other-dir/conditional.json"
+          }
+        }
+    `;
+
+    const {filename} = await getConfig(pluginOptions);
+
+    assert.equal(filename, '../some-other-dir/conditional.json');
+  });
+
+  it('should load filename from config with env vars', async function () {
+    const pluginOptions = getPluginOptions({env: {USER: 'some-user'}});
+    overlayFS.mkdirp(pluginOptions.projectRoot);
+
+    await fsFixture(overlayFS, pluginOptions.projectRoot)`
+      package.json:
+        {
+          "@atlaspack/reporter-conditional-manifest": {
+            "filename": "../\${USER}/conditional.json"
+          }
+        }
+    `;
+
+    const {filename} = await getConfig(pluginOptions);
+
+    assert.equal(filename, '../some-user/conditional.json');
+  });
+});

--- a/packages/reporters/conditional-manifest/test/Config.test.js
+++ b/packages/reporters/conditional-manifest/test/Config.test.js
@@ -2,7 +2,7 @@
 import type {PluginOptions, EnvMap} from '@atlaspack/types-internal';
 
 import {NodePackageManager} from '@atlaspack/package-manager';
-import {getConfig} from '../src/ConditionalManifestReporter';
+import {getConfig} from '../src/Config';
 import {overlayFS, fsFixture} from '@atlaspack/test-utils';
 import assert from 'assert';
 import {DEFAULT_FEATURE_FLAGS} from '@atlaspack/feature-flags';


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Add a configuration option to `package.json` so we can configure the path for the manifest. This is important as jira needs a separate directory for non-hashed file paths.

## Changes

- Add filename option to package.json
- Added new eslint package based on eslint-plugin-monorepo which fixes the auto-fixer behaviour

## Checklist

- [x] Existing or new tests cover this change
