### PR TITLE
V3: Forward missing symbols meta

### DIFF
--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -114,6 +114,7 @@ function getAssetGraph(serializedGraph, options) {
         isEsm: true,
       };
     }
+
     return [exported, jsSymbol];
   }
 


### PR DESCRIPTION
## Motivation

Some symbols are not passed through to JS and back to Rust correctly, which causes the scope hoisting packager to fail when `isEsm` is not set but `has_cjs_exports` is.

## Changes

Fix the worker layer to forward through the missing symbols, add tests related to exports introduced while debugging

## Checklist

- [x] Existing or new tests cover this change
