### PR TITLE
[V3] Make V3 output closer to V2

### DIFF
--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -76,13 +76,14 @@ impl Request for AssetRequest {
 
     let mut asset = Asset::new(
       code,
+      self.code.is_some(),
       self.env.clone(),
       self.file_path.clone(),
       self.pipeline.clone(),
       &self.project_root,
       self.query.clone(),
       self.side_effects,
-    );
+    )?;
 
     // Load an existing sourcemap if available for valid file types
     if matches!(

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -221,7 +221,7 @@ pub struct Asset {
   /// True if the Asset's code was returned from a resolver rather than being
   /// read from disk.
   #[serde(skip_serializing)]
-  pub is_virtual_code: bool,
+  pub is_virtual: bool,
 
   /// True if the asset has CommonJS exports
   pub has_cjs_exports: bool,
@@ -267,7 +267,7 @@ impl Asset {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     code: Code,
-    is_virtual_code: bool,
+    is_virtual: bool,
     env: Arc<Environment>,
     file_path: PathBuf,
     pipeline: Option<String>,
@@ -282,7 +282,7 @@ impl Asset {
       .ancestors()
       .any(|p| p.file_name() == Some(OsStr::new("node_modules")));
 
-    let virtual_code = if is_virtual_code {
+    let virtual_code = if is_virtual {
       Some(code.as_str()?)
     } else {
       None
@@ -309,7 +309,7 @@ impl Asset {
       query,
       side_effects,
       unique_key: None,
-      is_virtual_code,
+      is_virtual,
       ..Asset::default()
     })
   }

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -218,6 +218,11 @@ pub struct Asset {
   ///
   pub is_source: bool,
 
+  /// True if the Asset's code was returned from a resolver rather than being
+  /// read from disk.
+  #[serde(skip_serializing)]
+  pub is_virtual_code: bool,
+
   /// True if the asset has CommonJS exports
   pub has_cjs_exports: bool,
 
@@ -262,13 +267,14 @@ impl Asset {
   #[allow(clippy::too_many_arguments)]
   pub fn new(
     code: Code,
+    is_virtual_code: bool,
     env: Arc<Environment>,
     file_path: PathBuf,
     pipeline: Option<String>,
     project_root: &Path,
     query: Option<String>,
     side_effects: bool,
-  ) -> Self {
+  ) -> anyhow::Result<Self> {
     let file_type =
       FileType::from_extension(file_path.extension().and_then(|s| s.to_str()).unwrap_or(""));
 
@@ -276,8 +282,13 @@ impl Asset {
       .ancestors()
       .any(|p| p.file_name() == Some(OsStr::new("node_modules")));
 
+    let virtual_code = if is_virtual_code {
+      Some(code.as_str()?)
+    } else {
+      None
+    };
     let id = create_asset_id(CreateAssetIdParams {
-      code: None,
+      code: virtual_code,
       environment_id: &env.id(),
       file_path: &to_project_path(project_root, &file_path).to_string_lossy(),
       file_type: &file_type,
@@ -286,7 +297,7 @@ impl Asset {
       unique_key: None,
     });
 
-    Self {
+    Ok(Self {
       code,
       env,
       file_path,
@@ -298,8 +309,9 @@ impl Asset {
       query,
       side_effects,
       unique_key: None,
+      is_virtual_code,
       ..Asset::default()
-    }
+    })
   }
 
   #[allow(clippy::too_many_arguments)]
@@ -351,7 +363,7 @@ impl Asset {
     unique_key: Option<String>,
   ) -> Self {
     let id = create_asset_id(CreateAssetIdParams {
-      code: Some(code.as_str()),
+      code: None,
       environment_id: &source_asset.env.id(),
       file_path: &to_project_path(project_root, &source_asset.file_path).to_string_lossy(),
       file_type: &file_type,
@@ -452,23 +464,27 @@ mod tests {
 
     let asset_1 = Asset::new(
       Code::from("function hello() {}"),
+      false,
       env.clone(),
       project_root.join("test.js"),
       None,
       &project_root,
       None,
       false,
-    );
+    )
+    .unwrap();
 
     let asset_2 = Asset::new(
       Code::from("function helloButDifferent() {}"),
+      false,
       env.clone(),
       project_root.join("test.js"),
       None,
       &project_root,
       None,
       false,
-    );
+    )
+    .unwrap();
 
     // This nº should not change across runs / compilation
     assert_eq!(asset_1.id, "91d0d64458c223d1");
@@ -482,13 +498,15 @@ mod tests {
 
     let asset = Asset::new(
       Code::default(),
+      false,
       env.clone(),
       project_root.join("test.js"),
       None,
       &project_root,
       None,
       false,
-    );
+    )
+    .unwrap();
 
     assert_eq!(
       asset.id,
@@ -554,7 +572,7 @@ mod tests {
     assert_eq!(
       discovered_asset.id,
       create_asset_id(CreateAssetIdParams {
-        code: Some(""),
+        code: None,
         environment_id: &source_asset.env.id(),
         file_path: "test.js",
         file_type: &FileType::Css,

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -620,7 +620,7 @@ mod tests {
       result.discovered_assets[0],
       AssetWithDependencies {
         asset: Asset {
-          id: "88540641b9eed86d".into(),
+          id: "83301a06c27a61eb".into(),
           code: "module.exports[\"root\"] = `EcQGha_root`;\n".into(),
           file_path: "styles.module.css".into(),
           is_source: true,
@@ -683,8 +683,8 @@ mod tests {
       result.discovered_assets[0],
       AssetWithDependencies {
         asset: Asset {
-          id: "9ca5591ff8d30a6a".into(),
-          code: "module.exports[\"root\"] = `EcQGha_root`;\nmodule.exports[\"other\"] = `EcQGha_other ${module.exports['root']}`;\n".into(),
+          id: "83301a06c27a61eb".into(),
+          code: "module.exports[\"root\"] = `EcQGha_root`;\nmodule.exports[\"other\"] = `EcQGha_other ${module.exports[\"root\"]}`;\n".into(),
           file_path: "styles.module.css".into(),
           is_source: true,
           ..Default::default()
@@ -739,7 +739,7 @@ mod tests {
       result.discovered_assets[0],
       AssetWithDependencies {
         asset: Asset {
-          id: "82961aca890a97d6".into(),
+          id: "83301a06c27a61eb".into(),
           code: "module.exports[\"other\"] = `EcQGha_other globalClass`;\n".into(),
           file_path: "styles.module.css".into(),
           is_source: true,

--- a/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_css/src/css_transformer.rs
@@ -320,7 +320,7 @@ impl TransformerPlugin for AtlaspackCssTransformerPlugin {
                   sorted_exports,
                   seen,
                 )?;
-                code.push_str(format!("${{module.exports['{}']}}", *exported).as_str());
+                code.push_str(format!("${{module.exports[\"{}\"]}}", *exported).as_str());
                 let symbols = vec![Symbol {
                   exported: exported.clone(),
                   local: name.clone(),

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -806,6 +806,7 @@ mod tests {
 
     Asset::new(
       Code::from(code),
+      false,
       env.clone(),
       file_path.into(),
       None,
@@ -813,6 +814,7 @@ mod tests {
       None,
       false,
     )
+    .unwrap()
   }
 
   fn create_asset_at_project_root(project_root: &Path, file_path: &str, code: &str) -> Asset {
@@ -820,6 +822,7 @@ mod tests {
 
     Asset::new(
       Code::from(code),
+      false,
       env.clone(),
       file_path.into(),
       None,
@@ -827,6 +830,7 @@ mod tests {
       None,
       false,
     )
+    .unwrap()
   }
 
   fn empty_asset() -> Asset {

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use atlaspack_core::diagnostic;
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use swc_core::atoms::{Atom, JsWord};
 
 use atlaspack_core::plugin::{PluginOptions, TransformResult};
@@ -450,7 +450,10 @@ fn make_esm_helpers_dependency(
     specifier_type: SpecifierType::Esm,
     source_path: Some(asset_file_path.clone()),
     env: Environment {
-      include_node_modules: IncludeNodeModules::Bool(true),
+      include_node_modules: IncludeNodeModules::Map(BTreeMap::from([(
+        "@atlaspack/transformer-js".into(),
+        true,
+      )])),
       ..asset_environment.clone()
     }
     .into(),

--- a/packages/core/integration-tests/test/atlaspack-v3.js
+++ b/packages/core/integration-tests/test/atlaspack-v3.js
@@ -73,17 +73,22 @@ describe.v3('AtlaspackV3', function () {
     await atlaspack.buildAssetGraph();
   });
 
-  describe.only('should mirror V2 output', () => {
+  describe('should mirror V2 output', () => {
     it('with scope hoisting enabled', async () => {
       await fsFixture(overlayFS, __dirname)`
         scope-hoist
-          library.js:
-            export function doStuff() {
-              return 'stuff';
+          node_modules/library/named.js:
+            export default function namedFunction(arg) {
+              return arg;
             }
+          node_modules/library/index.js:
+            import namedFunction from './named.js';
+            export {namedFunction};
+          node_modules/library/package.json:
+            {"sideEffects": false}
           index.js:
-            import {doStuff} from './library';
-            sideEffectNoop(doStuff);
+            import {namedFunction} from 'library';
+            sideEffectNoop(namedFunction(''));
           index.html:
             <script type="module" src="./index.js" />
       `;
@@ -95,7 +100,7 @@ describe.v3('AtlaspackV3', function () {
       });
     });
 
-    it.only('with Assets that change type', async () => {
+    it('with Assets that change type', async () => {
       await fsFixture(overlayFS, __dirname)`
         type-change
           name.json:

--- a/packages/core/integration-tests/test/atlaspack-v3.js
+++ b/packages/core/integration-tests/test/atlaspack-v3.js
@@ -1,5 +1,6 @@
 // @flow
 
+import assert from 'assert';
 import {join} from 'path';
 
 import {AtlaspackV3, FileSystemV3} from '@atlaspack/core';
@@ -10,8 +11,32 @@ import {
   inputFS,
   it,
   overlayFS,
+  outputFS,
+  bundle,
 } from '@atlaspack/test-utils';
 import {LMDBLiteCache} from '@atlaspack/cache';
+
+async function assertOutputIsIdentical(entry: string) {
+  let bundlesV3 = await bundle(entry, {
+    inputFS: overlayFS,
+  }).then((b) => b.getBundles());
+
+  let bundlesV2 = await bundle(entry, {
+    inputFS: overlayFS,
+    featureFlags: {
+      atlaspackV3: false,
+    },
+  }).then((b) => b.getBundles());
+
+  assert.equal(bundlesV3.length, bundlesV2.length);
+
+  for (let i = 0; i < bundlesV2.length; i++) {
+    let v2Code = await outputFS.readFile(bundlesV2[i].filePath, 'utf8');
+    let v3Code = await outputFS.readFile(bundlesV3[i].filePath, 'utf8');
+
+    assert.equal(v3Code, v2Code);
+  }
+}
 
 describe.v3('AtlaspackV3', function () {
   it('builds', async () => {
@@ -40,5 +65,52 @@ describe.v3('AtlaspackV3', function () {
     });
 
     await atlaspack.buildAssetGraph();
+  });
+
+  describe.only('should mirror V2 output', () => {
+    it('with dynamic resolver code', async () => {
+      await fsFixture(overlayFS, __dirname)`
+        resolver-code
+          index.js:
+            import theGlobal from 'theGlobal';
+            sideEffectNoop(theGlobal)
+          index.html:
+            <script type="module" src="./index.js" />
+          package.json:
+            {
+              "alias": {
+                "theGlobal": {
+                  "global": "MY_GLOBAL"
+                }
+              }
+            }
+          yarn.lock:
+      `;
+
+      await assertOutputIsIdentical(
+        join(__dirname, 'resolver-code/index.html'),
+      );
+    });
+
+    it('with CSS modules', async () => {
+      await fsFixture(overlayFS, __dirname)`
+        css-modules
+          css.module.css:
+            .composed {
+              background: pink;
+            }
+            .foo {
+              composes: composed;
+              color: white;
+            }
+          index.js:
+            import {foo} from './css.module.css';
+            sideEffectNoop(foo)
+          index.html:
+            <script type="module" src="./index.js" />
+      `;
+
+      await assertOutputIsIdentical(join(__dirname, 'css-modules/index.html'));
+    });
   });
 });


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR attempts to make the V3 output more closely match the V2 one. I have added some tests that build apps with both versions and assert their output is identical. I have also made a few changes to ensure the tests are passing. 

## Changes

- Add tests for ensuring V2 and V3 output are identical
- Change CSS module quote style to match V2
- Only use virtual code in ID generation when it comes from the resolver (matches V2 behaviour)
- Replicate V2 environment for `esmodule-helpers` import

## Checklist

- [x] Existing or new tests cover this change
