### PR TITLE
V3: Don't use magic comment transformer in native

### DIFF
--- a/crates/atlaspack/src/plugins/config_plugins.rs
+++ b/crates/atlaspack/src/plugins/config_plugins.rs
@@ -207,6 +207,7 @@ impl Plugins for ConfigPlugins {
         "@atlaspack/transformer-react-refresh-wrap" => continue,
         "@atlaspack/transformer-posthtml" => continue,
         "@atlaspack/transformer-postcss" => continue,
+        "@atlassian/parcel-transformer-magic-comment" => continue,
         _ => {}
       }
 


### PR DESCRIPTION
- Skipping the `@atlassian/parcel-transformer-magic-comment` in V3