### PR TITLE
Fix inline requires source map generation

### DIFF
--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -94,7 +94,7 @@ describe('inline requires', () => {
     );
   });
 
-  it('keeps source-maps working', async () => {
+  it.v2('keeps source-maps working', async () => {
     await fsFixture(overlayFS, __dirname)`
         inline-requires
           dependency/index.js:

--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -167,7 +167,7 @@ describe('inline requires', () => {
     expect(line).not.toEqual(-1);
     const originalPosition = sourceMapConsumer.originalPositionFor({
       line,
-      column: 10,
+      column: 'console.log'.length + 3,
     });
     expect(originalPosition.line).toBe(7);
     expect(originalPosition.source).toBe('inline-requires/index.js');

--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -138,7 +138,6 @@ describe('inline requires', () => {
       path.join(__dirname, 'inline-requires/index.js'),
       {
         ...options,
-        // mode: 'development',
         inputFS: overlayFS,
         config: path.join(__dirname, 'inline-requires/.parcelrc'),
         defaultTargetOptions: {

--- a/packages/optimizers/inline-requires/src/InlineRequires.js
+++ b/packages/optimizers/inline-requires/src/InlineRequires.js
@@ -69,7 +69,7 @@ module.exports = new Optimizer<empty, BundleConfig>({
           sourceMap.extends(originalMap);
         }
       }
-      return {contents: result.code, map: originalMap};
+      return {contents: result.code, map: sourceMap};
     } catch (err) {
       logger.warn({
         origin: 'atlaspack-optimizer-experimental-inline-requires',


### PR DESCRIPTION
The wrong source-map was getting returned from inline requires.

An integration test is added to verify the mapping is correct (and was failing previously with the inline requires optimizer, but not with only the transformer).