### PR TITLE
Fix flaky worker tests

### DIFF
--- a/packages/core/integration-tests/test/workers.js
+++ b/packages/core/integration-tests/test/workers.js
@@ -11,6 +11,9 @@ import {
   run,
   runBundle,
 } from '@atlaspack/test-utils';
+import sinon from 'sinon';
+
+const nextTick = () => new Promise(process.nextTick);
 
 describe('atlaspack', function () {
   beforeEach(async () => {
@@ -67,12 +70,16 @@ describe('atlaspack', function () {
       },
     ]);
 
-    let res = await new Promise((resolve) => {
-      run(b, {
-        output: resolve,
-      });
+    let onMessage = sinon.spy();
+
+    await run(b, {
+      output: onMessage,
     });
-    assert.deepEqual(res, {default: 42});
+
+    await nextTick();
+
+    assert(onMessage.calledOnce);
+    assert(onMessage.calledWith({default: 42}));
   });
 
   it('bundles a dynamic import in a worker using legacy browser targets', async function () {
@@ -107,12 +114,14 @@ describe('atlaspack', function () {
       },
     ]);
 
-    let res = await new Promise((resolve) => {
-      run(b, {
-        output: resolve,
-      });
+    let onMessage = sinon.spy();
+
+    await run(b, {
+      output: onMessage,
     });
-    assert.deepEqual(res, {default: 42});
+
+    assert(onMessage.calledOnce);
+    assert(onMessage.calledWith({default: 42}));
   });
 
   it('bundles a dynamic import in a nested worker', async function () {
@@ -147,12 +156,16 @@ describe('atlaspack', function () {
       },
     ]);
 
-    let res = await new Promise((resolve) => {
-      run(b, {
-        output: resolve,
-      });
+    let onMessage = sinon.spy();
+
+    await run(b, {
+      output: onMessage,
     });
-    assert.deepEqual(res, {default: 42});
+
+    await nextTick();
+
+    assert(onMessage.calledOnce);
+    assert(onMessage.calledWith({default: 42}));
   });
 
   it('bundles dynamic imports in both the page and worker', async function () {
@@ -187,12 +200,14 @@ describe('atlaspack', function () {
       },
     ]);
 
-    let res = await new Promise((resolve) => {
-      run(b, {
-        output: resolve,
-      });
+    let onMessage = sinon.spy();
+
+    await run(b, {
+      output: onMessage,
     });
-    assert.deepEqual(res, {default: 42});
+
+    assert(onMessage.calledOnce);
+    assert(onMessage.calledWith({default: 42}));
   });
 
   it('should support workers pointing to themselves', async function () {


### PR DESCRIPTION
## Motivation

CI integration tests are fairly flaky and often fail due to the following error:

> should support workers pointing to themselves:
>   Error: done() called multiple times in test <atlaspack should support workers pointing to themselves> in addition, done() received error: Error: ENOENT: no such file or directory, realpath

## Changes

These changes update the tests so that the flakiness no longer occurs, it has been reproduced and verified locally via stress testing

## Checklist

- [x] Existing or new tests cover this change
