### PR TITLE
V3: Passthrough all default target options

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -160,17 +160,8 @@ export default class Atlaspack {
           : [entries],
         env: resolvedOptions.env,
         fs: inputFS && new FileSystemV3(inputFS),
-        defaultTargetOptions: {
-          // $FlowFixMe projectPath is just a string
-          distDir: resolvedOptions.defaultTargetOptions.distDir,
-          engines: resolvedOptions.defaultTargetOptions.engines,
-          isLibrary: resolvedOptions.defaultTargetOptions.isLibrary,
-          outputFormat: resolvedOptions.defaultTargetOptions.outputFormat,
-          sourceMaps: resolvedOptions.defaultTargetOptions.sourceMaps,
-          shouldOptimize: resolvedOptions.defaultTargetOptions.shouldOptimize,
-          shouldScopeHoist:
-            resolvedOptions.defaultTargetOptions.shouldScopeHoist,
-        },
+        // $FlowFixMe ProjectPath is a string
+        defaultTargetOptions: resolvedOptions.defaultTargetOptions,
         lmdb,
       });
     }


### PR DESCRIPTION
## Motivation

`publicUrl` is not being passed into `AtlaspackV3` causing internal builds to fail

## Changes

Pass through all the default options

## Checklist

- [x] Existing or new tests cover this change
