### PR TITLE
Add evaluateRootConditionalBundles option so servers can fallback to safe behaviour

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "devDependencies": {
     "@atlaspack/babel-register": "*",
     "@babel/core": "^7.22.11",
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@khanacademy/flow-to-ts": "^0.5.2",
     "@napi-rs/cli": "^2.18.3",
     "@types/node": ">= 18",

--- a/packages/bundlers/default/src/bundlerConfig.js
+++ b/packages/bundlers/default/src/bundlerConfig.js
@@ -136,6 +136,9 @@ const CONFIG_SCHEMA: SchemaEntity = {
     disableSharedBundles: {
       type: 'boolean',
     },
+    loadConditionalBundlesInParallel: {
+      type: 'boolean',
+    },
   },
   additionalProperties: false,
 };

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -55,24 +55,34 @@ export type DependencyBundleGraph = ContentGraph<
   number,
 >;
 
-// IdealGraph is the structure we will pass to decorate,
-// which mutates the assetGraph into the bundleGraph we would
-// expect from default bundler
-export type IdealGraph = {|
-  assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
-  assets: Array<Asset>,
-  bundleGraph: Graph<Bundle | 'root'>,
-  bundleGroupBundleIds: Set<NodeId>,
-  dependencyBundleGraph: DependencyBundleGraph,
-  manualAssetToBundle: Map<Asset, NodeId>,
-|};
-
 const dependencyPriorityEdges = {
   sync: 1,
   parallel: 2,
   lazy: 3,
   conditional: 4,
 };
