### PR TITLE
V3: Passing diagnostics from Rust

### DIFF
--- a/crates/atlaspack/src/error.rs
+++ b/crates/atlaspack/src/error.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 pub enum AtlaspackError {
   Diagnostic(Diagnostic),
-  String(String),
+  Unknown(String),
 }
 
 impl Serialize for AtlaspackError {
@@ -14,7 +14,7 @@ impl Serialize for AtlaspackError {
   {
     match self {
       AtlaspackError::Diagnostic(diagnostic) => diagnostic.serialize(serializer),
-      AtlaspackError::String(message) => message.serialize(serializer),
+      AtlaspackError::Unknown(message) => message.serialize(serializer),
     }
   }
 }
@@ -24,9 +24,9 @@ impl From<&anyhow::Error> for AtlaspackError {
     if let Some(diagnostic) = error.downcast_ref::<Diagnostic>() {
       Self::Diagnostic(diagnostic.clone())
     } else if let Some(message) = error.downcast_ref::<String>() {
-      Self::String(message.clone())
+      Self::Unknown(message.clone())
     } else {
-      Self::String(error.to_string())
+      Self::Unknown(error.to_string())
     }
   }
 }
@@ -35,7 +35,7 @@ impl From<AtlaspackError> for anyhow::Error {
   fn from(value: AtlaspackError) -> Self {
     match value {
       AtlaspackError::Diagnostic(diagnostic) => anyhow!(diagnostic),
-      AtlaspackError::String(message) => anyhow!(message),
+      AtlaspackError::Unknown(message) => anyhow!(message),
     }
   }
 }

--- a/crates/atlaspack/src/error.rs
+++ b/crates/atlaspack/src/error.rs
@@ -1,0 +1,41 @@
+use anyhow::anyhow;
+use atlaspack_core::types::Diagnostic;
+use serde::Serialize;
+
+pub enum AtlaspackError {
+  Diagnostic(Diagnostic),
+  String(String),
+}
+
+impl Serialize for AtlaspackError {
+  fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+  where
+    S: serde::Serializer,
+  {
+    match self {
+      AtlaspackError::Diagnostic(diagnostic) => diagnostic.serialize(serializer),
+      AtlaspackError::String(message) => message.serialize(serializer),
+    }
+  }
+}
+
+impl From<&anyhow::Error> for AtlaspackError {
+  fn from(error: &anyhow::Error) -> Self {
+    if let Some(diagnostic) = error.downcast_ref::<Diagnostic>() {
+      Self::Diagnostic(diagnostic.clone())
+    } else if let Some(message) = error.downcast_ref::<String>() {
+      Self::String(message.clone())
+    } else {
+      Self::String(error.to_string())
+    }
+  }
+}
+
+impl From<AtlaspackError> for anyhow::Error {
+  fn from(value: AtlaspackError) -> Self {
+    match value {
+      AtlaspackError::Diagnostic(diagnostic) => anyhow!(diagnostic),
+      AtlaspackError::String(message) => anyhow!(message),
+    }
+  }
+}

--- a/crates/atlaspack/src/lib.rs
+++ b/crates/atlaspack/src/lib.rs
@@ -1,10 +1,12 @@
 pub use atlaspack::*;
 pub use atlaspack_filesystem as file_system;
 pub use atlaspack_plugin_rpc as rpc;
+pub use error::*;
 
 pub mod atlaspack;
 pub(crate) mod request_tracker;
 
+mod error;
 mod plugins;
 mod project_root;
 mod requests;

--- a/crates/atlaspack/src/request_tracker/request_tracker.rs
+++ b/crates/atlaspack/src/request_tracker/request_tracker.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use std::sync::mpsc::Sender;
 use std::sync::Arc;
 
-use anyhow::anyhow;
 use petgraph::graph::NodeIndex;
 use petgraph::stable_graph::StableDiGraph;
 
@@ -14,6 +13,7 @@ use atlaspack_filesystem::FileSystemRef;
 
 use crate::plugins::PluginsRef;
 use crate::requests::RequestResult;
+use crate::AtlaspackError;
 
 use super::Request;
 use super::RequestEdgeType;
@@ -224,7 +224,7 @@ impl RequestTracker {
 
     *request_node = match result {
       Ok(result) => RequestNode::Valid(result.clone()),
-      Err(error) => RequestNode::Error(anyhow!(error.to_string())),
+      Err(error) => RequestNode::Error(AtlaspackError::from(error).into()),
     };
 
     Ok(())
@@ -249,7 +249,7 @@ impl RequestTracker {
     match request_node {
       RequestNode::Root => Err(diagnostic_error!("Impossible")),
       RequestNode::Incomplete => Err(diagnostic_error!("Impossible")),
-      RequestNode::Error(error) => Err(anyhow!(error.to_string())),
+      RequestNode::Error(error) => Err(AtlaspackError::from(error).into()),
       RequestNode::Valid(value) => Ok(value.result.clone()),
     }
   }

--- a/crates/atlaspack_core/src/types/diagnostic.rs
+++ b/crates/atlaspack_core/src/types/diagnostic.rs
@@ -22,7 +22,7 @@ pub enum ErrorKind {
 /// This is a user facing error for Atlaspack.
 ///
 /// Usually but not always this is linked to a source-code location.
-#[derive(Builder, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Builder, Debug, Deserialize, PartialEq, Serialize, Clone)]
 #[builder(derive(Debug))]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
@@ -59,6 +59,13 @@ impl Display for Diagnostic {
   }
 }
 
+impl TryFrom<anyhow::Error> for Diagnostic {
+  type Error = anyhow::Error;
+
+  fn try_from(value: anyhow::Error) -> Result<Self, Self::Error> {
+    value.downcast()
+  }
+}
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Language(FileType);
 
@@ -119,7 +126,6 @@ impl From<PathBuf> for CodeFrame {
     }
   }
 }
