### PR TITLE
add high level trace logs to v3

### DIFF
--- a/crates/atlaspack/src/requests/asset_graph_request.rs
+++ b/crates/atlaspack/src/requests/asset_graph_request.rs
@@ -73,6 +73,7 @@ impl AssetGraphBuilder {
     }
   }
 
+  #[tracing::instrument(level = "info", skip_all)]
   fn build(mut self) -> Result<ResultAndInvalidations, RunRequestError> {
     for entry in self.request_context.options.clone().entries.iter() {
       self.work_count += 1;

--- a/crates/atlaspack/src/requests/entry_request.rs
+++ b/crates/atlaspack/src/requests/entry_request.rs
@@ -28,6 +28,7 @@ pub struct EntryRequestOutput {
 
 #[async_trait]
 impl Request for EntryRequest {
+  #[tracing::instrument(level = "info", skip_all)]
   async fn run(
     &self,
     request_context: RunRequestContext,

--- a/crates/atlaspack/src/requests/target_request.rs
+++ b/crates/atlaspack/src/requests/target_request.rs
@@ -647,6 +647,7 @@ fn fallback_output_format(context: EnvironmentContext) -> OutputFormat {
 
 #[async_trait]
 impl Request for TargetRequest {
+  #[tracing::instrument(level = "info", skip_all)]
   async fn run(
     &self,
     request_context: RunRequestContext,

--- a/crates/atlaspack_monitoring/src/tracer.rs
+++ b/crates/atlaspack_monitoring/src/tracer.rs
@@ -3,13 +3,13 @@
 //! Tracing is disabled by default.
 use std::sync::Arc;
 
+use crate::from_env::{optional_var, FromEnvError};
 use anyhow::anyhow;
 use serde::Deserialize;
 use serde::Serialize;
 use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::EnvFilter;
-
-use crate::from_env::{optional_var, FromEnvError};
 
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase", tag = "mode")]
@@ -73,6 +73,7 @@ impl Tracer {
       TracerMode::Stdout => {
         tracing_subscriber::fmt()
           .with_env_filter(EnvFilter::from_default_env())
+          .with_span_events(FmtSpan::CLOSE)
           .try_init()
           .map_err(|err| {
             anyhow::anyhow!(err)
@@ -96,6 +97,7 @@ impl Tracer {
 
         tracing_subscriber::fmt()
           .with_writer(non_blocking)
+          .with_span_events(FmtSpan::CLOSE)
           .try_init()
           .map_err(|err| {
             anyhow::anyhow!(err).context("Failed to setup file tracing, is another tracer running?")

--- a/crates/node-bindings/src/atlaspack/atlaspack.rs
+++ b/crates/node-bindings/src/atlaspack/atlaspack.rs
@@ -55,6 +55,7 @@ pub struct AtlaspackNapi {
 
 #[napi]
 impl AtlaspackNapi {
+  #[tracing::instrument(level = "info", skip_all)]
   #[napi]
   pub fn create(napi_options: AtlaspackNapiOptions, lmdb: &LMDB, env: Env) -> napi::Result<Self> {
     let thread_id = std::thread::current().id();
@@ -108,6 +109,7 @@ impl AtlaspackNapi {
     })
   }
 
+  #[tracing::instrument(level = "info", skip_all)]
   #[napi]
   pub fn build_asset_graph(
     &self,
@@ -144,6 +146,7 @@ impl AtlaspackNapi {
     Ok(promise)
   }
 
+  #[tracing::instrument(level = "info", skip_all)]
   fn register_workers(&self, options: &AtlaspackNapiBuildOptions) -> napi::Result<()> {
     for _ in 0..self.node_worker_count {
       let transferable = JsTransferable::new(self.tx_worker.clone());
@@ -161,6 +164,7 @@ impl AtlaspackNapi {
   /// JavaScript does all its writes through a single thread, which is not this handle. If we want
   /// to sequence writes with the JavaScript writes, we should be using the
   /// [`lmdb_js_lite::writer::DatabaseWriterHandle`] instead.
+  #[tracing::instrument(level = "info", skip_all)]
   fn run_db_healthcheck(db: &Arc<DatabaseWriter>) -> napi::Result<()> {
     let run_healthcheck = || -> anyhow::Result<()> {
       let txn = db.read_txn()?;

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -88,7 +88,7 @@ describe('javascript', function () {
     assert.equal(output, 'should not fail');
   });
 
-  it('should produce a basic JS bundle with CommonJS requires', async function () {
+  it.only('should produce a basic JS bundle with CommonJS requires', async function () {
     const inputDir = path.join(__dirname, 'integration/commonjs');
     let b = await bundle(path.join(inputDir, '/index.js'));
 

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -88,7 +88,7 @@ describe('javascript', function () {
     assert.equal(output, 'should not fail');
   });
 
-  it.only('should produce a basic JS bundle with CommonJS requires', async function () {
+  it('should produce a basic JS bundle with CommonJS requires', async function () {
     const inputDir = path.join(__dirname, 'integration/commonjs');
     let b = await bundle(path.join(inputDir, '/index.js'));
 


### PR DESCRIPTION
This PR starts the work to enable build tracing in atlaspack. Currently we just want high level function traces.
Running a build with `ATLASPACK_TRACING_MODE=stdout RUST_LOG="info,swc_common=info,swc_ecma_compat_es2015=info,html5ever=info"` gives output of the following format:
```
2024-11-14T06:07:06.410921Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=4.00µs time.idle=10.9µs
2024-11-14T06:07:06.413204Z  INFO emit_module: swc_ecma_codegen: close time.busy=393µs time.idle=3.08µs
2024-11-14T06:07:06.682738Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=5.00µs time.idle=7.92µs
2024-11-14T06:07:06.683083Z  INFO emit_module: swc_ecma_codegen: close time.busy=45.9µs time.idle=3.21µs
2024-11-14T06:07:06.695358Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=5.67µs time.idle=12.8µs
2024-11-14T06:07:06.707554Z  INFO emit_module: swc_ecma_codegen: close time.busy=5.96ms time.idle=11.9µs
2024-11-14T06:07:06.731124Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=4.04µs time.idle=8.42µs
2024-11-14T06:07:06.731701Z  INFO emit_module: swc_ecma_codegen: close time.busy=157µs time.idle=3.58µs
2024-11-14T06:07:06.737471Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=3.00µs time.idle=5.38µs
2024-11-14T06:07:06.742517Z  INFO emit_module: swc_ecma_codegen: close time.busy=2.26ms time.idle=3.08µs
2024-11-14T06:07:06.968642Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=3.83µs time.idle=8.08µs
2024-11-14T06:07:06.969072Z  INFO emit_module: swc_ecma_codegen: close time.busy=75.6µs time.idle=3.17µs
2024-11-14T06:07:06.990415Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=4.42µs time.idle=7.88µs
2024-11-14T06:07:06.990461Z  INFO new: swc_ecma_compat_es2022::class_properties::private_field: close time.busy=3.08µs time.idle=6.29µs
2024-11-14T06:07:06.991761Z  INFO emit_module: swc_ecma_codegen: close time.busy=510µs time.idle=3.08µs
2024-11-14T06:07:06.991787Z  INFO emit_module: swc_ecma_codegen: close time.busy=516µs time.idle=3.21µs
```
We will eventually extend this to generate a trace file that can be used with a tool like perfetto to visually see and analyze the build times.