### PR TITLE
[V3] Ensure Asset ids are in sync with V2 / Fix changing filetype pipelines

### DIFF
--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -206,7 +206,7 @@ async fn run_pipelines(
 
       // If the Asset has changed type then we may need to trigger a different pipeline
       if current_asset.file_type != original_asset_type {
-        // When the Asset changes file_type we need to regenerate it's id
+        // When the Asset changes file_type we need to regenerate its id
         current_asset.update_id(project_root);
 
         let next_pipeline = plugins.transformers(

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -186,7 +186,7 @@ async fn run_pipelines(
 
     let mut current_asset = asset_to_modify.clone();
     let mut current_dependencies = dependencies;
-    let mut pipeline_incomplete = false;
+    let mut pipeline_complete = true;
 
     for transformer in pipeline.transformers_mut() {
       let transform_result = transformer
@@ -226,13 +226,13 @@ async fn run_pipelines(
             },
             Some((next_pipeline, next_pipeline_id)),
           ));
-          pipeline_incomplete = true;
+          pipeline_complete = false;
           break;
         }
       }
     }
 
-    if !pipeline_incomplete {
+    if pipeline_complete {
       // We assume the first asset to complete the pipeline is the initial asset
       if initial_asset.is_none() {
         initial_asset = Some(current_asset);

--- a/crates/atlaspack/src/requests/target_request.rs
+++ b/crates/atlaspack/src/requests/target_request.rs
@@ -274,18 +274,20 @@ impl TargetRequest {
 
     let browsers = match config.contents.browserslist.clone() {
       None => {
-        // Loading .browserslistrc
-        let browserslistrc = request_context
-          .file_system()
-          .read_to_string(
-            &request_context
-              .config()
-              .project_root
-              .join(".browserslistrc"),
-          )
-          .ok();
+        let browserslistrc_path = &request_context
+          .config()
+          .project_root
+          .join(".browserslistrc");
 
-        if let Some(browserslistrc) = browserslistrc {
+        // Loading .browserslistrc
+        if request_context
+          .file_system()
+          .is_file(browserslistrc_path.as_path())
+        {
+          let browserslistrc = request_context
+            .file_system()
+            .read_to_string(browserslistrc_path)?;
+
           Some(EnginesBrowsers::from_browserslistrc(&browserslistrc)?)
         } else {
           None

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -369,8 +369,10 @@ impl Asset {
   }
 
   pub fn set_file_type(&mut self, file_type: FileType, project_root: &Path) {
-    self.file_type = file_type;
-    self.update_id(project_root);
+    if file_type != self.file_type {
+      self.file_type = file_type;
+      self.update_id(project_root);
+    }
   }
 
   fn update_id(&mut self, project_root: &Path) {

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -384,6 +384,10 @@ impl Asset {
     self.meta.insert("interpreter".into(), shebang.into());
   }
 
+  pub fn set_meta_id(&mut self, id: impl Into<serde_json::Value>) {
+    self.meta.insert("id".into(), id.into());
+  }
+
   pub fn set_has_cjs_exports(&mut self, value: bool) {
     self.meta.insert("hasCJSExports".into(), value.into());
     self.has_cjs_exports = value;

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -368,14 +368,7 @@ impl Asset {
     }
   }
 
-  pub fn set_file_type(&mut self, file_type: FileType, project_root: &Path) {
-    if file_type != self.file_type {
-      self.file_type = file_type;
-      self.update_id(project_root);
-    }
-  }
-
-  fn update_id(&mut self, project_root: &Path) {
+  pub fn update_id(&mut self, project_root: &Path) {
     self.id = create_asset_id(CreateAssetIdParams {
       code: None,
       environment_id: &self.env.id(),

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -368,6 +368,23 @@ impl Asset {
     }
   }
 
+  pub fn set_file_type(&mut self, file_type: FileType, project_root: &Path) {
+    self.file_type = file_type;
+    self.update_id(project_root);
+  }
+
+  fn update_id(&mut self, project_root: &Path) {
+    self.id = create_asset_id(CreateAssetIdParams {
+      code: None,
+      environment_id: &self.env.id(),
+      file_path: &to_project_path(project_root, &self.file_path).to_string_lossy(),
+      file_type: &self.file_type,
+      pipeline: self.pipeline.as_deref(),
+      query: self.query.as_deref(),
+      unique_key: self.unique_key.as_deref(),
+    });
+  }
+
   pub fn set_interpreter(&mut self, shebang: impl Into<serde_json::Value>) {
     self.meta.insert("interpreter".into(), shebang.into());
   }

--- a/crates/atlaspack_core/src/types/environment/engines.rs
+++ b/crates/atlaspack_core/src/types/environment/engines.rs
@@ -18,9 +18,10 @@ pub enum EnginesBrowsers {
 impl Default for EnginesBrowsers {
   fn default() -> Self {
     Self::List(vec![
-      String::from("last 2 versions"),
-      String::from("> 0.25%"),
-      String::from("not dead"),
+      String::from("last 1 Chrome version"),
+      String::from("last 1 Safari version"),
+      String::from("last 1 Firefox version"),
+      String::from("last 1 Edge version"),
     ])
   }
 }

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -361,6 +361,7 @@ mod tests {
           file_path: "mock_path.js".into(),
           file_type: FileType::Js,
           symbols: Some(Vec::new()),
+          meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
           ..target_asset
         },
         discovered_assets: vec![],
@@ -415,6 +416,7 @@ mod tests {
         file_path: PathBuf::from("index.jsx"),
         file_type: FileType::Js,
         symbols: Some(Vec::new()),
+        meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
         ..target_asset
       },
     );
@@ -465,6 +467,7 @@ mod tests {
         file_path: PathBuf::from("index.tsx"),
         file_type: FileType::Js,
         symbols: Some(Vec::new()),
+        meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
         ..target_asset
       },
     );
@@ -517,6 +520,7 @@ mod tests {
             is_esm_export: false,
             self_referenced: false,
           },]),
+          meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
           ..target_asset
         },
       );
@@ -582,6 +586,7 @@ mod tests {
         file_path: PathBuf::from("src").join("index.jsx"),
         file_type: FileType::Js,
         symbols: Some(Vec::new()),
+        meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
         ..target_asset
       },
     );
@@ -642,6 +647,7 @@ mod tests {
         file_path: PathBuf::from("index.jsx"),
         file_type: FileType::Js,
         symbols: Some(Vec::new()),
+        meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
         ..target_asset
       },
     );
@@ -671,6 +677,7 @@ mod tests {
           code: Code::from(String::from("const test = ()=>{};")),
           file_path: "index.js".into(),
           symbols: Some(Vec::new()),
+          meta: serde_json::Map::from_iter([(String::from("id"), target_asset.id.clone().into())]),
           ..target_asset
         },
         discovered_assets: vec![],
@@ -774,6 +781,7 @@ mod tests {
             }
           ]),
           unique_key: None,
+          meta: serde_json::Map::from_iter([(String::from("id"), asset_id.clone().into())]),
           ..empty_asset()
         },
         discovered_assets: vec![],

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -316,9 +316,15 @@ impl TransformerPlugin for AtlaspackJsTransformerPlugin {
     }
 
     let config = atlaspack_js_swc_core::Config::default();
-    let result = conversion::convert_result(asset, &config, transformation_result, &self.options)
-      // TODO handle errors properly
-      .map_err(|_err| anyhow!("Failed to transform"))?;
+    let mut result =
+      conversion::convert_result(asset, &config, transformation_result, &self.options)
+        // TODO handle errors properly
+        .map_err(|_err| anyhow!("Failed to transform"))?;
+
+    // Change transformed Asset to JS file type
+    result
+      .asset
+      .set_file_type(FileType::Js, &self.options.project_root);
 
     Ok(result)
   }

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -316,15 +316,9 @@ impl TransformerPlugin for AtlaspackJsTransformerPlugin {
     }
 
     let config = atlaspack_js_swc_core::Config::default();
-    let mut result =
-      conversion::convert_result(asset, &config, transformation_result, &self.options)
-        // TODO handle errors properly
-        .map_err(|_err| anyhow!("Failed to transform"))?;
-
-    // Change transformed Asset to JS file type
-    result
-      .asset
-      .set_file_type(FileType::Js, &self.options.project_root);
+    let result = conversion::convert_result(asset, &config, transformation_result, &self.options)
+      // TODO handle errors properly
+      .map_err(|_err| anyhow!("Failed to transform"))?;
 
     Ok(result)
   }

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -343,8 +343,6 @@ pub(crate) fn convert_result(
   // it get's updated on the meta object.
   asset.set_meta_id(asset.id.clone());
 
-  asset.code = Code::from(result_source_code_string);
-
   if let Some(map) = result.map {
     // TODO: Fix diagnostic error handling
     let mut source_map = SourceMap::from_json(&options.project_root, &map).map_err(|_| vec![])?;

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -337,6 +337,13 @@ pub(crate) fn convert_result(
 
   asset.file_type = FileType::Js;
   asset.code = Code::new(result.code);
+  // Updating the file_type to JS will cause the asset id to be updated.
+  // However, the packager needs to be aware of the original id when creating
+  // symbols replacements in scope hoisting. That's why we store the id before
+  // it get's updated on the meta object.
+  asset.set_meta_id(asset.id.clone());
+
+  asset.code = Code::from(result_source_code_string);
 
   if let Some(map) = result.map {
     // TODO: Fix diagnostic error handling

--- a/packages/core/core/src/atlaspack-v3/worker/worker.js
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.js
@@ -274,7 +274,8 @@ export class AtlaspackWorker {
           code: [],
           meta: mutableAsset.meta,
           pipeline: mutableAsset.pipeline,
-          query: mutableAsset.query.toString(),
+          // Query should be undefined if it's empty
+          query: mutableAsset.query.toString() || undefined,
           symbols: mutableAsset.symbols.intoNapi(),
           uniqueKey: mutableAsset.uniqueKey,
           sideEffects: mutableAsset.sideEffects,

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -181,7 +181,6 @@ function getAssetGraph(serializedGraph, options) {
       asset.committed = true;
       asset.contentKey = id;
       asset.env.id = getEnvId(asset.env);
-      asset.meta.id = id;
       if (asset.symbols != null) {
         asset.symbols = new Map(asset.symbols.map(mapSymbols));
       }

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -570,12 +570,15 @@ describe('css', () => {
     );
   });
 
-  it('should support css nesting with lightningcss', async function () {
+  it('should support transpiling css nesting with lightningcss', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/css-nesting/a.css'),
       {
         defaultTargetOptions: {
-          engines: {},
+          engines: {
+            // Force the CSS nesting to be transpiled
+            browsers: ['ie 11'],
+          },
         },
       },
     );

--- a/packages/optimizers/css/package.json
+++ b/packages/optimizers/css/package.json
@@ -21,11 +21,11 @@
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/utils": "2.12.0",
     "browserslist": "^4.6.6",
-    "lightningcss": "^1.22.1",
+    "lightningcss": "^1.28.2",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "lightningcss-wasm": "^1.22.1"
+    "lightningcss-wasm": "^1.28.2"
   },
   "browser": {
     "lightningcss": "lightningcss-wasm"

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -20,11 +20,11 @@
     "@atlaspack/plugin": "2.12.0",
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/utils": "2.12.0",
-    "lightningcss": "^1.22.1",
+    "lightningcss": "^1.28.2",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "lightningcss-wasm": "^1.22.1",
+    "lightningcss-wasm": "^1.28.2",
     "postcss": "^8.4.5"
   },
   "browser": {

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -21,11 +21,11 @@
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/utils": "2.12.0",
     "browserslist": "^4.6.6",
-    "lightningcss": "^1.22.1",
+    "lightningcss": "^1.28.2",
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
-    "lightningcss-wasm": "^1.22.1"
+    "lightningcss-wasm": "^1.28.2"
   },
   "browser": {
     "lightningcss": "lightningcss-wasm"

--- a/yarn.lock
+++ b/yarn.lock
@@ -10410,74 +10410,80 @@ liftoff@^3.1.0:
     rechoir "^0.6.2"
     resolve "^1.1.7"
 
-lightningcss-darwin-arm64@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.22.1.tgz#c03c042335fd7e9e1f45c977b39ff6886b8b064f"
-  integrity sha512-ldvElu+R0QimNTjsKpaZkUv3zf+uefzLy/R1R19jtgOfSRM+zjUCUgDhfEDRmVqJtMwYsdhMI2aJtJChPC6Osg==
+lightningcss-darwin-arm64@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.28.2.tgz#a906fd84cb43d753cb5db9c367f8f38482e8fb03"
+  integrity sha512-/8cPSqZiusHSS+WQz0W4NuaqFjquys1x+NsdN/XOHb+idGHJSoJ7SoQTVl3DZuAgtPZwFZgRfb/vd1oi8uX6+g==
 
-lightningcss-darwin-x64@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.22.1.tgz#cdd380006a176b7faea83d1d642d9c5d65620f74"
-  integrity sha512-5p2rnlVTv6Gpw4PlTLq925nTVh+HFh4MpegX8dPDYJae+NFVjQ67gY7O6iHIzQjLipDiYejFF0yHrhjU3XgLBQ==
+lightningcss-darwin-x64@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.28.2.tgz#6c43249d4ae821416d0d78403eae56111d0c6a94"
+  integrity sha512-R7sFrXlgKjvoEG8umpVt/yutjxOL0z8KWf0bfPT3cYMOW4470xu5qSHpFdIOpRWwl3FKNMUdbKtMUjYt0h2j4g==
 
-lightningcss-freebsd-x64@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.22.1.tgz#dd1b19308e3b0f24b6f79da10fd3975e5e02ebda"
-  integrity sha512-1FaBtcFrZqB2hkFbAxY//Pnp8koThvyB6AhjbdVqKD4/pu13Rl91fKt2N9qyeQPUt3xy7ORUvSO+dPk3J6EjXg==
+lightningcss-freebsd-x64@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.28.2.tgz#804bc6652c6721e94a92e7bbb5e65165376cf108"
+  integrity sha512-l2qrCT+x7crAY+lMIxtgvV10R8VurzHAoUZJaVFSlHrN8kRLTvEg9ObojIDIexqWJQvJcVVV3vfzsEynpiuvgA==
 
-lightningcss-linux-arm-gnueabihf@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.22.1.tgz#134cf9b41abd44ec53d8bae02c9f6e4f257eb617"
-  integrity sha512-6rub98tYGfE5I5j0BP8t/2d4BZyu1S7Iz9vUkm0H26snAFHYxLfj3RbQn0xHHIePSetjLnhcg3QlfwUAkD/FYg==
+lightningcss-linux-arm-gnueabihf@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.28.2.tgz#c32595127b565690d854c9ff641831e4ad739ee1"
+  integrity sha512-DKMzpICBEKnL53X14rF7hFDu8KKALUJtcKdFUCW5YOlGSiwRSgVoRjM97wUm/E0NMPkzrTi/rxfvt7ruNK8meg==
 
-lightningcss-linux-arm64-gnu@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.22.1.tgz#33800723fb3d782c71cc131cf38ca678a0e9d1fa"
-  integrity sha512-nYO5qGtb/1kkTZu3FeTiM+2B2TAb7m2DkLCTgQIs2bk2o9aEs7I96fwySKcoHWQAiQDGR9sMux9vkV4KQXqPaQ==
+lightningcss-linux-arm64-gnu@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.28.2.tgz#85646f08c5efbfd7c94f8e5ed6392d5cf95fa42c"
+  integrity sha512-nhfjYkfymWZSxdtTNMWyhFk2ImUm0X7NAgJWFwnsYPOfmtWQEapzG/DXZTfEfMjSzERNUNJoQjPAbdqgB+sjiw==
 
-lightningcss-linux-arm64-musl@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.22.1.tgz#cff86acaa98a0245add5a333098befc894802137"
-  integrity sha512-MCV6RuRpzXbunvzwY644iz8cw4oQxvW7oer9xPkdadYqlEyiJJ6wl7FyJOH7Q6ZYH4yjGAUCvxDBxPbnDu9ZVg==
+lightningcss-linux-arm64-musl@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.28.2.tgz#4d9bc20cf6de28c4d0c586d81c577891555ad831"
+  integrity sha512-1SPG1ZTNnphWvAv8RVOymlZ8BDtAg69Hbo7n4QxARvkFVCJAt0cgjAw1Fox0WEhf4PwnyoOBaVH0Z5YNgzt4dA==
 
-lightningcss-linux-x64-gnu@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.22.1.tgz#3f68602228b49d661db0692548e061456b603ca2"
-  integrity sha512-RjNgpdM20VUXgV7us/VmlO3Vn2ZRiDnc3/bUxCVvySZWPiVPprpqW/QDWuzkGa+NCUf6saAM5CLsZLSxncXJwg==
+lightningcss-linux-x64-gnu@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.28.2.tgz#74bd797d7157817c4e42ec45f1844a69636a9d82"
+  integrity sha512-ZhQy0FcO//INWUdo/iEdbefntTdpPVQ0XJwwtdbBuMQe+uxqZoytm9M+iqR9O5noWFaxK+nbS2iR/I80Q2Ofpg==
 
-lightningcss-linux-x64-musl@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.22.1.tgz#e713e56798f8a50df3e3f285ef102191a01ef951"
-  integrity sha512-ZgO4C7Rd6Hv/5MnyY2KxOYmIlzk4rplVolDt3NbkNR8DndnyX0Q5IR4acJWNTBICQ21j3zySzKbcJaiJpk/4YA==
+lightningcss-linux-x64-musl@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.28.2.tgz#13ce6db4c491ebbb93099d6427746ab7bff3774f"
+  integrity sha512-alb/j1NMrgQmSFyzTbN1/pvMPM+gdDw7YBuQ5VSgcFDypN3Ah0BzC2dTZbzwzaMdUVDszX6zH5MzjfVN1oGuww==
 
-lightningcss-wasm@^1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-wasm/-/lightningcss-wasm-1.22.1.tgz#120053c7aaabc72d1d31cdec192e267af5f389eb"
-  integrity sha512-GzY3oTNtkPhDVt1AY0H0ZEWdcAjTOD1Y72nJlEO1JSRgA4UTUDhrklzdMhSLTyVHTpVAEfCxnD6fULBIbwgT/A==
+lightningcss-wasm@^1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-wasm/-/lightningcss-wasm-1.28.2.tgz#d0ff17118f1d8b95427ab1c885467caea58a439b"
+  integrity sha512-g5aNMCathgTUunh8HWBIBDhnjM65hWZEEem6h2LoHU4nLiwGQLebXRnVV/HpavrnkvL1g7iYog4BURcq7YWKCA==
   dependencies:
     napi-wasm "^1.0.1"
 
-lightningcss-win32-x64-msvc@1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.22.1.tgz#48b141554bf05cc4338f064b6892dd5dd16185ef"
-  integrity sha512-4pozV4eyD0MDET41ZLHAeBo+H04Nm2UEYIk5w/ts40231dRFV7E0cjwbnZvSoc1DXFgecAhiC0L16ruv/ZDCpg==
+lightningcss-win32-arm64-msvc@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.28.2.tgz#eaae12c4a58a545a3adf40b22ba9625e5c0ebd29"
+  integrity sha512-WnwcjcBeAt0jGdjlgbT9ANf30pF0C/QMb1XnLnH272DQU8QXh+kmpi24R55wmWBwaTtNAETZ+m35ohyeMiNt+g==
 
-lightningcss@^1.22.1:
-  version "1.22.1"
-  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.22.1.tgz#8108ddecb2e859032bdd99908abd2b37515b1750"
-  integrity sha512-Fy45PhibiNXkm0cK5FJCbfO8Y6jUpD/YcHf/BtuI+jvYYqSXKF4muk61jjE8YxCR9y+hDYIWSzHTc+bwhDE6rQ==
+lightningcss-win32-x64-msvc@1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.28.2.tgz#1f7c4474b2dc3dd1c12e22de32e4de23bdfa41e7"
+  integrity sha512-3piBifyT3avz22o6mDKywQC/OisH2yDK+caHWkiMsF82i3m5wDBadyCjlCQ5VNgzYkxrWZgiaxHDdd5uxsi0/A==
+
+lightningcss@^1.28.2:
+  version "1.28.2"
+  resolved "https://registry.yarnpkg.com/lightningcss/-/lightningcss-1.28.2.tgz#cc26fad9ad64a621bd39ac6248095891cf584cce"
+  integrity sha512-ePLRrbt3fgjXI5VFZOLbvkLD5ZRuxGKm+wJ3ujCqBtL3NanDHPo/5zicR5uEKAPiIjBYF99BM4K4okvMznjkVA==
   dependencies:
     detect-libc "^1.0.3"
   optionalDependencies:
-    lightningcss-darwin-arm64 "1.22.1"
-    lightningcss-darwin-x64 "1.22.1"
-    lightningcss-freebsd-x64 "1.22.1"
-    lightningcss-linux-arm-gnueabihf "1.22.1"
-    lightningcss-linux-arm64-gnu "1.22.1"
-    lightningcss-linux-arm64-musl "1.22.1"
-    lightningcss-linux-x64-gnu "1.22.1"
-    lightningcss-linux-x64-musl "1.22.1"
-    lightningcss-win32-x64-msvc "1.22.1"
+    lightningcss-darwin-arm64 "1.28.2"
+    lightningcss-darwin-x64 "1.28.2"
+    lightningcss-freebsd-x64 "1.28.2"
+    lightningcss-linux-arm-gnueabihf "1.28.2"
+    lightningcss-linux-arm64-gnu "1.28.2"
+    lightningcss-linux-arm64-musl "1.28.2"
+    lightningcss-linux-x64-gnu "1.28.2"
+    lightningcss-linux-x64-musl "1.28.2"
+    lightningcss-win32-arm64-msvc "1.28.2"
+    lightningcss-win32-x64-msvc "1.28.2"
 
 lilconfig@^2.0.3:
   version "2.0.3"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR makes a couple of changes to ensure that Asset ids are the same as in V2 builds. The primary reason for the difference being that V2 updates the Asset id whenever the file type is updated.   

This PR also fixes an issue where pipelines would be executed correctly on assets that changed file type. 

## Changes

- Add  `update_id` method to Asset
- Add `set_meta_id` method to Asset
- Update the Asset id whenever a file_type change is detected in the Asset request
- Set the `Asset.meta.id` before the id updates as the packager expects
- Return an undefined query from the node transformers when the query is empty
- Update the default browserslist to match V2
- Ensure Assets run through a new pipeline if they change file type
- Only read the .browserslistrc when it is present. This removes a bunch of logging noise from the tests.
- Update lightningcss and fix CSS nesting test to use an older browser so the native CSS transformer is in sync with the JS one

## Checklist

- [x] Existing or new tests cover this change
