### PR TITLE
WIP - Warn if transformer does not update source-map

### DIFF
--- a/packages/core/core/src/public/Asset.js
+++ b/packages/core/core/src/public/Asset.js
@@ -221,6 +221,14 @@ export class Asset extends BaseAsset implements IAsset {
 
 export class MutableAsset extends BaseAsset implements IMutableAsset {
   #asset /*: UncommittedAsset */;
+  /**
+   * This is set to true if the asset source code has been modified.
+   */
+  #hasUpdatedSource: boolean = false;
+  /**
+   * This is set to true if the asset source-maps have been updated.
+   */
+  #hasUpdatedSourceMap: boolean = false;
 
   constructor(asset: UncommittedAsset): MutableAsset {
     let existing = assetValueToMutableAsset.get(asset.value);
@@ -236,7 +244,22 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
   }
 
   setMap(map: ?SourceMap): void {
+    this.#hasUpdatedSourceMap = true;
     this.#asset.setMap(map);
+  }
+
+  /**
+   * True if the asset source code has been modified.
+   */
+  get hasUpdatedSource(): boolean {
+    return this.#hasUpdatedSource;
+  }
+
+  /**
+   * True if the asset source-maps have been updated.
+   */
+  get hasUpdatedSourceMap(): boolean {
+    return this.#hasUpdatedSourceMap;
   }
 
   get type(): string {
@@ -325,18 +348,22 @@ export class MutableAsset extends BaseAsset implements IMutableAsset {
   }
 
   setBuffer(buffer: Buffer): void {
+    this.#hasUpdatedSource = true;
     this.#asset.setBuffer(buffer);
   }
 
   setCode(code: string): void {
+    this.#hasUpdatedSource = true;
     this.#asset.setCode(code);
   }
 
   setStream(stream: Readable): void {
+    this.#hasUpdatedSource = true;
     this.#asset.setStream(stream);
   }
 
   setAST(ast: AST): void {
+    this.#hasUpdatedSource = true;
     return this.#asset.setAST(ast);
   }
 

--- a/packages/core/core/test/public/Asset.test.js
+++ b/packages/core/core/test/public/Asset.test.js
@@ -1,0 +1,72 @@
+// @flow strict-local
+
+import assert from 'assert';
+import {MutableAsset} from '../../src/public/Asset';
+import UncommittedAsset from '../../src/UncommittedAsset';
+
+describe('MutableAsset', () => {
+  const setup = () => {
+    // $FlowFixMe
+    const asset = new UncommittedAsset({value: {}});
+    const mutableAsset = new MutableAsset(asset);
+    return {mutableAsset};
+  };
+
+  describe('isDirty', () => {
+    it('is false when the mutable asset is created', () => {
+      const {mutableAsset} = setup();
+      assert.equal(mutableAsset.hasUpdatedSource, false);
+    });
+
+    it('is set to true if the code string is changed', () => {
+      const {mutableAsset} = setup();
+
+      assert.equal(mutableAsset.hasUpdatedSource, false);
+      mutableAsset.setCode('new code');
+      assert.equal(mutableAsset.hasUpdatedSource, true);
+    });
+
+    it('is set to true if the ast is changed', () => {
+      const {mutableAsset} = setup();
+
+      assert.equal(mutableAsset.hasUpdatedSource, false);
+      // $FlowFixMe
+      mutableAsset.setAST({});
+      assert.equal(mutableAsset.hasUpdatedSource, true);
+    });
+
+    it('is set to true if the source buffer is changed', () => {
+      const {mutableAsset} = setup();
+
+      assert.equal(mutableAsset.hasUpdatedSource, false);
+      // $FlowFixMe
+      mutableAsset.setBuffer(Buffer.from('new buffer'));
+      assert.equal(mutableAsset.hasUpdatedSource, true);
+    });
+
+    it('is set to true if the source stream is changed', () => {
+      const {mutableAsset} = setup();
+
+      assert.equal(mutableAsset.hasUpdatedSource, false);
+      // $FlowFixMe
+      mutableAsset.setStream({pipe: () => {}});
+      assert.equal(mutableAsset.hasUpdatedSource, true);
+    });
+  });
+
+  describe('hasUpdatedSourceMap', () => {
+    it('is false when the mutable asset is created', () => {
+      const {mutableAsset} = setup();
+      assert.equal(mutableAsset.hasUpdatedSourceMap, false);
+    });
+
+    it('is set to true if the source map is changed', () => {
+      const {mutableAsset} = setup();
+
+      assert.equal(mutableAsset.hasUpdatedSourceMap, false);
+      // $FlowFixMe
+      mutableAsset.setMap({toBuffer: () => Buffer.from('new map')});
+      assert.equal(mutableAsset.hasUpdatedSourceMap, true);
+    });
+  });
+});


### PR DESCRIPTION
This adds a warning if a transformer changes the asset source but does not update its source-map.

- - -

WIP because I'll update this to remove non JS/TS warnings and to log only a reasonable amount.