### PR TITLE
Add missing graph methods and tests

### DIFF
--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -598,16 +598,35 @@ export default class AdjacencyList<TEdgeType: number = 1> {
   forEachNodeIdConnectedFromReverse(
     from: NodeId,
     fn: (nodeId: NodeId) => boolean,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = ALL_EDGE_TYPES,
   ) {
+    const matches = (node) =>
+      type === ALL_EDGE_TYPES || type === this.#nodes.typeOf(node);
+
     let node = this.#nodes.head(from);
     while (node !== null) {
-      let edge = this.#nodes.lastOut(node);
-      while (edge !== null) {
-        let to = this.#edges.to(edge);
-        if (fn(to)) {
-          return;
+      if (matches(node)) {
+        let edge = this.#nodes.lastOut(node);
+        while (edge !== null) {
+          let to = this.#edges.to(edge);
+          if (fn(to)) {
+            return;
+          }
+          edge = this.#edges.prevOut(edge);
         }
-        edge = this.#edges.prevOut(edge);
+      }
+      node = this.#nodes.next(node);
+    }
+  }
+
+  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => void) {
+    let node = this.#nodes.head(to);
+    while (node !== null) {
+      let edge = this.#nodes.firstIn(node);
+      while (edge !== null) {
+        let from = this.#edges.from(edge);
+        fn(from);
+        edge = this.#edges.nextIn(edge);
       }
       node = this.#nodes.next(node);
     }
@@ -973,6 +992,7 @@ export class SharedTypeMap<TItemType, THash, TAddress: number>
   // Trick Flow into believing in `Symbol.iterator`.
   // See https://github.com/facebook/flow/issues/1163#issuecomment-353523840
   /*:: @@iterator(): Iterator<TAddress> { return ({}: any); } */
+
   // $FlowFixMe[unsupported-syntax]
   *[Symbol.iterator](): Iterator<TAddress> {
     let max = this.count;
@@ -1086,6 +1106,7 @@ export class NodeTypeMap<TEdgeType> extends SharedTypeMap<
   get nextId(): NodeId {
     return toNodeId(this.data[NodeTypeMap.#NEXT_ID]);
   }
+
   set nextId(nextId: NodeId) {
     this.data[NodeTypeMap.#NEXT_ID] = fromNodeId(nextId);
   }

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -163,6 +163,29 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     return this.adjacencyList.hasEdge(from, to, type);
   }
 
+  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => void) {
+    this._assertHasNodeId(to);
+
+    this.adjacencyList.forEachNodeIdConnectedTo(to, fn);
+  }
+
+  forEachNodeIdConnectedFrom(
+    from: NodeId,
+    fn: (nodeId: NodeId) => void,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = ALL_EDGE_TYPES,
+  ) {
+    this._assertHasNodeId(from);
+
+    this.adjacencyList.forEachNodeIdConnectedFromReverse(
+      from,
+      (id) => {
+        fn(id);
+        return false;
+      },
+      type,
+    );
+  }
+
   getNodeIdsConnectedTo(
     nodeId: NodeId,
     type:

--- a/packages/core/graph/test/Graph.test.js
+++ b/packages/core/graph/test/Graph.test.js
@@ -556,4 +556,52 @@ describe('Graph', () => {
       });
     });
   });
+
+  describe('forEachNodeConnectedTo', () => {
+    it('calls the callback for each node connected to the given node', () => {
+      const graph = new Graph();
+      const a = graph.addNode('0');
+      const b = graph.addNode('1');
+      const c = graph.addNode('2');
+      const d = graph.addNode('3');
+      graph.addNode('disconnected-1');
+      graph.addNode('disconnected-2');
+      graph.addEdge(a, b);
+      graph.addEdge(b, c);
+      graph.addEdge(b, d);
+      graph.addEdge(a, c);
+      graph.addEdge(c, d);
+
+      const order = [];
+      graph.forEachNodeIdConnectedTo(d, (node) => {
+        order.push(node);
+      });
+
+      assert.deepEqual(order, [b, c]);
+    });
+  });
+
+  describe('forEachNodeConnectedFrom', () => {
+    it('calls the callback for each node connected from the given node', () => {
+      const graph = new Graph();
+      const a = graph.addNode('0');
+      const b = graph.addNode('1');
+      const c = graph.addNode('2');
+      const d = graph.addNode('3');
+      graph.addNode('disconnected-1');
+      graph.addNode('disconnected-2');
+      graph.addEdge(a, b);
+      graph.addEdge(b, c);
+      graph.addEdge(b, d);
+      graph.addEdge(a, c);
+      graph.addEdge(c, d);
+
+      const order = [];
+      graph.forEachNodeIdConnectedFrom(a, (node) => {
+        order.push(node);
+      });
+
+      assert.deepEqual(order, [c, b]);
+    });
+  });
 });


### PR DESCRIPTION
Currently there are a few sections of the build which generate large amounts of garbage due to creating ID arrays to iterate graph edges.

This commit adds methods to the graph class that allow iteration without creating those temporary arrays.

This is useful for:

* Implementing a new bundler algorithm
* Improving performance of certain parts of the codebase

