### PR TITLE
Remove resizing overhead by passing edge capacity in getAssetGraph

### DIFF
--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -88,6 +88,7 @@ function getAssetGraph(serializedGraph, options) {
   let graph = new AssetGraph({
     _contentKeyToNodeId: new Map(),
     _nodeIdToContentKey: new Map(),
+    initialCapacity: serializedGraph.edges.length,
   });
 
   graph.safeToIncrementallyBundle = false;

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -17,6 +17,7 @@ export type GraphOpts<TNode, TEdgeType: number = 1> = {|
   nodes?: Array<TNode | null>,
   adjacencyList?: SerializedAdjacencyList<TEdgeType>,
   rootNodeId?: ?NodeId,
+  initialCapacity?: number,
 |};
 
 export type SerializedGraph<TNode, TEdgeType: number = 1> = {|
@@ -84,9 +85,12 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     this.setRootNodeId(opts?.rootNodeId);
 
     let adjacencyList = opts?.adjacencyList;
+    let initialCapacity = opts?.initialCapacity;
     this.adjacencyList = adjacencyList
       ? AdjacencyList.deserialize(adjacencyList)
-      : new AdjacencyList<TEdgeType>();
+      : new AdjacencyList<TEdgeType>(
+          typeof initialCapacity === 'number' ? {initialCapacity} : undefined,
+        );
   }
 
   setRootNodeId(id: ?NodeId) {


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This change takes 4-5 seconds off `getAssetGraph` by initialising the Graph with the actual edge capacity, removing the need to resize the array multiple times.

## Checklist

- [x] Existing or new tests cover this change
