### PR TITLE
V3: Support sourcemaps in JavaScript plugins

### DIFF
--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -169,6 +169,7 @@ pub struct Asset {
   pub code: Code,
 
   /// The source map for the asset
+  #[serde(skip_serializing)]
   pub map: Option<SourceMap>,
 
   /// Plugin specific metadata for the asset

--- a/packages/core/integration-tests/test/sourcemaps.js
+++ b/packages/core/integration-tests/test/sourcemaps.js
@@ -1479,8 +1479,7 @@ describe('sourcemaps', function () {
     },
   );
 
-  // TODO: Enable this for v3 once all the code has been integrated
-  it.v2('creates valid source maps for js transformers', async () => {
+  it('creates valid source maps for js transformers', async () => {
     let entry = path.join(
       __dirname,
       '/integration/sourcemaps-js-plugin/index.ts',
@@ -1510,8 +1509,7 @@ describe('sourcemaps', function () {
     ]);
   });
 
-  // TODO: Enable this for v3 once all the code has been integrated
-  it.v2('creates valid source maps for js and rust transformers', async () => {
+  it('creates valid source maps for js and rust transformers', async () => {
     let entry = path.join(
       __dirname,
       '/integration/sourcemaps-js-rust-plugins/index.ts',


### PR DESCRIPTION
## Motivation

Currently v3 does not support sourcemaps in JavaScript plugins, these changes update the workflow to support this feature. It has been found that one soucemap matches v2 internally, but the remaining are difficult to discern with all the bundle output differences in v3.

## Changes

* Skip serialising the map to JavaScript and commit it to LMDB instead
* Set map key so that the map can be retrieved via LMDB
* Pass map into JavaScript plugin worker and store the result back in Rust
* Add implementations for the JavaScript plugin `getMap` and `setMap`
* Ensure `generate` sets the map if provided in the result (this is what babel relies on)
* Update `CommittedAsset` map buffer handling to account for differences with v3 maps
* Enable v3 sourcemap tests

## Checklist

- [x] Existing or new tests cover this change
