### PR TITLE
Modify BundleGraph::getAssetWithDependency to use graph iteration methods

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1773,14 +1773,23 @@ export default class BundleGraph {
       return null;
     }
 
-    let res = this._graph.getNodeIdsConnectedTo(
+    let res = null;
+    let count = 0;
+    this._graph.forEachNodeIdConnectedTo(
       this._graph.getNodeIdByContentKey(dep.id),
+      (node) => {
+        res = node;
+        count += 1;
+        if (count > 1) {
+          throw new Error(
+            'Expected a single asset to be connected to a dependency',
+          );
+        }
+      },
     );
-    invariant(
-      res.length <= 1,
-      'Expected a single asset to be connected to a dependency',
-    );
-    let resNode = this._graph.getNode(res[0]);
+
+    invariant(res != null, 'Expected an asset to be connected to a dependency');
+    let resNode = this._graph.getNode(res);
     if (resNode?.type === 'asset') {
       return resNode.value;
     }

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1788,8 +1788,7 @@ export default class BundleGraph {
       },
     );
 
-    invariant(res != null, 'Expected an asset to be connected to a dependency');
-    let resNode = this._graph.getNode(res);
+    let resNode = res != null ? this._graph.getNode(res) : null;
     if (resNode?.type === 'asset') {
       return resNode.value;
     }

--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1786,6 +1786,7 @@ export default class BundleGraph {
           );
         }
       },
+      1,
     );
 
     let resNode = res != null ? this._graph.getNode(res) : null;

--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -619,13 +619,15 @@ export default class AdjacencyList<TEdgeType: number = 1> {
     }
   }
 
