### PR TITLE
Expose rust tracing instrumentation to javascript

### DIFF
--- a/crates/atlaspack_monitoring/src/tracer.rs
+++ b/crates/atlaspack_monitoring/src/tracer.rs
@@ -98,7 +98,9 @@ impl Tracer {
         None
       }
       TracerMode::Chrome => {
-        let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new().build();
+        let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+          .include_args(true)
+          .build();
         tracing_subscriber::registry()
           .with(chrome_layer)
           .try_init()

--- a/crates/node-bindings/src/js_tracing.rs
+++ b/crates/node-bindings/src/js_tracing.rs
@@ -29,7 +29,7 @@ impl AtlaspackTracer {
     if self.current_id == u32::MAX {
       self.current_id = 0;
     } else {
-      self.current_id = self.current_id + 1;
+      self.current_id += 1;
     }
 
     self.current_spans.insert(id, span.entered());

--- a/crates/node-bindings/src/js_tracing.rs
+++ b/crates/node-bindings/src/js_tracing.rs
@@ -1,0 +1,46 @@
+//! This module exposes the tracing API to JavaScript.
+
+use napi_derive::napi;
+use std::collections::HashMap;
+
+pub type SpanId = u32;
+
+#[napi]
+struct AtlaspackTracer {
+  current_spans: HashMap<SpanId, tracing::span::EnteredSpan>,
+  current_id: SpanId,
+}
+
+#[napi]
+impl AtlaspackTracer {
+  #[napi(constructor)]
+  pub fn new() -> Self {
+    Self {
+      current_spans: HashMap::new(),
+      current_id: 0,
+    }
+  }
+
+  #[napi]
+  pub fn enter(&mut self, label: String) -> SpanId {
+    let span = tracing::span!(tracing::Level::INFO, "js_span", label = label);
+
+    let id = self.current_id;
+    if self.current_id == u32::MAX {
+      self.current_id = 0;
+    } else {
+      self.current_id = self.current_id + 1;
+    }
+
+    self.current_spans.insert(id, span.entered());
+
+    id
+  }
+
+  #[napi]
+  pub fn exit(&mut self, id: SpanId) {
+    if let Some(span) = self.current_spans.remove(&id) {
+      drop(span);
+    }
+  }
+}

--- a/crates/node-bindings/src/lib.rs
+++ b/crates/node-bindings/src/lib.rs
@@ -19,6 +19,7 @@ mod fs_search;
 mod hash;
 #[cfg(not(target_arch = "wasm32"))]
 mod image;
+pub mod js_tracing;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod atlaspack;

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -136,7 +136,8 @@ export default class Atlaspack {
       });
     } catch (e) {
       // Fallthrough
-      logger.warn(e);
+      // eslint-disable-next-line no-console
+      console.warn(e);
     }
 
     let resolvedOptions: AtlaspackOptions = await resolveOptions({

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -15,6 +15,7 @@ import type {
   AssetGraphRequestInput,
   AssetGraphRequestResult,
 } from './AssetGraphRequest';
+import {instrument} from '../tracer';
 
 type RunInput = {|
   input: AssetGraphRequestInput,
@@ -48,7 +49,10 @@ export function createAssetGraphRequestRust(
         });
       }
 
-      let {assetGraph, changedAssets} = getAssetGraph(serializedAssetGraph);
+      let {assetGraph, changedAssets} = instrument(
+        'atlaspack_v3_getAssetGraph',
+        () => getAssetGraph(serializedAssetGraph),
+      );
 
       let changedAssetsPropagation = new Set(changedAssets.keys());
       let errors = propagateSymbols({

--- a/packages/core/core/src/tracer.js
+++ b/packages/core/core/src/tracer.js
@@ -1,0 +1,28 @@
+// @flow strict-local
+
+import {AtlaspackTracer} from '@atlaspack/rust';
+
+export const tracer: AtlaspackTracer = new AtlaspackTracer();
+
+export function instrument<T>(label: string, fn: () => T): T {
+  const span = tracer.enter(label);
+  try {
+    const result = fn();
+    return result;
+  } finally {
+    tracer.exit(span);
+  }
+}
+
+export async function instrumentAsync<T>(
+  label: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const span = tracer.enter(label);
+  try {
+    const result = await fn();
+    return result;
+  } finally {
+    tracer.exit(span);
+  }
+}

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -14,7 +14,7 @@ import {
 import {hashString} from '@atlaspack/rust';
 import {normalizePath} from '@atlaspack/utils';
 
-describe('bundler', function () {
+describe.only('bundler', function () {
   it('should not create shared bundles when a bundle is being reused and disableSharedBundles is enabled', async function () {
     await fsFixture(overlayFS, __dirname)`
       disable-shared-bundle-single-source

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -14,7 +14,7 @@ import {
 import {hashString} from '@atlaspack/rust';
 import {normalizePath} from '@atlaspack/utils';
 
-describe.only('bundler', function () {
+describe('bundler', function () {
   it('should not create shared bundles when a bundle is being reused and disableSharedBundles is enabled', async function () {
     await fsFixture(overlayFS, __dirname)`
       disable-shared-bundle-single-source

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -395,3 +395,9 @@ export type Resolution =
   | {|type: 'External'|}
   | {|type: 'Empty'|}
   | {|type: 'Global', value: string|};
+
+declare export class AtlaspackTracer {
+  constructor(): AtlaspackTracer;
+  enter(label: string): number;
+  exit(id: number): void;
+}


### PR DESCRIPTION
This commit adds a way to instrument javascript code with the rust tracing implementation.

This allows unified chrome profiles to be generated that include both rust and javascript spans.

Since span names need to be static, currently javascript spans will need to be labeled with a `label` arg/attribute.

