### PR TITLE
Update shared hashmap to use RwLock instead of threadlocal

### DIFF
--- a/crates/atlaspack_filesystem/src/lib.rs
+++ b/crates/atlaspack_filesystem/src/lib.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use atlaspack_shared_map::ThreadLocalHashMap;
+use atlaspack_shared_map::SharedHashMap;
 
 /// In-memory file-system for testing
 pub mod in_memory_file_system;
@@ -17,9 +17,7 @@ pub mod os_file_system;
 /// This should be `OsFileSystem` for non-testing environments and `InMemoryFileSystem` for testing.
 pub type FileSystemRef = Arc<dyn FileSystem + Send + Sync>;
 
-pub type DefaultHasher = xxhash_rust::xxh3::Xxh3Builder;
-
-pub type FileSystemRealPathCache = ThreadLocalHashMap<PathBuf, Option<PathBuf>, DefaultHasher>;
+pub type FileSystemRealPathCache = SharedHashMap<PathBuf, Option<PathBuf>>;
 
 /// Trait abstracting file-system operations
 /// .

--- a/crates/atlaspack_shared_map/src/lib.rs
+++ b/crates/atlaspack_shared_map/src/lib.rs
@@ -67,7 +67,7 @@ mod test {
   }
 
   #[test]
-  fn test_multiple_shared_hash_map() {
+  fn test_multiple_thread_shared_hash_map() {
     let map = Arc::new(SharedHashMap::<String, String>::new());
     let (close_tx, close_rx) = std::sync::mpsc::channel();
     let (tx, rx) = std::sync::mpsc::channel();

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use atlaspack_core::types::File;
 use atlaspack_filesystem::{FileSystemRealPathCache, FileSystemRef};
-use atlaspack_shared_map::ThreadLocalHashMap;
+use atlaspack_shared_map::SharedHashMap;
 
 use crate::package_json::PackageJson;
 use crate::package_json::SourceField;
@@ -22,13 +22,13 @@ pub struct Cache {
   /// from our public methods so this is ok for now. FrozenMap is an append only map, which doesn't require &mut
   /// to insert into. Since each value is in a Box, it won't move and therefore references are stable.
   #[allow(clippy::type_complexity)]
-  packages: ThreadLocalHashMap<PathBuf, Arc<Result<Arc<PackageJson>, ResolverError>>>,
+  packages: SharedHashMap<PathBuf, Arc<Result<Arc<PackageJson>, ResolverError>>>,
   #[allow(clippy::type_complexity)]
-  tsconfigs: ThreadLocalHashMap<PathBuf, Arc<Result<Arc<TsConfigWrapper>, ResolverError>>>,
+  tsconfigs: SharedHashMap<PathBuf, Arc<Result<Arc<TsConfigWrapper>, ResolverError>>>,
   // In particular just the is_dir_cache spends around 8% of the time on a large project resolution
   // hashing paths. Instead of using a hashmap we should try a trie here.
-  is_dir_cache: ThreadLocalHashMap<PathBuf, bool>,
-  is_file_cache: ThreadLocalHashMap<PathBuf, bool>,
+  is_dir_cache: SharedHashMap<PathBuf, bool>,
+  is_file_cache: SharedHashMap<PathBuf, bool>,
   realpath_cache: FileSystemRealPathCache,
 }
 
@@ -91,10 +91,10 @@ impl Cache {
   pub fn new(fs: FileSystemRef) -> Self {
     Self {
       fs,
-      packages: ThreadLocalHashMap::new(),
-      tsconfigs: ThreadLocalHashMap::new(),
-      is_file_cache: ThreadLocalHashMap::new(),
-      is_dir_cache: ThreadLocalHashMap::new(),
+      packages: SharedHashMap::new(),
+      tsconfigs: SharedHashMap::new(),
+      is_file_cache: SharedHashMap::new(),
+      is_dir_cache: SharedHashMap::new(),
       realpath_cache: FileSystemRealPathCache::default(),
     }
   }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

While doing some performance testing I found that the threadlocal version of the resolver cache was have a large negative impact on build times. Reverting back to the RwLock version is almost halving the asset graph build times in native builds. I have also validated that V2 builds are also performing better with this change, however not by the same margin. 

## Changes

- Migrate back to RwLock Hash maps for the resolver cache

## Checklist

- [x] Existing or new tests cover this change