-  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => void) {
+  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => boolean | void) {
     let node = this.#nodes.head(to);
     while (node !== null) {
       let edge = this.#nodes.firstIn(node);
       while (edge !== null) {
         let from = this.#edges.from(edge);
-        fn(from);
+        if (fn(from)) {
+          return;
+        }
         edge = this.#edges.nextIn(edge);
       }
       node = this.#nodes.next(node);

--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -3,7 +3,12 @@ import assert from 'assert';
 import nullthrows from 'nullthrows';
 import {SharedBuffer} from './shared-buffer';
 import {fromNodeId, toNodeId} from './types';
-import {ALL_EDGE_TYPES, type NullEdgeType, type AllEdgeTypes} from './Graph';
+import {
+  ALL_EDGE_TYPES,
+  NULL_EDGE_TYPE,
+  type NullEdgeType,
+  type AllEdgeTypes,
+} from './Graph';
 import type {NodeId} from './types';
 
 /** The address of the node in the nodes map. */
@@ -116,7 +121,7 @@ const MAX_LINK_TRIES: 3 = 3;
  * `getInboundEdgesByType` methods.
  *
  */
-export default class AdjacencyList<TEdgeType: number = 1> {
+export default class AdjacencyList<TEdgeType: number = NullEdgeType> {
   #nodes: NodeTypeMap<TEdgeType | NullEdgeType>;
   #edges: EdgeTypeMap<TEdgeType | NullEdgeType>;
 
@@ -363,7 +368,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
   addEdge(
     from: NodeId,
     to: NodeId,
-    type: TEdgeType | NullEdgeType = 1,
+    type: TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ): boolean {
     assert(from < this.#nodes.nextId, `Node ${from} does not exist.`);
     assert(to < this.#nodes.nextId, `Node ${to} does not exist.`);
@@ -433,7 +438,10 @@ export default class AdjacencyList<TEdgeType: number = 1> {
   hasEdge(
     from: NodeId,
     to: NodeId,
-    type: TEdgeType | NullEdgeType | Array<TEdgeType | NullEdgeType> = 1,
+    type:
+      | TEdgeType
+      | NullEdgeType
+      | Array<TEdgeType | NullEdgeType> = NULL_EDGE_TYPE,
   ): boolean {
     let hasEdge = (type: TEdgeType | NullEdgeType) => {
       let hash = this.#edges.hash(from, to, type);
@@ -458,7 +466,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
   removeEdge(
     from: NodeId,
     to: NodeId,
-    type: TEdgeType | NullEdgeType = 1,
+    type: TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ): void {
     let hash = this.#edges.hash(from, to, type);
     let edge = this.#edges.addressOf(hash, from, to, type);
@@ -568,7 +576,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
       | AllEdgeTypes
       | TEdgeType
       | NullEdgeType
-      | Array<TEdgeType | NullEdgeType> = 1,
+      | Array<TEdgeType | NullEdgeType> = NULL_EDGE_TYPE,
   ): NodeId[] {
     let matches = (node) =>
       type === ALL_EDGE_TYPES ||
@@ -622,7 +630,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
   forEachNodeIdConnectedTo(
     to: NodeId,
     fn: (nodeId: NodeId) => boolean | void,
-    type: AllEdgeTypes | TEdgeType | NullEdgeType = 1,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ) {
     const matches = (node) =>
       type === ALL_EDGE_TYPES || type === this.#nodes.typeOf(node);
@@ -656,7 +664,7 @@ export default class AdjacencyList<TEdgeType: number = 1> {
       | AllEdgeTypes
       | TEdgeType
       | NullEdgeType
-      | Array<TEdgeType | NullEdgeType> = 1,
+      | Array<TEdgeType | NullEdgeType> = NULL_EDGE_TYPE,
   ): NodeId[] {
     let matches = (node) =>
       type === ALL_EDGE_TYPES ||

--- a/packages/core/graph/src/AdjacencyList.js
+++ b/packages/core/graph/src/AdjacencyList.js
@@ -619,16 +619,25 @@ export default class AdjacencyList<TEdgeType: number = 1> {
     }
   }
 
-  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => boolean | void) {
+  forEachNodeIdConnectedTo(
+    to: NodeId,
+    fn: (nodeId: NodeId) => boolean | void,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = 1,
+  ) {
+    const matches = (node) =>
+      type === ALL_EDGE_TYPES || type === this.#nodes.typeOf(node);
+
     let node = this.#nodes.head(to);
     while (node !== null) {
-      let edge = this.#nodes.firstIn(node);
-      while (edge !== null) {
-        let from = this.#edges.from(edge);
-        if (fn(from)) {
-          return;
+      if (matches(node)) {
+        let edge = this.#nodes.firstIn(node);
+        while (edge !== null) {
+          let from = this.#edges.from(edge);
+          if (fn(from)) {
+            return;
+          }
+          edge = this.#edges.nextIn(edge);
         }
-        edge = this.#edges.nextIn(edge);
       }
       node = this.#nodes.next(node);
     }

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -163,7 +163,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     return this.adjacencyList.hasEdge(from, to, type);
   }
 
-  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => void) {
+  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => boolean | void) {
     this._assertHasNodeId(to);
 
     this.adjacencyList.forEachNodeIdConnectedTo(to, fn);

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -13,14 +13,15 @@ import {BitSet} from './BitSet';
 import nullthrows from 'nullthrows';
 
 export type NullEdgeType = 1;
-export type GraphOpts<TNode, TEdgeType: number = 1> = {|
+export const NULL_EDGE_TYPE: NullEdgeType = 1;
+export type GraphOpts<TNode, TEdgeType: number = NullEdgeType> = {|
   nodes?: Array<TNode | null>,
   adjacencyList?: SerializedAdjacencyList<TEdgeType>,
   rootNodeId?: ?NodeId,
   initialCapacity?: number,
 |};
 
-export type SerializedGraph<TNode, TEdgeType: number = 1> = {|
+export type SerializedGraph<TNode, TEdgeType: number = NullEdgeType> = {|
   nodes: Array<TNode | null>,
   adjacencyList: SerializedAdjacencyList<TEdgeType>,
   rootNodeId: ?NodeId,
@@ -74,7 +75,7 @@ export type DFSParams<TContext> = {|
   startNodeId?: ?NodeId,
 |};
 
-export default class Graph<TNode, TEdgeType: number = 1> {
+export default class Graph<TNode, TEdgeType: number = NullEdgeType> {
   nodes: Array<TNode | null>;
   adjacencyList: AdjacencyList<TEdgeType>;
   rootNodeId: ?NodeId;
@@ -138,7 +139,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   addEdge(
     from: NodeId,
     to: NodeId,
-    type: TEdgeType | NullEdgeType = 1,
+    type: TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ): boolean {
     if (Number(type) === 0) {
       throw new Error(`Edge type "${type}" not allowed`);
@@ -158,7 +159,10 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   hasEdge(
     from: NodeId,
     to: NodeId,
-    type?: TEdgeType | NullEdgeType | Array<TEdgeType | NullEdgeType> = 1,
+    type?:
+      | TEdgeType
+      | NullEdgeType
+      | Array<TEdgeType | NullEdgeType> = NULL_EDGE_TYPE,
   ): boolean {
     return this.adjacencyList.hasEdge(from, to, type);
   }
@@ -166,7 +170,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   forEachNodeIdConnectedTo(
     to: NodeId,
     fn: (nodeId: NodeId) => boolean | void,
-    type: AllEdgeTypes | TEdgeType | NullEdgeType = 1,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ) {
     this._assertHasNodeId(to);
 
@@ -176,7 +180,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   forEachNodeIdConnectedFrom(
     from: NodeId,
     fn: (nodeId: NodeId) => void,
-    type: AllEdgeTypes | TEdgeType | NullEdgeType = 1,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ) {
     this._assertHasNodeId(from);
 
@@ -196,7 +200,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
       | TEdgeType
       | NullEdgeType
       | Array<TEdgeType | NullEdgeType>
-      | AllEdgeTypes = 1,
+      | AllEdgeTypes = NULL_EDGE_TYPE,
   ): Array<NodeId> {
     this._assertHasNodeId(nodeId);
 
@@ -209,7 +213,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
       | TEdgeType
       | NullEdgeType
       | Array<TEdgeType | NullEdgeType>
-      | AllEdgeTypes = 1,
+      | AllEdgeTypes = NULL_EDGE_TYPE,
   ): Array<NodeId> {
     this._assertHasNodeId(nodeId);
 
@@ -240,7 +244,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     this.nodes[nodeId] = null;
   }
 
-  removeEdges(nodeId: NodeId, type: TEdgeType | NullEdgeType = 1) {
+  removeEdges(nodeId: NodeId, type: TEdgeType | NullEdgeType = NULL_EDGE_TYPE) {
     if (!this.hasNode(nodeId)) {
       return;
     }
@@ -253,7 +257,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   removeEdge(
     from: NodeId,
     to: NodeId,
-    type: TEdgeType | NullEdgeType = 1,
+    type: TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
     removeOrphans: boolean = true,
   ) {
     if (!this.adjacencyList.hasEdge(from, to, type)) {
@@ -269,7 +273,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   _removeEdge(
     from: NodeId,
     to: NodeId,
-    type: TEdgeType | NullEdgeType = 1,
+    type: TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
     removeOrphans: boolean = true,
   ) {
     if (!this.adjacencyList.hasEdge(from, to, type)) {
@@ -325,7 +329,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     fromNodeId: NodeId,
     toNodeIds: $ReadOnlyArray<NodeId>,
     replaceFilter?: null | ((NodeId) => boolean),
-    type?: TEdgeType | NullEdgeType = 1,
+    type?: TEdgeType | NullEdgeType = NULL_EDGE_TYPE,
   ): void {
     this._assertHasNodeId(fromNodeId);
 
@@ -355,7 +359,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
       | TEdgeType
       | NullEdgeType
       | Array<TEdgeType | NullEdgeType>
-      | AllEdgeTypes = 1,
+      | AllEdgeTypes = NULL_EDGE_TYPE,
   ): ?TContext {
     let enter = typeof visit === 'function' ? visit : visit.enter;
     if (
@@ -389,7 +393,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
       | TEdgeType
       | NullEdgeType
       | Array<TEdgeType | NullEdgeType>
-      | AllEdgeTypes = 1,
+      | AllEdgeTypes = NULL_EDGE_TYPE,
   ): ?TContext {
     return this.dfs({
       visit,

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -163,10 +163,14 @@ export default class Graph<TNode, TEdgeType: number = 1> {
     return this.adjacencyList.hasEdge(from, to, type);
   }
 
-  forEachNodeIdConnectedTo(to: NodeId, fn: (nodeId: NodeId) => boolean | void) {
+  forEachNodeIdConnectedTo(
+    to: NodeId,
+    fn: (nodeId: NodeId) => boolean | void,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = ALL_EDGE_TYPES,
+  ) {
     this._assertHasNodeId(to);
 
-    this.adjacencyList.forEachNodeIdConnectedTo(to, fn);
+    this.adjacencyList.forEachNodeIdConnectedTo(to, fn, type);
   }
 
   forEachNodeIdConnectedFrom(

--- a/packages/core/graph/src/Graph.js
+++ b/packages/core/graph/src/Graph.js
@@ -166,7 +166,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   forEachNodeIdConnectedTo(
     to: NodeId,
     fn: (nodeId: NodeId) => boolean | void,
-    type: AllEdgeTypes | TEdgeType | NullEdgeType = ALL_EDGE_TYPES,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = 1,
   ) {
     this._assertHasNodeId(to);
 
@@ -176,7 +176,7 @@ export default class Graph<TNode, TEdgeType: number = 1> {
   forEachNodeIdConnectedFrom(
     from: NodeId,
     fn: (nodeId: NodeId) => void,
-    type: AllEdgeTypes | TEdgeType | NullEdgeType = ALL_EDGE_TYPES,
+    type: AllEdgeTypes | TEdgeType | NullEdgeType = 1,
   ) {
     this._assertHasNodeId(from);
 

--- a/packages/core/graph/test/AdjacencyList.test.js
+++ b/packages/core/graph/test/AdjacencyList.test.js
@@ -7,6 +7,7 @@ import {Worker} from 'worker_threads';
 
 import AdjacencyList, {NodeTypeMap, EdgeTypeMap} from '../src/AdjacencyList';
 import {toNodeId} from '../src/types';
+import {ALL_EDGE_TYPES} from '../src/Graph';
 
 describe('AdjacencyList', () => {
   it('constructor should initialize an empty graph', () => {
@@ -342,6 +343,44 @@ describe('AdjacencyList', () => {
       });
 
       assert.deepEqual(nodeIds, [a, c, b]);
+    });
+
+    it('respects the edge type', () => {
+      const graph = new AdjacencyList();
+      const a = graph.addNode();
+      const b = graph.addNode();
+      const c = graph.addNode();
+
+      graph.addEdge(a, b);
+      graph.addEdge(c, b, 2);
+
+      const nodeIds = [];
+      graph.forEachNodeIdConnectedTo(b, (id) => {
+        nodeIds.push(id);
+      });
+
+      assert.deepEqual(nodeIds, [a]);
+    });
+
+    it('iterates all edges if all edge type is provided', () => {
+      const graph = new AdjacencyList();
+      const a = graph.addNode();
+      const b = graph.addNode();
+      const c = graph.addNode();
+
+      graph.addEdge(a, b);
+      graph.addEdge(c, b, 2);
+
+      const nodeIds = [];
+      graph.forEachNodeIdConnectedTo(
+        b,
+        (id) => {
+          nodeIds.push(id);
+        },
+        ALL_EDGE_TYPES,
+      );
+
+      assert.deepEqual(nodeIds, [a, c]);
     });
   });
 

--- a/packages/core/graph/test/AdjacencyList.test.js
+++ b/packages/core/graph/test/AdjacencyList.test.js
@@ -306,6 +306,26 @@ describe('AdjacencyList', () => {
       assert.deepEqual(nodeIds, [a, c]);
     });
 
+    it('stops traversal if the return value is true', () => {
+      const graph = new AdjacencyList();
+      const a = graph.addNode();
+      const b = graph.addNode();
+      const c = graph.addNode();
+      const d = graph.addNode();
+
+      graph.addEdge(a, d);
+      graph.addEdge(b, d);
+      graph.addEdge(c, d);
+
+      const nodeIds = [];
+      graph.forEachNodeIdConnectedTo(d, (nodeId) => {
+        nodeIds.push(nodeId);
+        return true;
+      });
+
+      assert.deepEqual(nodeIds, [a]);
+    });
+
     it('terminates if the graph is cyclic', () => {
       const graph = new AdjacencyList();
       const a = graph.addNode();


### PR DESCRIPTION
Prevents creating temporary arrays when finding the asset linked to a dependency. This is a relatively hot path in the bundler and can improve its performance.

I will perform a dev release from this branch and do some performance testing.