### PR TITLE
Await fsFixture

### DIFF
--- a/packages/core/integration-tests/test/AtlaspackDevDepRequestBug.test.js
+++ b/packages/core/integration-tests/test/AtlaspackDevDepRequestBug.test.js
@@ -26,30 +26,32 @@ describe('dev dep request bug', () => {
     });
 
     {
-      fsFixture(overlayFS, __dirname)`
-      test/other${i}.js:
-          export default function name() {
-            return 'jira ${i}';
-          }
-      test/test.js:
-          import name from './other${i}';
-          console.log('Hello, you ' + name());
+      await fsFixture(overlayFS, __dirname)`
+        test/other${i}.js:
+            export default function name() {
+              return 'jira ${i}';
+            }
+        test/test.js:
+            import name from './other${i}';
+            console.log('Hello, you ' + name());
       `;
+
       const atlaspack = new Atlaspack(options);
       await atlaspack.clearBuildCaches();
       await atlaspack.unstable_buildAssetGraph(false);
     }
 
     {
-      fsFixture(overlayFS, __dirname)`
-      test/other${i}.js:
-          export default function name() {
-            return 'atlaspack ${i}';
-          }
-      test/test.js:
-          import name from './other${i}';
-          console.log('Hello, you ' + name());
+      await fsFixture(overlayFS, __dirname)`
+        test/other${i}.js:
+            export default function name() {
+              return 'atlaspack ${i}';
+            }
+        test/test.js:
+            import name from './other${i}';
+            console.log('Hello, you ' + name());
       `;
+
       const atlaspack = new Atlaspack(options);
       await atlaspack.clearBuildCaches();
       await atlaspack.unstable_buildAssetGraph(false);


### PR DESCRIPTION
## Motivation

Some flakey integration test failures point to the `overlayFS` and `AtlaspackDevDepRequestBug.test.js` test specifically. One possible cause of files not existing yet is because the fixture is not awaited.

## Changes

Await the fs fixture

## Checklist

- [x] Existing or new tests cover this change
