### PR TITLE
Enable more v3 tests

### DIFF
--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -14,8 +14,8 @@ import {
 
 import {ATLASPACK_VERSION} from '../../core/src/constants';
 
-describe.v2('JS API', function () {
-  it('should respect distEntry', async function () {
+describe('JS API', function () {
+  it.v2('should respect distEntry', async function () {
     const NAME = 'custom-name.js';
 
     let b = await bundle(

--- a/packages/core/integration-tests/test/atlaspack-link.js
+++ b/packages/core/integration-tests/test/atlaspack-link.js
@@ -19,7 +19,7 @@ function createProgram(opts: ProgramOptions) {
   return cli;
 }
 
-describe.v2('@atlaspack/link', () => {
+describe('@atlaspack/link', () => {
   let _cwd;
   let _stdout;
 

--- a/packages/core/integration-tests/test/bundle-text.js
+++ b/packages/core/integration-tests/test/bundle-text.js
@@ -16,7 +16,7 @@ describe('bundle-text:', function () {
     await removeDistDirectory();
   });
 
-  it.v2('inlines and compiles a css bundle', async () => {
+  it('inlines and compiles a css bundle', async () => {
     await fsFixture(overlayFS, __dirname)`
       index.js:
         import cssText from 'bundle-text:./styles.css';
@@ -121,7 +121,7 @@ describe('bundle-text:', function () {
     assert.deepEqual(logs, []);
   });
 
-  it.v2('inlines and compiles a bundle using a dynamic import', async () => {
+  it('inlines and compiles a bundle using a dynamic import', async () => {
     await fsFixture(overlayFS, __dirname)`
       index.js:
         export default import('bundle-text:./styles.css');

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -14,7 +14,7 @@ import {
 import {hashString} from '@atlaspack/rust';
 import {normalizePath} from '@atlaspack/utils';
 
-describe.v2('bundler', function () {
+describe('bundler', function () {
   it('should not create shared bundles when a bundle is being reused and disableSharedBundles is enabled', async function () {
     await fsFixture(overlayFS, __dirname)`
       disable-shared-bundle-single-source
@@ -560,8 +560,10 @@ describe.v2('bundler', function () {
     await run(b);
   });
 
-  it('should not count inline assests towards parallel request limit', async function () {
-    await fsFixture(overlayFS, __dirname)`
+  it.v2(
+    'should not count inline assests towards parallel request limit',
+    async function () {
+      await fsFixture(overlayFS, __dirname)`
       inlined-assests
         buzz.js:
           export default 7;
@@ -593,38 +595,39 @@ describe.v2('bundler', function () {
         yarn.lock: {}
     `;
 
-    // Shared bundle should not be removed in this case
-    let b = await bundle(path.join(__dirname, 'inlined-assests/local.html'), {
-      mode: 'production',
-      defaultTargetOptions: {
-        shouldScopeHoist: false,
-      },
-      inputFS: overlayFS,
-    });
+      // Shared bundle should not be removed in this case
+      let b = await bundle(path.join(__dirname, 'inlined-assests/local.html'), {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: false,
+        },
+        inputFS: overlayFS,
+      });
 
-    assertBundles(b, [
-      {
-        assets: ['local.html'],
-      },
-      {
-        assets: ['buzz.js'],
-      },
-      {
-        assets: [
-          'inline-module.js',
-          'local.html',
-          'bundle-url.js',
-          'cacheLoader.js',
-          'js-loader.js',
-        ],
-      },
-      {
-        assets: ['esmodule-helpers.js'],
-      },
-    ]);
+      assertBundles(b, [
+        {
+          assets: ['local.html'],
+        },
+        {
+          assets: ['buzz.js'],
+        },
+        {
+          assets: [
+            'inline-module.js',
+            'local.html',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
+          ],
+        },
+        {
+          assets: ['esmodule-helpers.js'],
+        },
+      ]);
 
-    await run(b);
-  });
+      await run(b);
+    },
+  );
 
   it('should not create a shared bundle from an asset if that asset is shared by less than minBundles bundles', async function () {
     let b = await bundle(
@@ -1421,7 +1424,7 @@ describe.v2('bundler', function () {
       await run(b);
     });
 
-    it('should respect Asset.isBundleSplittable', async function () {
+    it.v2('should respect Asset.isBundleSplittable', async function () {
       await fsFixture(overlayFS, dir)`
         yarn.lock: {}
 
@@ -1660,8 +1663,10 @@ describe.v2('bundler', function () {
       await run(b);
     });
 
-    it('should support manual shared bundles with constants module', async function () {
-      await fsFixture(overlayFS, dir)`
+    it.v2(
+      'should support manual shared bundles with constants module',
+      async function () {
+        await fsFixture(overlayFS, dir)`
         yarn.lock: {}
 
         package.json:
@@ -1700,39 +1705,40 @@ describe.v2('bundler', function () {
           export default 'vendor-async.js' + a;
         `;
 
-      let b = await bundle(path.join(dir, 'index.html'), {
-        mode: 'production',
-        defaultTargetOptions: {
-          shouldScopeHoist: true,
-          sourceMaps: false,
-          shouldOptimize: false,
-        },
-        inputFS: overlayFS,
-      });
+        let b = await bundle(path.join(dir, 'index.html'), {
+          mode: 'production',
+          defaultTargetOptions: {
+            shouldScopeHoist: true,
+            sourceMaps: false,
+            shouldOptimize: false,
+          },
+          inputFS: overlayFS,
+        });
 
-      assertBundles(b, [
-        {
-          assets: ['index.html'],
-        },
-        {
-          assets: [
-            'bundle-manifest.js',
-            'esm-js-loader.js',
-            'index.js',
-            'vendor-constants.js',
-          ],
-        },
-        {
-          assets: ['async.js'],
-        },
-        {
-          // Vendor MSB for JS
-          assets: ['vendor-async.js', 'vendor-constants.js'],
-        },
-      ]);
+        assertBundles(b, [
+          {
+            assets: ['index.html'],
+          },
+          {
+            assets: [
+              'bundle-manifest.js',
+              'esm-js-loader.js',
+              'index.js',
+              'vendor-constants.js',
+            ],
+          },
+          {
+            assets: ['async.js'],
+          },
+          {
+            // Vendor MSB for JS
+            assets: ['vendor-async.js', 'vendor-constants.js'],
+          },
+        ]);
 
-      await run(b);
-    });
+        await run(b);
+      },
+    );
 
     it('should support manual shared bundles with internalized assets', async function () {
       await fsFixture(overlayFS, dir)`
@@ -2199,8 +2205,10 @@ describe.v2('bundler', function () {
     });
   });
 
-  it('should reuse type change bundles from parent bundle groups', async function () {
-    await fsFixture(overlayFS, __dirname)`
+  it.v2(
+    'should reuse type change bundles from parent bundle groups',
+    async function () {
+      await fsFixture(overlayFS, __dirname)`
       reuse-type-change-bundles
         index.html:
           <link rel="stylesheet" type="text/css" href="./style.css">
@@ -2220,42 +2228,45 @@ describe.v2('bundler', function () {
           import './common.css';
     `;
 
-    let b = await bundle(
-      path.join(__dirname, 'reuse-type-change-bundles', 'index.html'),
-      {
-        mode: 'production',
-        inputFS: overlayFS,
-      },
-    );
+      let b = await bundle(
+        path.join(__dirname, 'reuse-type-change-bundles', 'index.html'),
+        {
+          mode: 'production',
+          inputFS: overlayFS,
+        },
+      );
 
-    assertBundles(b, [
-      {
-        assets: ['index.html'],
-      },
-      {
-        assets: ['style.css', 'common.css'],
-      },
-      {
-        assets: ['index.js', 'bundle-manifest.js', 'esm-js-loader.js'],
-      },
-      {
-        assets: ['async.js'],
-      },
-    ]);
+      assertBundles(b, [
+        {
+          assets: ['index.html'],
+        },
+        {
+          assets: ['style.css', 'common.css'],
+        },
+        {
+          assets: ['index.js', 'bundle-manifest.js', 'esm-js-loader.js'],
+        },
+        {
+          assets: ['async.js'],
+        },
+      ]);
 
-    await run(b);
-  });
+      await run(b);
+    },
+  );
 
-  it('should not split any bundles when using singleFileOutput', async function () {
-    const targets = {
-      'single-file': {
-        distDir: 'dist-single',
-        __unstable_singleFileOutput: true,
-      },
-      'normally-split': {distDir: 'dist-normal'},
-    };
+  it.v2(
+    'should not split any bundles when using singleFileOutput',
+    async function () {
+      const targets = {
+        'single-file': {
+          distDir: 'dist-single',
+          __unstable_singleFileOutput: true,
+        },
+        'normally-split': {distDir: 'dist-normal'},
+      };
 
-    await fsFixture(overlayFS, __dirname)`
+      await fsFixture(overlayFS, __dirname)`
       single-file-output
         a.js:
           import {c} from './b';
@@ -2273,47 +2284,48 @@ describe.v2('bundler', function () {
         yarn.lock: {}
     `;
 
-    let singleBundle = await bundle(
-      path.join(__dirname, 'single-file-output/a.js'),
-      {
-        defaultTargetOptions: {shouldScopeHoist: false},
-        inputFS: overlayFS,
-        targets: {['single-file']: targets['single-file']},
-      },
-    );
+      let singleBundle = await bundle(
+        path.join(__dirname, 'single-file-output/a.js'),
+        {
+          defaultTargetOptions: {shouldScopeHoist: false},
+          inputFS: overlayFS,
+          targets: {['single-file']: targets['single-file']},
+        },
+      );
 
-    let splitBundle = await bundle(
-      path.join(__dirname, 'single-file-output/a.js'),
-      {
-        defaultTargetOptions: {shouldScopeHoist: false},
-        inputFS: overlayFS,
-        targets: {['normally-split']: targets['normally-split']},
-      },
-    );
+      let splitBundle = await bundle(
+        path.join(__dirname, 'single-file-output/a.js'),
+        {
+          defaultTargetOptions: {shouldScopeHoist: false},
+          inputFS: overlayFS,
+          targets: {['normally-split']: targets['normally-split']},
+        },
+      );
 
-    // There should be a single bundle, including a, b, and c
-    assertBundles(singleBundle, [
-      {assets: ['a.js', 'b.js', 'c.js', 'esmodule-helpers.js']},
-    ]);
+      // There should be a single bundle, including a, b, and c
+      assertBundles(singleBundle, [
+        {assets: ['a.js', 'b.js', 'c.js', 'esmodule-helpers.js']},
+      ]);
 
-    await run(singleBundle);
+      await run(singleBundle);
 
-    // Without the property, the bundle should be split properly
-    assertBundles(splitBundle, [
-      {
-        assets: [
-          'a.js',
-          'b.js',
-          'bundle-url.js',
-          'cacheLoader.js',
-          'esmodule-helpers.js',
-          'js-loader.js',
-        ],
-      },
-      {assets: ['c.js']},
-      {type: 'css', assets: ['should-be-ignored.css']},
-    ]);
+      // Without the property, the bundle should be split properly
+      assertBundles(splitBundle, [
+        {
+          assets: [
+            'a.js',
+            'b.js',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'esmodule-helpers.js',
+            'js-loader.js',
+          ],
+        },
+        {assets: ['c.js']},
+        {type: 'css', assets: ['should-be-ignored.css']},
+      ]);
 
-    await run(splitBundle);
-  });
+      await run(splitBundle);
+    },
+  );
 });

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -92,6 +92,7 @@ describe('conditional bundling', function () {
               "..."
             ]
           }
+
         index.js:
           const imported = importCond('cond', './a', './b');
 

--- a/packages/core/integration-tests/test/contentHashing.js
+++ b/packages/core/integration-tests/test/contentHashing.js
@@ -21,12 +21,12 @@ function bundle(path) {
   });
 }
 
-describe.v2('content hashing', function () {
+describe('content hashing', function () {
   beforeEach(async () => {
     await outputFS.rimraf(path.join(__dirname, '/input'));
   });
 
-  it('should update content hash when content changes', async function () {
+  it.v2('should update content hash when content changes', async function () {
     await ncp(
       path.join(__dirname, '/integration/html-css'),
       path.join(__dirname, '/input'),
@@ -59,7 +59,7 @@ describe.v2('content hashing', function () {
     assert.notEqual(filename, newFilename);
   });
 
-  it('should update content hash when raw asset changes', async function () {
+  it.v2('should update content hash when raw asset changes', async function () {
     await ncp(
       path.join(__dirname, '/integration/import-raw'),
       path.join(__dirname, '/input'),
@@ -94,25 +94,28 @@ describe.v2('content hashing', function () {
     );
   });
 
-  it('should generate the same hash for the same distDir inside separate projects', async () => {
-    let a = await _bundle(
-      path.join(__dirname, 'integration/hash-distDir/a/index.html'),
-      {sourceMaps: true},
-    );
-    let b = await _bundle(
-      path.join(__dirname, 'integration/hash-distDir/b/index.html'),
-      {sourceMaps: true},
-    );
+  it.v2(
+    'should generate the same hash for the same distDir inside separate projects',
+    async () => {
+      let a = await _bundle(
+        path.join(__dirname, 'integration/hash-distDir/a/index.html'),
+        {sourceMaps: true},
+      );
+      let b = await _bundle(
+        path.join(__dirname, 'integration/hash-distDir/b/index.html'),
+        {sourceMaps: true},
+      );
 
-    let aBundles = a.getBundles();
-    let bBundles = b.getBundles();
+      let aBundles = a.getBundles();
+      let bBundles = b.getBundles();
 
-    assert.equal(aBundles.length, 2);
-    assert.equal(bBundles.length, 2);
+      assert.equal(aBundles.length, 2);
+      assert.equal(bBundles.length, 2);
 
-    let aJS = aBundles.find((bundle) => bundle.type === 'js');
-    let bJS = bBundles.find((bundle) => bundle.type === 'js');
-    assert(/index\.[a-f0-9]*\.js/.test(path.basename(aJS.filePath)));
-    assert.equal(aJS.name, bJS.name);
-  });
+      let aJS = aBundles.find((bundle) => bundle.type === 'js');
+      let bJS = bBundles.find((bundle) => bundle.type === 'js');
+      assert(/index\.[a-f0-9]*\.js/.test(path.basename(aJS.filePath)));
+      assert.equal(aJS.name, bJS.name);
+    },
+  );
 });

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -419,34 +419,28 @@ describe('css', () => {
     assert.equal(css.split('\n').length, 1);
   });
 
-  it.v2(
-    'should produce a sourcemap when sourceMaps are used',
-    async function () {
-      await bundle(path.join(__dirname, '/integration/cssnano/index.js'), {
-        defaultTargetOptions: {
-          shouldOptimize: true,
-        },
-      });
+  it('should produce a sourcemap when sourceMaps are used', async function () {
+    await bundle(path.join(__dirname, '/integration/cssnano/index.js'), {
+      defaultTargetOptions: {
+        shouldOptimize: true,
+      },
+    });
 
-      let css = await outputFS.readFile(
-        path.join(distDir, 'index.css'),
-        'utf8',
-      );
-      assert(css.includes('.local'));
-      assert(css.includes('.index'));
+    let css = await outputFS.readFile(path.join(distDir, 'index.css'), 'utf8');
+    assert(css.includes('.local'));
+    assert(css.includes('.index'));
 
-      let lines = css.trim().split('\n');
-      assert.equal(lines.length, 2);
-      assert.equal(lines[1], '/*# sourceMappingURL=index.css.map */');
+    let lines = css.trim().split('\n');
+    assert.equal(lines.length, 2);
+    assert.equal(lines[1], '/*# sourceMappingURL=index.css.map */');
 
-      let map = JSON.parse(
-        await outputFS.readFile(path.join(distDir, 'index.css.map'), 'utf8'),
-      );
-      assert.equal(map.file, 'index.css.map');
-      assert(map.sources.includes('integration/cssnano/local.css'));
-      assert(map.sources.includes('integration/cssnano/index.css'));
-    },
-  );
+    let map = JSON.parse(
+      await outputFS.readFile(path.join(distDir, 'index.css.map'), 'utf8'),
+    );
+    assert.equal(map.file, 'index.css.map');
+    assert(map.sources.includes('integration/cssnano/local.css'));
+    assert(map.sources.includes('integration/cssnano/index.css'));
+  });
 
   // This breaks in v3 as it uses asset.addURLDependency inside the SVG transformer
   it.v2('should inline data-urls for text-encoded files', async () => {
@@ -576,9 +570,7 @@ describe('css', () => {
     );
   });
 
-  // This seems to broken due to the browser/target not being passed corrctly
-  // and the nesting doesn't get compiled out
-  it.v2('should support css nesting with lightningcss', async function () {
+  it('should support css nesting with lightningcss', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/css-nesting/a.css'),
       {

--- a/packages/core/integration-tests/test/encodedURI.js
+++ b/packages/core/integration-tests/test/encodedURI.js
@@ -1,13 +1,13 @@
 import assert from 'assert';
-import path from 'path';
+import {join} from 'path';
 import {bundle, describe, it, outputFS, distDir} from '@atlaspack/test-utils';
 
-describe.v2('encodedURI', function () {
+describe('encodedURI', function () {
   it('should support bundling files which names in encoded URI', async function () {
-    await bundle(path.join(__dirname, '/integration/encodedURI/index.html'));
+    await bundle(join(__dirname, '/integration/encodedURI/index.html'));
 
     let files = await outputFS.readdir(distDir);
-    let html = await outputFS.readFile(path.join(distDir, 'index.html'));
+    let html = await outputFS.readFile(join(distDir, 'index.html'));
     for (let file of files) {
       if (file !== 'index.html') {
         assert(html.includes(file));

--- a/packages/core/integration-tests/test/globals.js
+++ b/packages/core/integration-tests/test/globals.js
@@ -11,7 +11,7 @@ import {
 } from '@atlaspack/test-utils';
 import sinon from 'sinon';
 
-describe.v2('globals', function () {
+describe('globals', function () {
   it('should support global alias syntax', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/global-alias/index.js'),
@@ -81,7 +81,7 @@ describe.v2('globals', function () {
       assert.deepEqual(onGlobal.firstCall.args, ['global']);
     });
 
-    it('when scope hoisting is enabled', async function () {
+    it.v2('when scope hoisting is enabled', async function () {
       let bundleGraph = await bundle(path.join(dir, 'index.js'), {
         defaultTargetOptions: {
           context: 'browser',

--- a/packages/core/integration-tests/test/glsl.js
+++ b/packages/core/integration-tests/test/glsl.js
@@ -9,7 +9,7 @@ import {
   normaliseNewlines,
 } from '@atlaspack/test-utils';
 
-describe.v2('glsl', function () {
+describe('glsl', function () {
   it('should support requiring GLSL files via glslify', async function () {
     let b = await bundle(path.join(__dirname, '/integration/glsl/index.js'));
 
@@ -19,6 +19,7 @@ describe.v2('glsl', function () {
     );
 
     let output = await run(b);
+
     assert.equal(typeof output, 'function');
     assert.ok(
       output().reduce((acc, requiredShader) => {
@@ -29,22 +30,25 @@ describe.v2('glsl', function () {
     );
   });
 
-  it('should correctly resolve relative GLSL imports', async function () {
+  it.v2('should correctly resolve relative GLSL imports', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/glsl-relative-import/index.js'),
     );
 
-    let output = await run(b);
+    let output = (await run(b)).trim();
+
     assert.strictEqual(
-      output.trim(),
-      `#define GLSLIFY 1
+      output,
+      `
+#define GLSLIFY 1
 float b(float p) { return p*2.0; }
 
 float c(float p) { return b(p)*3.0; }
 
 varying float x;
 
-void main() { gl_FragColor = vec4(c(x)); }`,
+void main() { gl_FragColor = vec4(c(x)); }
+      `.trim(),
     );
   });
 });

--- a/packages/core/integration-tests/test/graphql.js
+++ b/packages/core/integration-tests/test/graphql.js
@@ -3,7 +3,7 @@ import path from 'path';
 import {bundle, describe, it, run} from '@atlaspack/test-utils';
 import {parse, print} from 'graphql/language';
 
-describe.v2('graphql', function () {
+describe('graphql', function () {
   it('should support requiring graphql files', async function () {
     let b = await bundle(path.join(__dirname, '/integration/graphql/index.js'));
 

--- a/packages/core/integration-tests/test/image.js
+++ b/packages/core/integration-tests/test/image.js
@@ -60,13 +60,8 @@ describe('images', function () {
 
     it('from javascript', testCase('js'));
     it.v2('from html', testCase('html'));
-    it.v2('from css', testCase('css'));
+    it('from css', testCase('css'));
   });
-
-  it.v2(
-    'can be resized and reformatted from html with a query string',
-    async () => {},
-  );
 
   describe('can change image format with a query string', () => {
     function testCase(ext) {
@@ -83,8 +78,8 @@ describe('images', function () {
     }
 
     it('from javascript', testCase('js'));
-    it.v2('from html', testCase('html'));
-    it.v2('from css', testCase('css'));
+    it('from html', testCase('html'));
+    it('from css', testCase('css'));
 
     it.v2('all formats', async () => {
       let b = await bundle(

--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -13,7 +13,7 @@ import {
 
 [false, true].forEach((value) => {
   const implementation = value ? 'rust' : 'js';
-  describe.v2(`inline requires - ${implementation}`, () => {
+  describe(`inline requires - ${implementation}`, () => {
     let options = {
       defaultTargetOptions: {
         shouldScopeHoist: true,

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -204,26 +204,22 @@ describe('javascript', function () {
     assert.deepEqual(res.ys, {b: 'b'});
   });
 
-  it.v2(
-    'should bundle node_modules for a browser environment',
-    async function () {
-      // TODO: Fails in v3 due to "ENOENT: no such file or directory" for the
-      let b = await bundle(
-        path.join(__dirname, '/integration/node_require_browser/main.js'),
-      );
+  it('should bundle node_modules for a browser environment', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/node_require_browser/main.js'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'main.js',
-          assets: ['main.js', 'local.js', 'index.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'main.js',
+        assets: ['main.js', 'local.js', 'index.js'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.equal(typeof output, 'function');
-      assert.equal(output(), 3);
-    },
-  );
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 3);
+  });
 
   it('should not bundle node_modules for a node environment', async function () {
     let b = await bundle(
@@ -314,26 +310,22 @@ describe('javascript', function () {
     await outputFS.rimraf(path.join(fixturePath, 'dist'));
   });
 
-  it.v2(
-    'should bundle node_modules for a node environment if includeNodeModules is specified',
-    async function () {
-      // TODO: Fails in v3 due to "ENOENT: no such file or directory" for the
-      let b = await bundle(
-        path.join(__dirname, '/integration/include_node_modules/main.js'),
-      );
+  it('should bundle node_modules for a node environment if includeNodeModules is specified', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/include_node_modules/main.js'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'main.js',
-          assets: ['main.js', 'local.js', 'index.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'main.js',
+        assets: ['main.js', 'local.js', 'index.js'],
+      },
+    ]);
 
-      let output = await run(b);
-      assert.equal(typeof output, 'function');
-      assert.equal(output(), 3);
-    },
-  );
+    let output = await run(b);
+    assert.equal(typeof output, 'function');
+    assert.equal(output(), 3);
+  });
 
   it('should bundle builtins for a browser environment', async function () {
     let b = await bundle(

--- a/packages/core/integration-tests/test/packager.js
+++ b/packages/core/integration-tests/test/packager.js
@@ -25,84 +25,75 @@ function hasPolyfill(code) {
 
 describe('packager', function () {
   describe('globalThis polyfill', function () {
-    it.v2(
-      'should exclude globalThis polyfill in modern builds',
-      async function () {
-        const entryPoint = path.join(
-          __dirname,
-          'integration/html-js-dynamic/index.html',
-        );
-        const options = {
-          mode: 'production',
-          defaultTargetOptions: {
-            shouldOptimize: false,
-            engines: {
-              browsers: 'last 2 Chrome version',
-            },
+    it('should exclude globalThis polyfill in modern builds', async function () {
+      const entryPoint = path.join(
+        __dirname,
+        'integration/html-js-dynamic/index.html',
+      );
+      const options = {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldOptimize: false,
+          engines: {
+            browsers: 'last 2 Chrome version',
           },
-        };
-        const bundleGraph = await runBundler(entryPoint, options);
+        },
+      };
+      const bundleGraph = await runBundler(entryPoint, options);
 
-        for (const b of bundleGraph.getBundles()) {
-          if (b.type !== 'js') continue;
-          let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
-          assert.ok(!hasPolyfill(code));
-        }
-      },
-    );
+      for (const b of bundleGraph.getBundles()) {
+        if (b.type !== 'js') continue;
+        let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
+        assert.ok(!hasPolyfill(code));
+      }
+    });
 
-    it.v2(
-      'should include globalThis polyfill in ie11 builds',
-      async function () {
-        const entryPoint = path.join(
-          __dirname,
-          'integration/packager-global-this/index.html',
-        );
-        const options = {
-          mode: 'production',
-          defaultTargetOptions: {
-            shouldOptimize: false,
-            engines: {
-              browsers: 'ie 11',
-            },
+    it('should include globalThis polyfill in ie11 builds', async function () {
+      const entryPoint = path.join(
+        __dirname,
+        'integration/packager-global-this/index.html',
+      );
+      const options = {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldOptimize: false,
+          engines: {
+            browsers: 'ie 11',
           },
-        };
+        },
+      };
 
-        const bundleGraph = await runBundler(entryPoint, options);
+      const bundleGraph = await runBundler(entryPoint, options);
 
-        for (const b of bundleGraph.getBundles()) {
-          if (b.type !== 'js') continue;
-          let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
-          assert.ok(hasPolyfill(code));
-        }
-      },
-    );
+      for (const b of bundleGraph.getBundles()) {
+        if (b.type !== 'js') continue;
+        let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
+        assert.ok(hasPolyfill(code));
+      }
+    });
 
-    it.v2(
-      'should exclude globalThis polyfill in node builds',
-      async function () {
-        const entryPoint = path.join(
-          __dirname,
-          'integration/packager-global-this/index.js',
-        );
-        const options = {
-          mode: 'production',
-          defaultTargetOptions: {
-            shouldOptimize: false,
-            engines: {
-              browsers: 'node 18',
-            },
+    it('should exclude globalThis polyfill in node builds', async function () {
+      const entryPoint = path.join(
+        __dirname,
+        'integration/packager-global-this/index.js',
+      );
+      const options = {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldOptimize: false,
+          engines: {
+            browsers: 'node 18',
           },
-        };
+        },
+      };
 
-        const bundleGraph = await runBundler(entryPoint, options);
+      const bundleGraph = await runBundler(entryPoint, options);
 
-        for (const b of bundleGraph.getBundles()) {
-          if (b.type !== 'js') continue;
-          let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
-          assert.ok(!hasPolyfill(code));
-        }
-      },
-    );
+      for (const b of bundleGraph.getBundles()) {
+        if (b.type !== 'js') continue;
+        let code = await overlayFS.readFile(nullthrows(b.filePath), 'utf8');
+        assert.ok(!hasPolyfill(code));
+      }
+    });
   });
 });

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -827,7 +827,7 @@ describe('scope hoisting', function () {
       assert.deepEqual(output, [1, 2]);
     });
 
-    it.v2('supports live bindings across bundles', async function () {
+    it('supports live bindings across bundles', async function () {
       let b = await bundle(
         ['a.html', 'b.html'].map((f) =>
           path.join(
@@ -2248,26 +2248,23 @@ describe('scope hoisting', function () {
       assert(called);
     });
 
-    it.v2(
-      'should insert esModule flag for interop for async (or shared) bundles',
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            '/integration/scope-hoisting/es6/interop-async/index.html',
-          ),
-          {
-            mode: 'production',
-            defaultTargetOptions: {
-              shouldOptimize: false,
-            },
+    it('should insert esModule flag for interop for async (or shared) bundles', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/es6/interop-async/index.html',
+        ),
+        {
+          mode: 'production',
+          defaultTargetOptions: {
+            shouldOptimize: false,
           },
-        );
+        },
+      );
 
-        let res = await run(b, {output: null}, {require: false});
-        assert.deepEqual(await res.output, ['client', 'client', 'viewer']);
-      },
-    );
+      let res = await run(b, {output: null}, {require: false});
+      assert.deepEqual(await res.output, ['client', 'client', 'viewer']);
+    });
 
     it('should enable minifier to remove unused modules despite of interopDefault', async function () {
       let b = await bundle(
@@ -3633,7 +3630,7 @@ describe('scope hoisting', function () {
       await run(b);
     });
 
-    it.v2('supports constant inlining with shared bundles', async function () {
+    it('supports constant inlining with shared bundles', async function () {
       let b = await bundle(
         [
           path.join(
@@ -4073,20 +4070,17 @@ describe('scope hoisting', function () {
       assert.equal(output.foo, 'b');
     });
 
-    it.v2(
-      "doesn't insert parcelRequire for missing non-js assets",
-      async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            '/integration/scope-hoisting/commonjs/missing-non-js/a.js',
-          ),
-        );
+    it("doesn't insert parcelRequire for missing non-js assets", async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/scope-hoisting/commonjs/missing-non-js/a.js',
+        ),
+      );
 
-        let output = await run(b);
-        assert.equal(output, 27);
-      },
-    );
+      let output = await run(b);
+      assert.equal(output, 27);
+    });
 
     it.v2('define exports in the outermost scope', async function () {
       let b = await bundle(
@@ -4620,7 +4614,7 @@ describe('scope hoisting', function () {
       assert.deepEqual(out, ['a', 'b', 'c', 'd']);
     });
 
-    it.v2('supports requiring a CSS asset', async function () {
+    it('supports requiring a CSS asset', async function () {
       let b = await bundle(
         path.join(
           __dirname,
@@ -5390,7 +5384,7 @@ describe('scope hoisting', function () {
     });
   });
 
-  it.v2('should not throw with JS included from HTML', async function () {
+  it('should not throw with JS included from HTML', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/html-js/index.html'),
     );
@@ -5419,33 +5413,30 @@ describe('scope hoisting', function () {
     assert.deepEqual(value, ['other']);
   });
 
-  it.v2(
-    'should not throw with JS dynamic imports included from HTML',
-    async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/html-js-dynamic/index.html'),
-      );
+  it('should not throw with JS dynamic imports included from HTML', async function () {
+    let b = await bundle(
+      path.join(__dirname, '/integration/html-js-dynamic/index.html'),
+    );
 
-      assertBundles(b, [
-        {
-          name: 'index.html',
-          assets: ['index.html'],
-        },
-        {
-          type: 'js',
-          assets: ['index.js'],
-        },
-        {
-          type: 'js',
-          assets: ['local.js'],
-        },
-      ]);
+    assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html'],
+      },
+      {
+        type: 'js',
+        assets: ['index.js'],
+      },
+      {
+        type: 'js',
+        assets: ['local.js'],
+      },
+    ]);
 
-      let res = await run(b, {output: null}, {require: false});
-      assert.equal(typeof res.output, 'function');
-      assert.equal(await res.output(), 'Imported: foobar');
-    },
-  );
+    let res = await run(b, {output: null}, {require: false});
+    assert.equal(typeof res.output, 'function');
+    assert.equal(await res.output(), 'Imported: foobar');
+  });
 
   it.v2(
     'should include the prelude in shared entry bundles',
@@ -5852,40 +5843,37 @@ describe('scope hoisting', function () {
     );
   });
 
-  it.v2(
-    'correctly updates dependencies when a specifier is added',
-    async function () {
-      let testDir = path.join(
-        __dirname,
-        '/integration/scope-hoisting/es6/cache-add-specifier',
-      );
+  it('correctly updates dependencies when a specifier is added', async function () {
+    let testDir = path.join(
+      __dirname,
+      '/integration/scope-hoisting/es6/cache-add-specifier',
+    );
 
-      let b = bundler(path.join(testDir, 'a.js'), {
-        inputFS: overlayFS,
-        outputFS: overlayFS,
-      });
+    let b = bundler(path.join(testDir, 'a.js'), {
+      inputFS: overlayFS,
+      outputFS: overlayFS,
+    });
 
-      let subscription = await b.watch();
+    let subscription = await b.watch();
 
-      let bundleEvent = await getNextBuild(b);
-      assert(bundleEvent.type === 'buildSuccess');
-      let output = await run(bundleEvent.bundleGraph);
-      assert.deepEqual(output, 'foo');
+    let bundleEvent = await getNextBuild(b);
+    assert(bundleEvent.type === 'buildSuccess');
+    let output = await run(bundleEvent.bundleGraph);
+    assert.deepEqual(output, 'foo');
 
-      await overlayFS.mkdirp(testDir);
-      await overlayFS.copyFile(
-        path.join(testDir, 'a.1.js'),
-        path.join(testDir, 'a.js'),
-      );
+    await overlayFS.mkdirp(testDir);
+    await overlayFS.copyFile(
+      path.join(testDir, 'a.1.js'),
+      path.join(testDir, 'a.js'),
+    );
 
-      bundleEvent = await getNextBuild(b);
-      assert(bundleEvent.type === 'buildSuccess');
-      output = await run(bundleEvent.bundleGraph);
-      assert.deepEqual(output, 'foobar');
+    bundleEvent = await getNextBuild(b);
+    assert(bundleEvent.type === 'buildSuccess');
+    output = await run(bundleEvent.bundleGraph);
+    assert.deepEqual(output, 'foobar');
 
-      await subscription.unsubscribe();
-    },
-  );
+    await subscription.unsubscribe();
+  });
 
   it('should not rewrite this in arrow function class properties', async function () {
     let b = await bundle(
@@ -5912,19 +5900,16 @@ describe('scope hoisting', function () {
     });
   });
 
-  it.v2(
-    'should insert the prelude for sibling bundles referenced in HTML',
-    async function () {
-      let b = await bundle(
-        path.join(
-          __dirname,
-          'integration/scope-hoisting/es6/sibling-dependencies/index.html',
-        ),
-      );
-      let res = await run(b, {output: null}, {require: false});
-      assert.equal(res.output, 'a');
-    },
-  );
+  it('should insert the prelude for sibling bundles referenced in HTML', async function () {
+    let b = await bundle(
+      path.join(
+        __dirname,
+        'integration/scope-hoisting/es6/sibling-dependencies/index.html',
+      ),
+    );
+    let res = await run(b, {output: null}, {require: false});
+    assert.equal(res.output, 'a');
+  });
 
   it('should unmark dependency as deferred when dependency becomes used', async function () {
     let testDir = path.join(
@@ -6020,114 +6005,105 @@ describe('scope hoisting', function () {
     assert.strictEqual(output, 'foo');
   });
 
-  it.v2(
-    'produce the same bundle hash regardless of transformation order',
-    async function () {
-      let testDir = path.join(
-        __dirname,
-        'integration/scope-hoisting/es6/non-deterministic-bundle-hashes',
-      );
+  it('produce the same bundle hash regardless of transformation order', async function () {
+    let testDir = path.join(
+      __dirname,
+      'integration/scope-hoisting/es6/non-deterministic-bundle-hashes',
+    );
 
-      const waitHandler = (fileToDelay, fileToWaitFor) => {
-        const waitMap = new Map();
+    const waitHandler = (fileToDelay, fileToWaitFor) => {
+      const waitMap = new Map();
 
-        function wait(filePath) {
-          if (waitMap.has(filePath)) {
-            return Promise.resolve();
-          }
-          return new Promise((resolve) => {
-            waitMap.set(filePath, resolve);
-          });
+      function wait(filePath) {
+        if (waitMap.has(filePath)) {
+          return Promise.resolve();
         }
-        // a set of filepaths that have been read
-        function seen(filePath) {
-          // check map of things we're waiting for to resolved promises
-          let promisesToResolve = waitMap.get(filePath);
-          if (promisesToResolve) {
-            // if we find any, we call it
-            promisesToResolve();
-          }
-          waitMap.set(filePath, null);
+        return new Promise((resolve) => {
+          waitMap.set(filePath, resolve);
+        });
+      }
+      // a set of filepaths that have been read
+      function seen(filePath) {
+        // check map of things we're waiting for to resolved promises
+        let promisesToResolve = waitMap.get(filePath);
+        if (promisesToResolve) {
+          // if we find any, we call it
+          promisesToResolve();
         }
-
-        return {
-          get(target, prop) {
-            let original = Reflect.get(...arguments);
-            if (prop === 'readFile') {
-              return async function (...args) {
-                if (args[0].includes(fileToDelay)) {
-                  await wait(fileToWaitFor);
-                }
-                let result = await original.apply(this, args);
-                seen(path.basename(args[0]));
-                return result;
-              };
-            }
-            return original;
-          },
-        };
-      };
-
-      let workerFarm = createWorkerFarm({
-        maxConcurrentWorkers: 0,
-      });
-
-      let slowFooFS = new Proxy(overlayFS, waitHandler('foo.js', 'bar.js'));
-
-      try {
-        let b = await bundle(path.join(testDir, 'index.html'), {
-          inputFS: slowFooFS,
-          outputFS: slowFooFS,
-          shouldDisableCache: true,
-          workerFarm,
-        });
-
-        let bundleHashDelayFoo = b
-          .getBundles()
-          .find(
-            (b) => b.filePath.endsWith('.js') && b.filePath.includes('index'),
-          )
-          .filePath.split('.')[1];
-
-        let slowBarFS = new Proxy(overlayFS, waitHandler('bar.js', 'foo.js'));
-
-        let b2 = await bundle(path.join(testDir, 'index.html'), {
-          inputFS: slowBarFS,
-          outputFS: slowBarFS,
-          shouldDisableCache: true,
-          workerFarm,
-        });
-
-        let bundleHashDelayBar = b2
-          .getBundles()
-          .find(
-            (b) => b.filePath.endsWith('.js') && b.filePath.includes('index'),
-          )
-          .filePath.split('.')[1];
-
-        assert.strictEqual(bundleHashDelayFoo, bundleHashDelayBar);
-      } finally {
-        await workerFarm.end();
+        waitMap.set(filePath, null);
       }
 
-      it('should not deduplicate an asset if it will become unreachable', async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            'integration/sibling-deduplicate-unreachable/index.js',
-          ),
-          {mode: 'production'},
-        );
-        let res = await run(b);
-        assert.equal(res, 'target');
-      });
-    },
-  );
+      return {
+        get(target, prop) {
+          let original = Reflect.get(...arguments);
+          if (prop === 'readFile') {
+            return async function (...args) {
+              if (args[0].includes(fileToDelay)) {
+                await wait(fileToWaitFor);
+              }
+              let result = await original.apply(this, args);
+              seen(path.basename(args[0]));
+              return result;
+            };
+          }
+          return original;
+        },
+      };
+    };
 
-  it.v2(
-    'should add experimental bundle queue runtime for out of order bundle execution',
-    async function () {
-      await fsFixture(overlayFS, __dirname)`
+    let workerFarm = createWorkerFarm({
+      maxConcurrentWorkers: 0,
+    });
+
+    let slowFooFS = new Proxy(overlayFS, waitHandler('foo.js', 'bar.js'));
+
+    try {
+      let b = await bundle(path.join(testDir, 'index.html'), {
+        inputFS: slowFooFS,
+        outputFS: slowFooFS,
+        shouldDisableCache: true,
+        workerFarm,
+      });
+
+      let bundleHashDelayFoo = b
+        .getBundles()
+        .find((b) => b.filePath.endsWith('.js') && b.filePath.includes('index'))
+        .filePath.split('.')[1];
+
+      let slowBarFS = new Proxy(overlayFS, waitHandler('bar.js', 'foo.js'));
+
+      let b2 = await bundle(path.join(testDir, 'index.html'), {
+        inputFS: slowBarFS,
+        outputFS: slowBarFS,
+        shouldDisableCache: true,
+        workerFarm,
+      });
+
+      let bundleHashDelayBar = b2
+        .getBundles()
+        .find((b) => b.filePath.endsWith('.js') && b.filePath.includes('index'))
+        .filePath.split('.')[1];
+
+      assert.strictEqual(bundleHashDelayFoo, bundleHashDelayBar);
+    } finally {
+      await workerFarm.end();
+    }
+
+    it('should not deduplicate an asset if it will become unreachable', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          'integration/sibling-deduplicate-unreachable/index.js',
+        ),
+        {mode: 'production'},
+      );
+      let res = await run(b);
+      assert.equal(res, 'target');
+    });
+  });
+
+  it('should add experimental bundle queue runtime for out of order bundle execution', async function () {
+    await fsFixture(overlayFS, __dirname)`
       bundle-queue-runtime
         a.html:
           <script type="module" src="./a.js"></script>
@@ -6160,43 +6136,40 @@ describe('scope hoisting', function () {
           }
         yarn.lock:`;
 
-      let b = await bundle(
-        [
-          path.join(__dirname, 'bundle-queue-runtime/index.html'),
-          path.join(__dirname, 'bundle-queue-runtime/a.html'),
-        ],
-        {
-          mode: 'production',
-          defaultTargetOptions: {
-            shouldScopeHoist: true,
-            shouldOptimize: false,
-            outputFormat: 'esmodule',
-          },
-          inputFS: overlayFS,
+    let b = await bundle(
+      [
+        path.join(__dirname, 'bundle-queue-runtime/index.html'),
+        path.join(__dirname, 'bundle-queue-runtime/a.html'),
+      ],
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+          shouldOptimize: false,
+          outputFormat: 'esmodule',
         },
-      );
+        inputFS: overlayFS,
+      },
+    );
 
-      let contents = await outputFS.readFile(
-        b.getBundles().find((b) => /index.*\.js/.test(b.filePath)).filePath,
-        'utf8',
-      );
-      assert(contents.includes('$parcel$global.rwr('));
+    let contents = await outputFS.readFile(
+      b.getBundles().find((b) => /index.*\.js/.test(b.filePath)).filePath,
+      'utf8',
+    );
+    assert(contents.includes('$parcel$global.rwr('));
 
-      let result;
-      await run(b, {
-        result: (r) => {
-          result = r;
-        },
-      });
+    let result;
+    await run(b, {
+      result: (r) => {
+        result = r;
+      },
+    });
 
-      assert.deepEqual(await result, ['a', 'b', 'c']);
-    },
-  );
+    assert.deepEqual(await result, ['a', 'b', 'c']);
+  });
 
-  it.v2(
-    'should add experimental bundle queue runtime to manual shared bundles',
-    async function () {
-      await fsFixture(overlayFS, __dirname)`
+  it('should add experimental bundle queue runtime to manual shared bundles', async function () {
+    await fsFixture(overlayFS, __dirname)`
       bundle-queue-runtime
         index.html:
           <script type="module" src="./index.js"></script>
@@ -6222,64 +6195,63 @@ describe('scope hoisting', function () {
           }
         yarn.lock:`;
 
-      let b = await bundle(
-        [path.join(__dirname, 'bundle-queue-runtime/index.html')],
-        {
-          mode: 'production',
-          defaultTargetOptions: {
-            shouldScopeHoist: true,
-            shouldOptimize: false,
-            outputFormat: 'esmodule',
-          },
-          inputFS: overlayFS,
+    let b = await bundle(
+      [path.join(__dirname, 'bundle-queue-runtime/index.html')],
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+          shouldOptimize: false,
+          outputFormat: 'esmodule',
         },
-      );
-      function hasAsset(bundle, assetName) {
-        let result = false;
+        inputFS: overlayFS,
+      },
+    );
+    function hasAsset(bundle, assetName) {
+      let result = false;
 
-        bundle.traverseAssets((asset) => {
-          if (asset.filePath.includes(assetName)) {
-            result = true;
-          }
-        });
-
-        return result;
-      }
-      let sharedBundleContents = await outputFS.readFile(
-        nullthrows(
-          b.getBundles().find((b) => hasAsset(b, 'shared.js')),
-          'No shared bundle',
-        ).filePath,
-        'utf8',
-      );
-      let entryContents = await outputFS.readFile(
-        nullthrows(
-          b.getBundles().find((b) => hasAsset(b, 'index.js')),
-          'No entry bundle',
-        ).filePath,
-        'utf8',
-      );
-
-      assert(
-        sharedBundleContents.includes('$parcel$global.rlb('),
-        'Shared bundle should include register loaded bundle runtime',
-      );
-
-      assert(
-        entryContents.includes('$parcel$global.rwr('),
-        'Entry should include run when ready runtime',
-      );
-
-      let result;
-      await run(b, {
-        result: (r) => {
-          result = r;
-        },
+      bundle.traverseAssets((asset) => {
+        if (asset.filePath.includes(assetName)) {
+          result = true;
+        }
       });
 
-      assert.deepEqual(await result, ['index', 'shared']);
-    },
-  );
+      return result;
+    }
+    let sharedBundleContents = await outputFS.readFile(
+      nullthrows(
+        b.getBundles().find((b) => hasAsset(b, 'shared.js')),
+        'No shared bundle',
+      ).filePath,
+      'utf8',
+    );
+    let entryContents = await outputFS.readFile(
+      nullthrows(
+        b.getBundles().find((b) => hasAsset(b, 'index.js')),
+        'No entry bundle',
+      ).filePath,
+      'utf8',
+    );
+
+    assert(
+      sharedBundleContents.includes('$parcel$global.rlb('),
+      'Shared bundle should include register loaded bundle runtime',
+    );
+
+    assert(
+      entryContents.includes('$parcel$global.rwr('),
+      'Entry should include run when ready runtime',
+    );
+
+    let result;
+    await run(b, {
+      result: (r) => {
+        result = r;
+      },
+    });
+
+    assert.deepEqual(await result, ['index', 'shared']);
+  });
 
   it('should not add experimental bundle queue runtime to empty bundles', async function () {
     await fsFixture(overlayFS, __dirname)`

--- a/packages/core/integration-tests/test/transpilation.js
+++ b/packages/core/integration-tests/test/transpilation.js
@@ -17,7 +17,7 @@ import nullthrows from 'nullthrows';
 
 const inputDir = path.join(__dirname, '/input');
 
-describe.v2('transpilation', function () {
+describe('transpilation', function () {
   it('should not transpile if no targets are defined', async function () {
     await bundle(path.join(__dirname, '/integration/babel-default/index.js'), {
       defaultTargetOptions: {
@@ -101,221 +101,253 @@ describe.v2('transpilation', function () {
     assert(file.includes('fileName: "integration/jsx/index.jsx"'));
   });
 
-  it('should support compiling JSX correctly with member expression type', async function () {
-    await bundle(path.join(__dirname, '/integration/jsx-member/index.jsx'));
+  describe.v2('supports compiling JSX', () => {
+    it('with member expression type', async function () {
+      await bundle(path.join(__dirname, '/integration/jsx-member/index.jsx'));
 
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('React.createElement(S.Foo'));
-  });
-
-  it('should support compiling JSX in JS files with React dependency', async function () {
-    await bundle(path.join(__dirname, '/integration/jsx-react/index.js'));
-
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('React.createElement("div"'));
-  });
-
-  it('should support compiling JSX with pure annotations', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-react/pure-comment.js'),
-    );
-
-    let file = await outputFS.readFile(
-      path.join(distDir, 'pure-comment.js'),
-      'utf8',
-    );
-    assert(
-      file.includes('/*#__PURE__*/ (0, _reactDefault.default).createElement'),
-    );
-
-    let res = await run(b);
-    assert(res.Foo());
-  });
-
-  it('should support compiling JSX in JS files with React aliased to Preact', async function () {
-    await bundle(path.join(__dirname, '/integration/jsx-react-alias/index.js'));
-
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('React.createElement("div"'));
-  });
-
-  it('should support compiling JSX in JS files with Preact dependency', async function () {
-    await bundle(path.join(__dirname, '/integration/jsx-preact/index.js'));
-
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('h("div"'));
-  });
-
-  it('should support compiling JSX in JS files with Preact url dependency', async function () {
-    await bundle(
-      path.join(__dirname, '/integration/jsx-preact-with-url/index.js'),
-    );
-
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('h("div"'));
-  });
-
-  it('should support compiling JSX in TS files with Preact dependency', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-preact-ts/index.tsx'),
-    );
-
-    assert(typeof (await run(b)) === 'object');
-  });
-
-  it('should support compiling JSX in JS files with Nerv dependency', async function () {
-    await bundle(path.join(__dirname, '/integration/jsx-nervjs/index.js'));
-
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('Nerv.createElement("div"'));
-  });
-
-  it('should support compiling JSX in JS files with Hyperapp dependency', async function () {
-    await bundle(path.join(__dirname, '/integration/jsx-hyperapp/index.js'));
-
-    let file = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(file.includes('h("div"'));
-  });
-
-  it('should not transpile spread in JSX with modern targets', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-spread/index.jsx'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('React.createElement("div"'));
-    assert(file.includes('...a'));
-    assert(!file.includes('@swc/helpers'));
-  });
-
-  it('should support the automatic JSX runtime with React >= 17', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-automatic/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('react/jsx-dev-runtime'));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support the automatic JSX runtime with preact >= 10.5', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-automatic-preact/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('preact/jsx-dev-runtime'));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support the automatic JSX runtime with React ^16.14.0', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-automatic-16/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('react/jsx-dev-runtime'));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support the automatic JSX runtime with React 18 prereleases', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-automatic-18/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('react/jsx-dev-runtime'));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support the automatic JSX runtime with experimental React versions', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-automatic-experimental/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('react/jsx-dev-runtime'));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support the automatic JSX runtime with preact with alias', async function () {
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/jsx-automatic-preact-with-alias/index.js',
-      ),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(/\Wreact\/jsx-dev-runtime\W/.test(file));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support the automatic JSX runtime with explicit tsconfig.json', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-automatic-tsconfig/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('preact/jsx-dev-runtime'));
-    assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
-  });
-
-  it('should support explicit JSX pragma in tsconfig.json', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-pragma-tsconfig/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('JSX(JSXFragment'));
-    assert(file.includes('JSX("div"'));
-  });
-
-  it('should support explicitly enabling JSX in tsconfig.json', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/jsx-tsconfig/index.js'),
-    );
-
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('React.createElement("div"'));
-  });
-
-  it('should support enabling decorators in tsconfig.json', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/decorators/index.ts'),
-    );
-
-    let output = [];
-    await run(b, {
-      output(o) {
-        output.push(o);
-      },
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('React.createElement(S.Foo'));
     });
 
-    assert.deepEqual(output, [
-      'first(): factory evaluated',
-      'second(): factory evaluated',
-      'second(): called',
-      'first(): called',
-    ]);
-  });
+    it('with pure annotations', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-react/pure-comment.js'),
+      );
 
-  it('should support enabling decorators and setting useDefineForClassFields in tsconfig.json', async function () {
-    let b = await bundle(
-      path.join(
-        __dirname,
-        '/integration/decorators-useDefineForClassFields/index.ts',
-      ),
-    );
+      let file = await outputFS.readFile(
+        path.join(distDir, 'pure-comment.js'),
+        'utf8',
+      );
+      assert(
+        file.includes('/*#__PURE__*/ (0, _reactDefault.default).createElement'),
+      );
 
-    let output = [];
-    await run(b, {
-      output(...o) {
-        output.push(...o);
-      },
+      let res = await run(b);
+      assert(res.Foo());
     });
 
-    assert.deepEqual(output, ['foo 15', 'foo 16']);
+    it('spread with modern targets', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-spread/index.jsx'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('React.createElement("div"'));
+      assert(file.includes('...a'));
+      assert(!file.includes('@swc/helpers'));
+    });
+
+    it('in js files with a React dependency', async function () {
+      await bundle(path.join(__dirname, '/integration/jsx-react/index.js'));
+
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('React.createElement("div"'));
+    });
+
+    it('in js files with React aliased to Preact', async function () {
+      await bundle(
+        path.join(__dirname, '/integration/jsx-react-alias/index.js'),
+      );
+
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('React.createElement("div"'));
+    });
+
+    it('in js files with Preact dependency', async function () {
+      await bundle(path.join(__dirname, '/integration/jsx-preact/index.js'));
+
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('h("div"'));
+    });
+
+    it('in ts files with Preact dependency', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-preact-ts/index.tsx'),
+      );
+
+      assert(typeof (await run(b)) === 'object');
+    });
+
+    it('in js files with Preact url dependency', async function () {
+      await bundle(
+        path.join(__dirname, '/integration/jsx-preact-with-url/index.js'),
+      );
+
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('h("div"'));
+    });
+
+    it('in js files with Nerv dependency', async function () {
+      await bundle(path.join(__dirname, '/integration/jsx-nervjs/index.js'));
+
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('Nerv.createElement("div"'));
+    });
+
+    it('in js files with Hyperapp dependency', async function () {
+      await bundle(path.join(__dirname, '/integration/jsx-hyperapp/index.js'));
+
+      let file = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(file.includes('h("div"'));
+    });
+  });
+
+  describe.v2('supports the automatic jsx runtime', () => {
+    it('with React >= 17', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-automatic/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('react/jsx-dev-runtime'));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+
+    it('with Preact >= 10.5', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-automatic-preact/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('preact/jsx-dev-runtime'));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+
+    it('with React ^16.14.0', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-automatic-16/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('react/jsx-dev-runtime'));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+
+    it('with React 18 prereleases', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-automatic-18/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('react/jsx-dev-runtime'));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+
+    it('with experimental React versions', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/jsx-automatic-experimental/index.js',
+        ),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('react/jsx-dev-runtime'));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+
+    it('with Preact alias', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/jsx-automatic-preact-with-alias/index.js',
+        ),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(/\Wreact\/jsx-dev-runtime\W/.test(file));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+
+    it('with explicit tsconfig.json', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-automatic-tsconfig/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('preact/jsx-dev-runtime'));
+      assert(file.includes('(0, _jsxDevRuntime.jsxDEV)("div"'));
+    });
+  });
+
+  describe('of tsconfig.json', () => {
+    it.v2('supports explicit JSX pragma', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-pragma-tsconfig/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('JSX(JSXFragment'));
+      assert(file.includes('JSX("div"'));
+    });
+
+    it.v2('supports explicitly enabling JSX', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/jsx-tsconfig/index.js'),
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('React.createElement("div"'));
+    });
+
+    it('supports decorators', async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/decorators/index.ts'),
+      );
+
+      let output = [];
+      await run(b, {
+        output(o) {
+          output.push(o);
+        },
+      });
+
+      assert.deepEqual(output, [
+        'first(): factory evaluated',
+        'second(): factory evaluated',
+        'second(): called',
+        'first(): called',
+      ]);
+    });
+
+    it('supports decorators and setting useDefineForClassFields', async function () {
+      let b = await bundle(
+        path.join(
+          __dirname,
+          '/integration/decorators-useDefineForClassFields/index.ts',
+        ),
+      );
+
+      let output = [];
+      await run(b, {
+        output(...o) {
+          output.push(...o);
+        },
+      });
+
+      assert.deepEqual(output, ['foo 15', 'foo 16']);
+    });
   });
 
   it('should support transpiling optional chaining', async function () {
@@ -343,61 +375,72 @@ describe.v2('transpilation', function () {
     assert(!file.includes('es.array.concat'));
   });
 
-  it('should resolve @swc/helpers and regenerator-runtime relative to parcel', async function () {
-    let dir = path.join('/tmp/' + Math.random().toString(36).slice(2));
-    await outputFS.mkdirp(dir);
-    await ncp(path.join(__dirname, '/integration/swc-helpers'), dir);
-    await bundle(path.join(dir, 'index.js'), {
-      mode: 'production',
-      inputFS: overlayFS,
-      defaultTargetOptions: {
-        engines: {
-          browsers: '>= 0.25%',
-        },
-      },
-    });
-  });
-
-  it('should support commonjs and esm versions of @swc/helpers', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/swc-helpers-library/index.js'),
-    );
-
-    let file = await outputFS.readFile(
-      nullthrows(b.getBundles().find((b) => b.env.outputFormat === 'commonjs'))
-        .filePath,
-      'utf8',
-    );
-    assert(file.includes('@swc/helpers/cjs/_class_call_check.cjs'));
-
-    file = await outputFS.readFile(
-      nullthrows(b.getBundles().find((b) => b.env.outputFormat === 'esmodule'))
-        .filePath,
-      'utf8',
-    );
-    assert(file.includes('@swc/helpers/_/_class_call_check'));
-  });
-
-  it('should support commonjs versions of @swc/helpers without scope hoisting', async function () {
-    let b = await bundle(
-      path.join(__dirname, '/integration/swc-helpers-library/index.js'),
-      {
-        targets: {
-          test: {
-            distDir,
-            isLibrary: true,
-            scopeHoist: false,
+  it.v2(
+    'should resolve @swc/helpers and regenerator-runtime relative to parcel',
+    async function () {
+      let dir = path.join('/tmp/' + Math.random().toString(36).slice(2));
+      await outputFS.mkdirp(dir);
+      await ncp(path.join(__dirname, '/integration/swc-helpers'), dir);
+      await bundle(path.join(dir, 'index.js'), {
+        mode: 'production',
+        inputFS: overlayFS,
+        defaultTargetOptions: {
+          engines: {
+            browsers: '>= 0.25%',
           },
         },
-      },
-    );
+      });
+    },
+  );
 
-    let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
-    assert(file.includes('@swc/helpers/cjs/_class_call_check.cjs'));
-    await run(b);
-  });
+  it.v2(
+    'should support commonjs and esm versions of @swc/helpers',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/swc-helpers-library/index.js'),
+      );
 
-  it('should print errors from transpilation', async function () {
+      let file = await outputFS.readFile(
+        nullthrows(
+          b.getBundles().find((b) => b.env.outputFormat === 'commonjs'),
+        ).filePath,
+        'utf8',
+      );
+      assert(file.includes('@swc/helpers/cjs/_class_call_check.cjs'));
+
+      file = await outputFS.readFile(
+        nullthrows(
+          b.getBundles().find((b) => b.env.outputFormat === 'esmodule'),
+        ).filePath,
+        'utf8',
+      );
+      assert(file.includes('@swc/helpers/_/_class_call_check'));
+    },
+  );
+
+  it.v2(
+    'should support commonjs versions of @swc/helpers without scope hoisting',
+    async function () {
+      let b = await bundle(
+        path.join(__dirname, '/integration/swc-helpers-library/index.js'),
+        {
+          targets: {
+            test: {
+              distDir,
+              isLibrary: true,
+              scopeHoist: false,
+            },
+          },
+        },
+      );
+
+      let file = await outputFS.readFile(b.getBundles()[0].filePath, 'utf8');
+      assert(file.includes('@swc/helpers/cjs/_class_call_check.cjs'));
+      await run(b);
+    },
+  );
+
+  it.v2('should print errors from transpilation', async function () {
     let source = path.join(
       __dirname,
       '/integration/transpilation-invalid/index.js',

--- a/packages/core/integration-tests/test/typescript.js
+++ b/packages/core/integration-tests/test/typescript.js
@@ -18,7 +18,7 @@ const tscConfig = path.join(
   '/integration/typescript-config/.parcelrc',
 );
 
-describe.v2('typescript', function () {
+describe('typescript', function () {
   // This tests both the SWC transformer implementation of typescript (which
   // powers typescript by default in Parcel) as well as through the Typescript
   // tsc transformer. Use a `undefined` config to indicate the default config, and the
@@ -29,232 +29,244 @@ describe.v2('typescript', function () {
     undefined /* default config -- testing SWC typescript */,
     tscConfig,
   ]) {
-    it('should produce a ts bundle using ES6 imports', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript/index.ts'),
-        {config},
-      );
+    describe(`using ${
+      config ? '@atlaspack/transformer-typescript-tsc' : 'default config'
+    }`, () => {
+      it.v2('should produce a ts bundle using ES6 imports', async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript/index.ts'),
+          {config},
+        );
 
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'Local.ts', 'esmodule-helpers.js'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-    });
-
-    it('should produce a ts bundle using commonJS require', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-require/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'Local.ts', 'esmodule-helpers.js'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-    });
-
-    it('should support json require', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-json/index.ts'),
-      );
-
-      // assert.equal(b.assets.size, 2);
-      // assert.equal(b.childBundles.size, 1);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-    });
-
-    it('should support env variables', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-env/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'esmodule-helpers.js'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.env, 'function');
-      assert.equal(output.env(), 'test');
-    });
-
-    it('should support importing a URL to a raw asset', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-raw/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['index.ts', 'bundle-url.js', 'esmodule-helpers.js'],
-        },
-        {
-          type: 'txt',
-          assets: ['test.txt'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.getRaw, 'function');
-      assert(/http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()));
-      assert(
-        await outputFS.exists(
-          path.join(distDir, nullthrows(url.parse(output.getRaw()).pathname)),
-        ),
-      );
-    });
-
-    it('should minify with minify enabled', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-require/index.ts'),
-        {
-          config,
-          defaultTargetOptions: {
-            shouldOptimize: true,
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: ['index.ts', 'Local.ts', 'esmodule-helpers.js'],
           },
-        },
-      );
+        ]);
 
-      assertBundles(b, [
-        {
-          type: 'js',
-          assets: ['index.ts', 'Local.ts', 'esmodule-helpers.js'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.count, 'function');
-      assert.equal(output.count(), 3);
-
-      let js = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-      assert(!js.includes('local.a'));
-    });
-
-    it('should support compiling JSX', async function () {
-      await bundle(
-        path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
-        {config},
-      );
-
-      let file = await outputFS.readFile(
-        path.join(distDir, 'index.js'),
-        'utf8',
-      );
-      assert(file.includes('React.createElement("div"'));
-    });
-
-    it('should use esModuleInterop by default', async function () {
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-interop/index.ts'),
-        {config},
-      );
-
-      assertBundles(b, [
-        {
-          name: 'index.js',
-          assets: ['esmodule-helpers.js', 'index.ts', 'commonjs-module.js'],
-        },
-      ]);
-
-      let output = await run(b);
-      assert.equal(typeof output.test, 'function');
-      assert.equal(output.test(), 'test passed');
-    });
-
-    it('fs.readFileSync should inline a file as a string', async function () {
-      if (config != null) {
-        return;
-      }
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-fs/index.ts'),
-        {config},
-      );
-
-      const text = 'export default <div>Hello</div>;';
-      let output = await run(b);
-
-      assert.deepEqual(output, {
-        fromTs: text,
-        fromTsx: text,
+        let output = await run(b);
+        assert.equal(typeof output.count, 'function');
+        assert.equal(output.count(), 3);
       });
-    });
 
-    it('should handle legacy cast in .ts file', async function () {
-      if (config != null) {
-        return;
-      }
-      await bundle(
-        path.join(__dirname, '/integration/typescript-legacy-cast/index.ts'),
-        {config},
+      it.v2(
+        'should produce a ts bundle using commonJS require',
+        async function () {
+          let b = await bundle(
+            path.join(__dirname, '/integration/typescript-require/index.ts'),
+            {config},
+          );
+
+          assertBundles(b, [
+            {
+              type: 'js',
+              assets: ['index.ts', 'Local.ts', 'esmodule-helpers.js'],
+            },
+          ]);
+
+          let output = await run(b);
+          assert.equal(typeof output.count, 'function');
+          assert.equal(output.count(), 3);
+        },
       );
-    });
 
-    it('should handle compile enums correctly', async function () {
-      if (config != null) {
-        return;
-      }
-      let b = await bundle(
-        path.join(__dirname, '/integration/typescript-enum/index.ts'),
-        {config},
-      );
+      it('should support json require', async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-json/index.ts'),
+        );
 
-      let output = await run(b);
+        // assert.equal(b.assets.size, 2);
+        // assert.equal(b.childBundles.size, 1);
 
-      assert.deepEqual(output, {
-        A: {
-          X: 'X',
-          Y: 'Y',
-        },
-        B: {
-          X: 'X',
-          Y: 'Y',
-        },
-        C: {
-          X: 'X',
-          Y: 'Y',
-        },
-        z: {
-          a: 'X',
-          c: 'Y',
-        },
+        let output = await run(b);
+        assert.equal(typeof output.count, 'function');
+        assert.equal(output.count(), 3);
       });
-    });
 
-    it('should handle simultaneous import type and reexport correctly', async function () {
-      if (config != null) {
-        return;
-      }
-      let b = await bundle(
-        path.join(
-          __dirname,
-          '/integration/typescript-import-type-reexport/index.ts',
-        ),
-        {config},
-      );
+      it.v2('should support env variables', async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-env/index.ts'),
+          {config},
+        );
 
-      let output = await run(b);
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: ['index.ts', 'esmodule-helpers.js'],
+          },
+        ]);
 
-      assert.deepEqual(output, {
-        Bar: 123,
+        let output = await run(b);
+        assert.equal(typeof output.env, 'function');
+        assert.equal(output.env(), 'test');
+      });
+
+      it.v2('should support importing a URL to a raw asset', async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-raw/index.ts'),
+          {config},
+        );
+
+        assertBundles(b, [
+          {
+            name: 'index.js',
+            assets: ['index.ts', 'bundle-url.js', 'esmodule-helpers.js'],
+          },
+          {
+            type: 'txt',
+            assets: ['test.txt'],
+          },
+        ]);
+
+        let output = await run(b);
+        assert.equal(typeof output.getRaw, 'function');
+        assert(
+          /http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output.getRaw()),
+        );
+        assert(
+          await outputFS.exists(
+            path.join(distDir, nullthrows(url.parse(output.getRaw()).pathname)),
+          ),
+        );
+      });
+
+      it.v2('should minify with minify enabled', async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-require/index.ts'),
+          {
+            config,
+            defaultTargetOptions: {
+              shouldOptimize: true,
+            },
+          },
+        );
+
+        assertBundles(b, [
+          {
+            type: 'js',
+            assets: ['index.ts', 'Local.ts', 'esmodule-helpers.js'],
+          },
+        ]);
+
+        let output = await run(b);
+        assert.equal(typeof output.count, 'function');
+        assert.equal(output.count(), 3);
+
+        let js = await outputFS.readFile(
+          path.join(distDir, 'index.js'),
+          'utf8',
+        );
+        assert(!js.includes('local.a'));
+      });
+
+      it.v2('should support compiling JSX', async function () {
+        await bundle(
+          path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
+          {config},
+        );
+
+        let file = await outputFS.readFile(
+          path.join(distDir, 'index.js'),
+          'utf8',
+        );
+        assert(file.includes('React.createElement("div"'));
+      });
+
+      it.v2('should use esModuleInterop by default', async function () {
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-interop/index.ts'),
+          {config},
+        );
+
+        assertBundles(b, [
+          {
+            name: 'index.js',
+            assets: ['esmodule-helpers.js', 'index.ts', 'commonjs-module.js'],
+          },
+        ]);
+
+        let output = await run(b);
+        assert.equal(typeof output.test, 'function');
+        assert.equal(output.test(), 'test passed');
+      });
+
+      it('fs.readFileSync should inline a file as a string', async function () {
+        if (config != null) {
+          return;
+        }
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-fs/index.ts'),
+          {config},
+        );
+
+        const text = 'export default <div>Hello</div>;';
+        let output = await run(b);
+
+        assert.deepEqual(output, {
+          fromTs: text,
+          fromTsx: text,
+        });
+      });
+
+      it('should handle legacy cast in .ts file', async function () {
+        if (config != null) {
+          return;
+        }
+        await bundle(
+          path.join(__dirname, '/integration/typescript-legacy-cast/index.ts'),
+          {config},
+        );
+      });
+
+      it('should handle compile enums correctly', async function () {
+        if (config != null) {
+          return;
+        }
+        let b = await bundle(
+          path.join(__dirname, '/integration/typescript-enum/index.ts'),
+          {config},
+        );
+
+        let output = await run(b);
+
+        assert.deepEqual(output, {
+          A: {
+            X: 'X',
+            Y: 'Y',
+          },
+          B: {
+            X: 'X',
+            Y: 'Y',
+          },
+          C: {
+            X: 'X',
+            Y: 'Y',
+          },
+          z: {
+            a: 'X',
+            c: 'Y',
+          },
+        });
+      });
+
+      it('should handle simultaneous import type and reexport correctly', async function () {
+        if (config != null) {
+          return;
+        }
+        let b = await bundle(
+          path.join(
+            __dirname,
+            '/integration/typescript-import-type-reexport/index.ts',
+          ),
+          {config},
+        );
+
+        let output = await run(b);
+
+        assert.deepEqual(output, {
+          Bar: 123,
+        });
       });
     });
   }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1314,58 +1314,66 @@ export function request(
 
 // $FlowFixMe
 let origDescribe = globalThis.describe;
-let parcelVersion: string | void;
+let atlaspackVersion: string | void;
+
+function applyVersion(version: string | void, fn: () => void) {
+  let previousVersion = atlaspackVersion;
+  atlaspackVersion = version;
+  fn();
+  atlaspackVersion = previousVersion;
+}
 
 export function describe(...args: mixed[]) {
-  parcelVersion = undefined;
-  origDescribe.apply(this, args);
+  applyVersion(undefined, origDescribe.bind(this, ...args));
 }
 
 describe.only = function (...args: mixed[]) {
-  parcelVersion = undefined;
-  origDescribe.only.apply(this, args);
+  applyVersion(undefined, origDescribe.only.bind(this, ...args));
 };
 
 describe.skip = function (...args: mixed[]) {
-  parcelVersion = undefined;
-  origDescribe.skip.apply(this, args);
+  applyVersion(undefined, origDescribe.skip.bind(this, ...args));
 };
 
 describe.v2 = function (...args: mixed[]) {
-  parcelVersion = 'v2';
-  if (!isAtlaspackV3) {
-    origDescribe.apply(this, args);
-  }
+  applyVersion('v2', () => {
+    if (!isAtlaspackV3) {
+      origDescribe.apply(this, args);
+    }
+  });
 };
 
 describe.v2.only = function (...args: mixed[]) {
-  parcelVersion = 'v2';
-  if (!isAtlaspackV3) {
-    origDescribe.only.apply(this, args);
-  }
+  applyVersion('v2', () => {
+    if (!isAtlaspackV3) {
+      origDescribe.only.apply(this, args);
+    }
+  });
 };
 
 describe.v3 = function (...args: mixed[]) {
-  parcelVersion = 'v3';
-  if (isAtlaspackV3) {
-    origDescribe.apply(this, args);
-  }
+  applyVersion('v3', () => {
+    if (isAtlaspackV3) {
+      origDescribe.apply(this, args);
+    }
+  });
 };
 
 describe.v3.only = function (...args: mixed[]) {
-  parcelVersion = 'v3';
-  if (isAtlaspackV3) {
-    origDescribe.only.apply(this, args);
-  }
+  applyVersion('v3', () => {
+    if (isAtlaspackV3) {
+      origDescribe.only.apply(this, args);
+    }
+  });
 };
 
 let origIt = globalThis.it;
 
 export function it(...args: mixed[]) {
   if (
-    parcelVersion == null ||
-    (parcelVersion == 'v2' && !isAtlaspackV3) ||
-    (parcelVersion == 'v3' && isAtlaspackV3)
+    atlaspackVersion == null ||
+    (atlaspackVersion == 'v2' && !isAtlaspackV3) ||
+    (atlaspackVersion == 'v3' && isAtlaspackV3)
   ) {
     origIt.apply(this, args);
   }


### PR DESCRIPTION
## Motivation

Several tests from v3 are now passing, so they have been enabled

## Changes

* Enable 120 more tests overall (682 → 802, ~51% total tests)
* Fix version handling for `describe` blocks
* Group some related tests together in describe blocks, so they can be disabled all at once

## Checklist

- [x] Existing or new tests cover this change
