### PR TITLE
update rust toolchain version for workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           cache: yarn
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
           components: rustfmt
       - run: yarn --frozen-lockfile
       - run: yarn lint
@@ -63,7 +63,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.os }}
@@ -93,7 +93,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
           target: ${{ matrix.target }}
       - uses: bahmutov/npm-install@v1.8.35
       - uses: Swatinem/rust-cache@v2
@@ -89,7 +89,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
           profile: minimal
           override: true
       - uses: bahmutov/npm-install@v1.8.35
@@ -141,7 +141,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
           target: ${{ matrix.target }}
       - name: Install cross compile toolchains
         run: |

--- a/.github/workflows/repl.yml
+++ b/.github/workflows/repl.yml
@@ -36,7 +36,7 @@ jobs:
           node-version: 20
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: 1.80.1
+          toolchain: 1.82.0
           targets: wasm32-unknown-unknown
       - name: Install wasm-opt
         run: |


### PR DESCRIPTION
The canary release is failing for some of the jobs due to missing versions of the toolchain.