### PR TITLE
Serialise asset graph as json

### DIFF
--- a/packages/core/cli/src/makeDebugCommand.js
+++ b/packages/core/cli/src/makeDebugCommand.js
@@ -84,10 +84,10 @@ export function makeDebugCommand(): commander$Command {
             useLmdbJsLite: true,
           },
         });
+
         console.log('Created atlaspack instance');
 
         await atlaspack.unstable_buildAssetGraph();
-        console.log('Done building asset graph');
         process.exit(0);
       } catch (err) {
         handleUncaughtException(err);

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -585,6 +585,8 @@ export default class Atlaspack {
     writeToCache: boolean = true,
   ): Promise<AssetGraphRequestResult> {
     await this._init();
+
+    const origin = '@atlaspack/core';
     const input = {
       optionsRef: this.#optionsRef,
       name: 'Main',
@@ -594,6 +596,8 @@ export default class Atlaspack {
       lazyExcludes: [],
       requestedAssetIds: this.#requestedAssetIds,
     };
+
+    const start = Date.now();
     const result = await this.#requestTracker.runRequest(
       this.rustAtlaspack != null
         ? createAssetGraphRequestRust(this.rustAtlaspack)(input)
@@ -601,12 +605,17 @@ export default class Atlaspack {
       {force: true},
     );
 
-    logger.info({message: 'Done building asset graph!'});
+    const duration = Date.now() - start;
+
+    logger.info({
+      message: `Done building asset graph in ${duration / 1000}s!`,
+      origin,
+    });
 
     if (writeToCache) {
-      logger.info({message: 'Write request tracker to cache'});
+      logger.info({message: 'Write request tracker to cache', origin});
       await this.writeRequestTrackerToCache();
-      logger.info({message: 'Done writing request tracker to cache'});
+      logger.info({message: 'Done writing request tracker to cache', origin});
     }
 
     return result;

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -42,6 +42,9 @@ export function createAssetGraphRequestRust(
       let serializedAssetGraph;
       try {
         serializedAssetGraph = await rustAtlaspack.buildAssetGraph();
+        serializedAssetGraph.nodes = serializedAssetGraph.nodes.flatMap(
+          (node) => JSON.parse(node),
+        );
       } catch (err) {
         throw new ThrowableDiagnostic({
           diagnostic: err,


### PR DESCRIPTION
## Motivation

Serialising the asset graph from Rust to JavaScript can take a significant amount of time for large asset graphs. The current version of Napi is not designed to transport large data structures all at once, which has been alluded to in napi-rs issues in the past.

These changes improve the total time it takes to build the asset graph by serialising with json and parsing the result on the other end, as seen in the following table:

| Benchmark  | Before | After | Improvement
| - | - | - | - |
| internal | 265s | 156s | -109s (41%) |
| three-js | 6.29s  | 4.69s  | -1.6s (25%) |

Whilst serialising to json is not ideal, it can be removed once more of the core has been ported to Rust.

## Changes

* Improve debug asset graph command logs by specifying an origin and the final build time
* Add `edges` and `nodes` functions to the asset graph
* Add `serialize_nodes` to the asset graph, which returns a json structure partitioned so that it never exceeds the max string length in JavaScript. This ensures `Invalid String Length` errors do not occur when parsing the structure back in the `AssetGraphRequestRust` module.
* Update the serialisation to use `serialize_nodes` in addition to default serialisation for edges (this is not expensive)
* Remove old serialisation of the asset graph

## Checklist

- [x] Existing or new tests cover this change
