### PR TITLE
Support asset not needing bundle loading

### DIFF
--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -483,17 +483,27 @@ function getLoaderRuntime({
       bundle,
     )) {
       // This bundle has a conditional dependency, we need to load the bundle group
-
-      // Load conditional bundles with helper (and a dev mode with additional hints)
-      loaderModules.push(
-        `require('./helpers/conditional-loader${
-          options.mode === 'development' ? '-dev' : ''
-        }')('${cond.key}', function (){return Promise.all([${cond.ifTrueBundles
-          .map((targetBundle) => getLoaderForBundle(bundle, targetBundle))
-          .join(',')}]);}, function (){return Promise.all([${cond.ifFalseBundles
-          .map((targetBundle) => getLoaderForBundle(bundle, targetBundle))
-          .join(',')}]);})`,
+      const ifTrueLoaders = cond.ifTrueBundles.map((targetBundle) =>
+        getLoaderForBundle(bundle, targetBundle),
       );
+      const ifFalseLoaders = cond.ifFalseBundles.map((targetBundle) =>
+        getLoaderForBundle(bundle, targetBundle),
+      );
+
+      if (ifTrueLoaders.length > 0 || ifFalseLoaders.length > 0) {
+        // Load conditional bundles with helper (and a dev mode with additional hints)
+        loaderModules.push(
+          `require('./helpers/conditional-loader${
+            options.mode === 'development' ? '-dev' : ''
+          }')('${
+            cond.key
+          }', function (){return Promise.all([${ifTrueLoaders.join(
+            ',',
+          )}]);}, function (){return Promise.all([${ifFalseLoaders.join(
+            ',',
+          )}]);})`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

A simple change would be to reference the existing asset instead of erroring directly. This seems to be needed as assets could already be loaded even if there's no current bundle. 

## Changes

Add else statement to load asset id even if not found in async or current bundle.

## Checklist

- [ ] Existing or new tests cover this change
