### PR TITLE
Fix leaky event listeners

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -118,10 +118,21 @@ export default class Atlaspack {
 
     await initSourcemaps;
     await initRust?.();
+
+    this.#disposable = new Disposable();
+
     try {
       initializeMonitoring?.();
-      process.on('exit', () => {
+
+      const onExit = () => {
         closeMonitoring?.();
+      };
+
+      process.on('exit', onExit);
+
+      this.#disposable.add(() => {
+        process.off('exit', onExit);
+        onExit();
       });
     } catch (e) {
       // Fallthrough
@@ -188,7 +199,6 @@ export default class Atlaspack {
       await this.#farm.createSharedReference(resolvedOptions, false);
     this.#optionsRef = optionsRef;
 
-    this.#disposable = new Disposable();
     if (this.#initialOptions.workerFarm) {
       // If we don't own the farm, dispose of only these references when
       // Atlaspack ends.

--- a/packages/core/core/test/atlaspack-v3/WorkerPool.test.js
+++ b/packages/core/core/test/atlaspack-v3/WorkerPool.test.js
@@ -6,7 +6,11 @@ import {WorkerPool, waitForMessage} from '../../src/atlaspack-v3/WorkerPool';
 import assert from 'assert';
 
 function probeStatus(worker: Worker) {
-  const response = waitForMessage(worker, 'status');
+  const response = waitForMessage(
+    worker,
+    'status',
+    new AbortController().signal,
+  );
   worker.postMessage({type: 'probeStatus'});
   return response;
 }


### PR DESCRIPTION
## Motivation

When running the integration tests, it becomes apparent that we do not cleanup some event listeners and hit the max limit. This may be the cause of the flakey tests we have seen lately, as these changes have had three consecutive green builds without any need to rerun failed tests.

## Changes

Fix the cleanup of exit and worker listeners

## Checklist

- [x] Existing or new tests cover this change