-
 /// Represents a snippet of code to highlight
 #[derive(Serialize, Default, Deserialize, Debug, PartialEq, Clone)]
 pub struct CodeHighlight {

--- a/crates/node-bindings/src/atlaspack/mod.rs
+++ b/crates/node-bindings/src/atlaspack/mod.rs
@@ -6,5 +6,6 @@ pub mod dependency;
 pub mod environment;
 pub mod file_system_napi;
 pub mod monitoring;
+pub mod napi_result;
 pub mod package_manager_napi;
 pub mod worker;

--- a/crates/node-bindings/src/atlaspack/napi_result.rs
+++ b/crates/node-bindings/src/atlaspack/napi_result.rs
@@ -1,0 +1,31 @@
+use napi::{bindgen_prelude::ToNapiValue, Env, JsObject};
+
+/// This creates the following JavaScript tuple
+/// ```
+/// [result: any | null, error: any | null]
+/// ```
+pub struct NapiAtlaspackResult;
+
+impl NapiAtlaspackResult {
+  /// This creates the following JavaScript tuple
+  /// ```
+  /// [JsAny, null]
+  /// ```
+  pub fn ok(env: &Env, target: impl ToNapiValue) -> napi::Result<JsObject> {
+    let mut obj = env.create_array(2)?;
+    obj.set(0, target)?;
+    obj.set(1, env.get_null())?;
+    obj.coerce_to_object()
+  }
+
+  /// This creates the following JavaScript tuple
+  /// ```
+  /// [null, JsAny]
+  /// ```
+  pub fn error(env: &Env, target: impl ToNapiValue) -> napi::Result<JsObject> {
+    let mut obj = env.create_array(2)?;
+    obj.set(0, env.get_null())?;
+    obj.set(1, target)?;
+    obj.coerce_to_object()
+  }
+}

--- a/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
+++ b/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
@@ -6,6 +6,7 @@ import {
   type AtlaspackNapiOptions,
 } from '@atlaspack/rust';
 import {workerPool} from './WorkerPool';
+import ThrowableDiagnostic from '@atlaspack/diagnostic';
 
 export type AtlaspackV3Options = {|
   fs?: AtlaspackNapiOptions['fs'],
@@ -50,7 +51,8 @@ export class AtlaspackV3 {
 
   async buildAssetGraph(): Promise<any> {
     const workerIds = [];
-    let result = await this._internal.buildAssetGraph({
+
+    let [graph, error] = await this._internal.buildAssetGraph({
       registerWorker: (tx_worker) => {
         // $FlowFixMe
         const workerId = workerPool.registerWorker(tx_worker);
@@ -60,6 +62,12 @@ export class AtlaspackV3 {
 
     workerPool.releaseWorkers(workerIds);
 
-    return result;
+    if (error !== null) {
+      throw new ThrowableDiagnostic({
+        diagnostic: error,
+      });
+    }
+
+    return graph;
   }
 }

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -37,17 +37,11 @@ export function createAssetGraphRequestRust(
     id: input.name,
     run: async (input) => {
       let options = input.options;
-      let serializedAssetGraph;
-      try {
-        serializedAssetGraph = await rustAtlaspack.buildAssetGraph();
-        serializedAssetGraph.nodes = serializedAssetGraph.nodes.flatMap(
-          (node) => JSON.parse(node),
-        );
-      } catch (err) {
-        throw new ThrowableDiagnostic({
-          diagnostic: err,
-        });
-      }
+      let serializedAssetGraph = await rustAtlaspack.buildAssetGraph();
+
+      serializedAssetGraph.nodes = serializedAssetGraph.nodes.flatMap((node) =>
+        JSON.parse(node),
+      );
 
       let {assetGraph, changedAssets} = instrument(
         'atlaspack_v3_getAssetGraph',


### PR DESCRIPTION
Errors are currently sent to the JavaScript layer as strings. This is a problem because the JavaScript layer currently handles formatting the error output from a `Diagnostic` object - which cannot be done from a string leading to poor error messages.

This PR allows Rust to return `Diagnostic` objects to JavaScript to handle formatting and printing. This works by having Rust check if the internal `anyhow::Error` is a `Diagnostic`, if it is then it converts it to JavaScript and returns that otherwise it returns the error in string form.

On the Napi side, to serialize the `Diagnostic` value we need access to `Env` which isn't available in `deferred.reject()` so instead the error value is passed via `deferred.resolve()`. 

This then necessitated `AtlaspackNapi.buildAssetGraph()` returning a tuple and rethrowing is handled in the JavaScript layer.

```typescript
type Ok<T> = [T, null]
type Err<E> = [null, E]
type Result<T, E> = Ok<T> | Err<E>
```

## Preview

By comparison to V2 error messages, V3 error messages are pretty low on detail at this stage

#### V2 Error Message

![image](https://github.com/user-attachments/assets/d98967d6-2aa5-48c5-afed-23743d25e59e)

#### V3 Error Message

![image](https://github.com/user-attachments/assets/bc40a9c2-84f6-42dd-bae8-7d11358169cb)

## Todo

We need to add additional error information (`codeFrames`, `hints`, etc) to the error handling of our internals (resolver, transformer, etc). 

For the time being this PR allows Diagnostic errors to propage to JavaScript, following PRs should look at addressing the contents of those errors
