### PR TITLE
turn tests for optional deps on for v3

### DIFF
--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -2158,30 +2158,27 @@ describe('javascript', function () {
     assert.equal(output.test(), 'pkg-main-module');
   });
 
-  it.v2(
-    'should support optional dependencies in try...catch blocks',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/optional-dep/index.js'),
-      );
+  it('should support optional dependencies in try...catch blocks', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/optional-dep/index.js'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['index.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js'],
+      },
+    ]);
 
-      let output = await run(b);
+    let output = await run(b);
 
-      assert.equal(Object.getPrototypeOf(output).constructor.name, 'Error');
-      assert(
-        /Cannot find module ['"]optional-dep['"]/.test(output.message),
-        'Should set correct error message',
-      );
-      assert.equal(output.code, 'MODULE_NOT_FOUND');
-    },
-  );
+    assert.equal(Object.getPrototypeOf(output).constructor.name, 'Error');
+    assert(
+      /Cannot find module ['"]optional-dep['"]/.test(output.message),
+      'Should set correct error message',
+    );
+    assert.equal(output.code, 'MODULE_NOT_FOUND');
+  });
 
   it('should support excluding dependencies in falsy branches', async function () {
     let b = await bundle(

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -4862,7 +4862,7 @@ describe('scope hoisting', function () {
       assert.deepStrictEqual(calls, [1, 2, 3, 4, 5, 6, 7]);
     });
 
-    it.v2('should support optional requires', async function () {
+    it('should support optional requires', async function () {
       let b = await bundle(
         path.join(
           __dirname,


### PR DESCRIPTION
I believe these tests work now, they pass on my local with `ATLASPACK_V3=true` so I want to test it in CI.