### PR TITLE
Add manualSharedBundle to the types for Bundle

### DIFF
--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1413,6 +1413,10 @@ export interface Bundle {
    */
   +hashReference: string;
   /**
+   * Name of the manual shared bundle config, if that caused this bundle to be created
+   */
+  +manualSharedBundle: ?string;
+  /**
    * Returns the assets that are executed immediately when the bundle is loaded.
    * Some bundles may not have any entry assets, for example, shared bundles.
    */


### PR DESCRIPTION
Most of our products want the bundles produced by a `manualSharedBundles` config to have the same name as specified in the config object.

We can do this easily with a namer, but the type has never been added to the public `Bundle` type, despite being actually implemented.

To avoid littering our products with `// @ts-expect-error` calls, adding it to the public types here.