+
+export const idealBundleGraphEdges = Object.freeze({
+  default: 1,
+  conditional: 2,
+});
+
+type IdealBundleGraph = Graph<
+  Bundle | 'root',
+  $Values<typeof idealBundleGraphEdges>,
+>;
+
+// IdealGraph is the structure we will pass to decorate,
+// which mutates the assetGraph into the bundleGraph we would
+// expect from default bundler
+export type IdealGraph = {|
+  assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
+  assets: Array<Asset>,
+  bundleGraph: IdealBundleGraph,
+  bundleGroupBundleIds: Set<NodeId>,
+  dependencyBundleGraph: DependencyBundleGraph,
+  manualAssetToBundle: Map<Asset, NodeId>,
+|};
 
 export function createIdealGraph(
   assetGraph: MutableBundleGraph,
@@ -91,7 +101,7 @@ export function createIdealGraph(
 
   // A Graph of Bundles and a root node (dummy string), which models only Bundles, and connections to their
   // referencing Bundle. There are no actual BundleGroup nodes, just bundles that take on that role.
-  let bundleGraph: Graph<Bundle | 'root'> = new Graph();
+  let bundleGraph: IdealBundleGraph = new Graph();
   let stack: Array<[BundleRoot, NodeId]> = [];
 
   let bundleRootEdgeTypes = {
@@ -363,12 +373,7 @@ export function createIdealGraph(
                 dependencyPriorityEdges[dependency.priority],
               );
 
-              if (
-                (config.loadConditionalBundlesInParallel ??
-                  !bundle.env.shouldScopeHoist) &&
-                dependency.priority === 'conditional'
-              ) {
-                // When configured (or serving code in development), serve conditional bundles in parallel so we don't get module not found errors
+              if (dependency.priority === 'conditional') {
                 let [referencingBundleRoot, bundleGroupNodeId] = nullthrows(
                   stack[stack.length - 1],
                 );
@@ -377,8 +382,24 @@ export function createIdealGraph(
                   bundleRoots.get(referencingBundleRoot),
                 )[0];
 
-                bundleRoots.set(childAsset, [bundleId, bundleGroupNodeId]);
-                bundleGraph.addEdge(referencingBundleId, bundleId);
+                if (
+                  getFeatureFlag('conditionalBundlingApi') &&
+                  (config.loadConditionalBundlesInParallel ??
+                    !bundle.env.shouldScopeHoist)
+                ) {
+                  // When configured (or serving code in development), serve conditional bundles in parallel so we don't get module not found errors
+                  bundleRoots.set(childAsset, [bundleId, bundleGroupNodeId]);
+                  bundleGraph.addEdge(referencingBundleId, bundleId);
+                }
+
+                if (getFeatureFlag('conditionalBundlingApi')) {
+                  // Add conditional edge
+                  bundleGraph.addEdge(
+                    referencingBundleId,
+                    bundleId,
+                    idealBundleGraphEdges.conditional,
+                  );
+                }
               }
             } else if (
               dependency.priority === 'parallel' ||
@@ -1307,7 +1328,7 @@ export function createIdealGraph(
   }
 
   function removeBundle(
-    bundleGraph: Graph<Bundle | 'root'>,
+    bundleGraph: IdealBundleGraph,
     bundleId: NodeId,
     assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
   ) {

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -2289,11 +2289,7 @@ export default class BundleGraph {
     this._graph.dfs({
       visit: (nodeId) => {
         let node = nullthrows(this._graph.getNode(nodeId));
-        if (node.type !== 'bundle') {
-          return;
-        }
-
-        if (node.value.id === bundle.id) {
+        if (node.type !== 'bundle' || node.value.id === bundle.id) {
           return;
         }
 

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -73,6 +73,9 @@ export const bundleGraphEdgeTypes = {
   // Signals that the dependency is internally resolvable via the bundle's ancestry,
   // and that the bundle connected to the dependency is not necessary for the source bundle.
   internal_async: 5,
+  // This type is used to mark an edge between a bundle and a conditional bundle.
+  // This allows efficient discovery of conditional bundles in packaging
+  conditional: 5,
 };
 
 export type BundleGraphEdgeType = $Values<typeof bundleGraphEdgeTypes>;
@@ -1176,6 +1179,14 @@ export default class BundleGraph {
     );
   }
 
+  createBundleConditionalReference(from: Bundle, to: Bundle): void {
+    this._graph.addEdge(
+      this._graph.getNodeIdByContentKey(from.id),
+      this._graph.getNodeIdByContentKey(to.id),
+      bundleGraphEdgeTypes.conditional,
+    );
+  }
+
   getBundlesWithAsset(asset: Asset): Array<Bundle> {
     return this._graph
       .getNodeIdsConnectedTo(
@@ -2271,5 +2282,31 @@ export default class BundleGraph {
     let root = getRootDir(entries);
     this._targetEntryRoots.set(target.distDir, root);
     return root;
+  }
+
+  getReferencedConditionalBundles(bundle: Bundle): Array<Bundle> {
+    let referencedBundles = new Set();
+    this._graph.dfs({
+      visit: (nodeId) => {
+        let node = nullthrows(this._graph.getNode(nodeId));
+        if (node.type !== 'bundle') {
+          return;
+        }
+
+        if (node.value.id === bundle.id) {
+          return;
+        }
+
+        referencedBundles.add(node.value);
+      },
+      startNodeId: this._graph.getNodeIdByContentKey(bundle.id),
+      getChildren: (nodeId) =>
+        this._graph.getNodeIdsConnectedFrom(
+          nodeId,
+          bundleGraphEdgeTypes.conditional,
+        ),
+    });
+
+    return [...referencedBundles];
   }
 }

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -494,4 +494,10 @@ export default class BundleGraph<TBundle: IBundle>
 
     return bundleConditions;
   }
+
+  getReferencedConditionalBundles(bundle: IBundle): Array<TBundle> {
+    return this.#graph
+      .getReferencedConditionalBundles(bundleToInternalBundle(bundle))
+      .map((result) => this.#createBundle(result, this.#graph, this.#options));
+  }
 }

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -280,6 +280,13 @@ export default class MutableBundleGraph
     );
   }
 
+  createBundleConditionalReference(from: IBundle, to: IBundle): void {
+    return this.#graph.createBundleConditionalReference(
+      bundleToInternalBundle(from),
+      bundleToInternalBundle(to),
+    );
+  }
+
   getDependencyAssets(dependency: IDependency): Array<IAsset> {
     return this.#graph
       .getDependencyAssets(dependencyToInternalDependency(dependency))

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -27,7 +27,7 @@ import MutableBundleGraph from '../public/MutableBundleGraph';
 import {Bundle, NamedBundle} from '../public/Bundle';
 import {report} from '../ReporterRunner';
 import dumpGraphToGraphViz from '../dumpGraphToGraphViz';
-import {unique, setDifference} from '@atlaspack/utils';
+import {unique, setSymmetricDifference} from '@atlaspack/utils';
 import {hashString} from '@atlaspack/rust';
 import PluginOptions from '../public/PluginOptions';
 import applyRuntimes from '../applyRuntimes';
@@ -511,7 +511,10 @@ class BundlerRunner {
       unique(bundleNames),
       'Bundles must have unique name. Conflicting names: ' +
         [
-          ...setDifference(new Set(bundleNames), new Set(unique(bundleNames))),
+          ...setSymmetricDifference(
+            new Set(bundleNames),
+            new Set(unique(bundleNames)),
+          ),
         ].join(),
     );
   }

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -641,4 +641,109 @@ describe('conditional bundling', function () {
       );
     },
   );
+
+  it.v2(
+    `should load conditional bundles in entry html when enabled`,
+    async function () {
+      const dir = path.join(__dirname, 'import-cond-entry-html-enabled');
+      overlayFS.mkdirp(dir);
+
+      await fsFixture(overlayFS, dir)`
+      .parcelrc:
+        {
+          "extends": "@atlaspack/config-default",
+          "reporters": [
+            "@atlaspack/reporter-conditional-manifest",
+            "..."
+          ]
+        }
+      package.json:
+        {
+          "@atlaspack/packager-html": {
+            "evaluateRootConditionalBundles": true
+          }
+        }
+
+      yarn.lock: {}
+
+      index.html:
+        <!doctype html>
+        <html>
+        <head>
+          <title>Test</title>
+        </head>
+        <body>
+          <script type="module" src="./index.js"></script>
+        </body>
+        </html>
+
+      index.js:
+        const conditions = { 'cond1': true, 'cond2': true };
+        globalThis.__MCOND = function(key) { return conditions[key]; }
+
+        const imported1 = importCond('cond1', './a', './b');
+
+        export default imported1;
+
+      a.js:
+        export default 'module-a';
+
+      b.js:
+        export default 'module-b';
+    `;
+
+      let bundleGraph = await bundle(path.join(dir, '/index.html'), {
+        inputFS: overlayFS,
+        featureFlags: {conditionalBundlingApi: true},
+        defaultConfig: path.join(dir, '.parcelrc'),
+        defaultTargetOptions: {
+          outputFormat: 'esmodule',
+          shouldScopeHoist: true,
+        },
+      });
+
+      let entry = nullthrows(
+        bundleGraph.getBundles().find((b) => b.name === 'index.html'),
+        'index.html bundle not found',
+      );
+
+      let entryJs = nullthrows(
+        bundleGraph
+          .getBundles()
+          .find((b) => b.displayName === 'index.[hash].js'),
+        'index.js bundle not found',
+      );
+
+      // Load the generated manifest
+      let conditionalManifest = JSON.parse(
+        overlayFS
+          .readFileSync(path.join(distDir, 'conditional-manifest.json'))
+          .toString(),
+      );
+
+      let entryContents = overlayFS.readFileSync(entry.filePath).toString();
+
+      // Get the true bundle path
+      let ifTrueBundleName = nullthrows(
+        conditionalManifest[path.basename(entryJs.filePath)]?.cond1
+          ?.ifTrueBundles?.[0],
+        'ifTrue bundle not found in manifest',
+      );
+      assert.ok(
+        entryContents.includes(ifTrueBundleName),
+        'ifTrue script not found in HTML',
+      );
+
+      // Get the false bundle path
+      let ifFalseBundleName = nullthrows(
+        conditionalManifest[path.basename(entryJs.filePath)]?.cond1
+          ?.ifFalseBundles?.[0],
+        'ifFalse bundle not found in manifest',
+      );
+      assert.ok(
+        entryContents.includes(ifFalseBundleName),
+        'ifFalse script not found in HTML',
+      );
+    },
+  );
 });

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -23,7 +23,7 @@ describe('conditional bundling', function () {
 
   it(`when disabled, should treat importCond as a sync import`, async function () {
     const dir = path.join(__dirname, 'disabled-import-cond');
-    overlayFS.mkdirp(dir);
+    await overlayFS.mkdirp(dir);
 
     await fsFixture(overlayFS, dir)`
         index.js:
@@ -51,7 +51,7 @@ describe('conditional bundling', function () {
 
   it(`when disabled, should transform types in importCond`, async function () {
     const dir = path.join(__dirname, 'disabled-import-cond-types');
-    overlayFS.mkdirp(dir);
+    await overlayFS.mkdirp(dir);
 
     await fsFixture(overlayFS, dir)`
         index.ts:
@@ -81,7 +81,7 @@ describe('conditional bundling', function () {
     `should have true and false deps as bundles in conditional manifest`,
     async function () {
       const dir = path.join(__dirname, 'import-cond-cond-manifest');
-      overlayFS.mkdirp(dir);
+      await overlayFS.mkdirp(dir);
 
       await fsFixture(overlayFS, dir)`
         .parcelrc:
@@ -139,7 +139,7 @@ describe('conditional bundling', function () {
 
   it.v2(`should use true bundle when condition is true`, async function () {
     const dir = path.join(__dirname, 'import-cond-true');
-    overlayFS.mkdirp(dir);
+    await overlayFS.mkdirp(dir);
 
     await fsFixture(overlayFS, dir)`
         .parcelrc:
@@ -218,7 +218,7 @@ describe('conditional bundling', function () {
 
   it.v2(`should use both conditional bundles correctly`, async function () {
     const dir = path.join(__dirname, 'import-cond-both');
-    overlayFS.mkdirp(dir);
+    await overlayFS.mkdirp(dir);
 
     await fsFixture(overlayFS, dir)`
         .parcelrc:
@@ -329,7 +329,7 @@ describe('conditional bundling', function () {
     `should load false bundle when importing dynamic bundles`,
     async function () {
       const dir = path.join(__dirname, 'import-cond-false-dynamic');
-      overlayFS.mkdirp(dir);
+      await overlayFS.mkdirp(dir);
 
       await fsFixture(overlayFS, dir)`
       .parcelrc:
@@ -399,7 +399,7 @@ describe('conditional bundling', function () {
   it.v2(`should load dev warning when bundle isn't loaded`, async function () {
     const dir = path.join(__dirname, 'import-cond-dev-warning');
 
-    overlayFS.mkdirp(dir);
+    await overlayFS.mkdirp(dir);
 
     await fsFixture(overlayFS, dir)`
         index.js:
@@ -457,7 +457,7 @@ describe('conditional bundling', function () {
     `should handle loading conditional bundles when imported in different bundles`,
     async function () {
       const dir = path.join(__dirname, 'import-cond-different-bundles');
-      overlayFS.mkdirp(dir);
+      await overlayFS.mkdirp(dir);
 
       await fsFixture(overlayFS, dir)`
         .parcelrc:
@@ -547,7 +547,7 @@ describe('conditional bundling', function () {
     `should load bundles in parallel when config enabled`,
     async function () {
       const dir = path.join(__dirname, 'import-cond-parallel-enabled');
-      overlayFS.mkdirp(dir);
+      await overlayFS.mkdirp(dir);
 
       await fsFixture(overlayFS, dir)`
       .parcelrc:
@@ -646,7 +646,7 @@ describe('conditional bundling', function () {
     `should load conditional bundles in entry html when enabled`,
     async function () {
       const dir = path.join(__dirname, 'import-cond-entry-html-enabled');
-      overlayFS.mkdirp(dir);
+      await overlayFS.mkdirp(dir);
 
       await fsFixture(overlayFS, dir)`
       .parcelrc:

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1501,6 +1501,7 @@ export interface MutableBundleGraph extends BundleGraph<Bundle> {
   addBundleToBundleGroup(Bundle, BundleGroup): void;
   createAssetReference(Dependency, Asset, Bundle): void;
   createBundleReference(Bundle, Bundle): void;
+  createBundleConditionalReference(Bundle, Bundle): void;
   createBundle(CreateBundleOpts): Bundle;
   /** Turns an edge (Dependency -> Asset-s) into (Dependency -> BundleGroup -> Asset-s) */
   createBundleGroup(Dependency, Target): BundleGroup;
@@ -1659,6 +1660,7 @@ export interface BundleGraph<TBundle: Bundle> {
     ifTrueAssetId: string,
     ifFalseAssetId: string,
   |}>;
+  getReferencedConditionalBundles(bundle: Bundle): Array<TBundle>;
 }
 
 /**

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1501,6 +1501,9 @@ export interface MutableBundleGraph extends BundleGraph<Bundle> {
   addBundleToBundleGroup(Bundle, BundleGroup): void;
   createAssetReference(Dependency, Asset, Bundle): void;
   createBundleReference(Bundle, Bundle): void;
+  /** Creates a conditional relationship in the graph between two bundles
+   * Used to track which bundles conditionally reference another
+   */
   createBundleConditionalReference(Bundle, Bundle): void;
   createBundle(CreateBundleOpts): Bundle;
   /** Turns an edge (Dependency -> Asset-s) into (Dependency -> BundleGroup -> Asset-s) */

--- a/packages/core/utils/src/collection.js
+++ b/packages/core/utils/src/collection.js
@@ -34,7 +34,41 @@ function sortEntry(entry: mixed) {
   return entry;
 }
 
+/**
+ * Get the difference of A and B sets
+ *
+ * This is the set of elements which are in A but not in B
+ * For example, the difference of the sets {1,2,3} and {3,4} is {1,2}
+ *
+ * @param {*} a Set A
+ * @param {*} b Set B
+ * @returns A \ B
+ */
 export function setDifference<T>(
+  a: $ReadOnlySet<T>,
+  b: $ReadOnlySet<T>,
+): Set<T> {
+  let difference = new Set();
+  for (let e of a) {
+    if (!b.has(e)) {
+      difference.add(e);
+    }
+  }
+
+  return difference;
+}
+
+/**
+ * Get the symmetric difference of A and B sets
+ *
+ * This is the set of elements which are in either of the sets, but not in their intersection.
+ * For example, the symmetric difference of the sets {1,2,3} and {3,4} is {1,2,4}
+ *
+ * @param {*} a Set A
+ * @param {*} b Set B
+ * @returns A Δ B
+ */
+export function setSymmetricDifference<T>(
   a: $ReadOnlySet<T>,
   b: $ReadOnlySet<T>,
 ): Set<T> {

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -36,6 +36,7 @@ export {
   objectSortedEntries,
   objectSortedEntriesDeep,
   setDifference,
+  setSymmetricDifference,
   setEqual,
   setIntersect,
   setUnion,

--- a/packages/core/utils/test/collection.test.js
+++ b/packages/core/utils/test/collection.test.js
@@ -5,6 +5,7 @@ import {
   objectSortedEntries,
   objectSortedEntriesDeep,
   setDifference,
+  setSymmetricDifference,
 } from '../src/collection';
 
 describe('objectSortedEntries', () => {
@@ -42,10 +43,20 @@ describe('objectSortedEntriesDeep', () => {
     );
   });
 });
+
 describe('setDifference', () => {
   it('returns a setDifference of two sets of T type', () => {
     assert.deepEqual(
       setDifference(new Set([1, 2, 3]), new Set([3, 4, 5])),
+      new Set([1, 2]),
+    );
+  });
+});
+
+describe('setSymmetricDifference', () => {
+  it('returns a setSymmetricDifference of two sets of T type', () => {
+    assert.deepEqual(
+      setSymmetricDifference(new Set([1, 2, 3]), new Set([3, 4, 5])),
       new Set([1, 2, 4, 5]),
     );
   });

--- a/packages/packagers/html/src/HTMLPackager.js
+++ b/packages/packagers/html/src/HTMLPackager.js
@@ -13,7 +13,6 @@ import {
   urlJoin,
 } from '@atlaspack/utils';
 import nullthrows from 'nullthrows';
-import {join} from 'path';
 
 // https://www.w3.org/TR/html5/dom.html#metadata-content-2
 const metadataContent = new Set([

--- a/packages/packagers/svg/src/SVGPackager.js
+++ b/packages/packagers/svg/src/SVGPackager.js
@@ -9,7 +9,7 @@ import {
   replaceInlineReferences,
   replaceURLReferences,
   urlJoin,
-  setDifference,
+  setSymmetricDifference,
 } from '@atlaspack/utils';
 
 export default (new Packager({
@@ -28,7 +28,7 @@ export default (new Packager({
     // Add bundles in the same bundle group that are not inline. For example, if two inline
     // bundles refer to the same library that is extracted into a shared bundle.
     let referencedBundles = [
-      ...setDifference(
+      ...setSymmetricDifference(
         new Set(bundleGraph.getReferencedBundles(bundle)),
         new Set(bundleGraph.getReferencedBundles(bundle, {recursive: false})),
       ),

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -53,6 +53,7 @@ async function report({
     for (const target of targets) {
       const conditionalManifestFilename = join(target.distDir, filename);
       const conditionalManifest = JSON.stringify(
+        // If there's no content, send an empty manifest so we can still map from it safely
         manifest[target.name] ?? {},
         null,
         2,

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -52,9 +52,8 @@ async function report({
 
     for (const target of targets) {
       const conditionalManifestFilename = join(target.distDir, filename);
-
       const conditionalManifest = JSON.stringify(
-        manifest[target.name],
+        manifest[target.name] ?? {},
         null,
         2,
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -367,6 +367,13 @@
     "@jridgewell/trace-mapping" "^0.3.25"
     jsesc "^3.0.2"
 
+"@babel/helper-annotate-as-pure@^7.18.6":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.25.9.tgz#d8eac4d2dc0d7b6e11fa6e535332e0d3184f06b4"
+  integrity sha512-gv7320KBUFJz1RnylIg5WWYPRXKZ884AGkYpgpWW02TH66Dl+HaC1t1CKd0z3R4b6hdYEcmrNZHUmfCP+1u3/g==
+  dependencies:
+    "@babel/types" "^7.25.9"
+
 "@babel/helper-annotate-as-pure@^7.22.5":
   version "7.22.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.22.5.tgz#e7f06737b197d580a01edf75d97e2c8be99d3882"
@@ -779,6 +786,16 @@
   version "7.21.0-placeholder-for-preset-env.2"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz#7844f9289546efa9febac2de4cfe358a050bd703"
   integrity sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==
+
+"@babel/plugin-proposal-private-property-in-object@^7.21.11":
+  version "7.21.11"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz#69d597086b6760c4126525cfa154f34631ff272c"
+  integrity sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.18.6"
+    "@babel/helper-create-class-features-plugin" "^7.21.0"
+    "@babel/helper-plugin-utils" "^7.20.2"
+    "@babel/plugin-syntax-private-property-in-object" "^7.14.5"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"


### PR DESCRIPTION
## Motivation

Currently, in Jira, we have to find every way we serve HTML and make sure we send the conditional bundles for the initial page load. This is difficult as there are many legacy server routes we need to support. To avoid explicitly doing this, we can load all the required bundles in the page load as a fallback and remove these explicit inclusions in some cases.

## Changes

- Rename symmetric set difference and add set difference function
- Add conditional bundle edges to the bundle graph
- In HTMLPackager, when enabled, insert conditional bundle modules

## Checklist

- [x] Existing or new tests cover this change
