### PR TITLE
Fix inline require sourcemaps test

### DIFF
--- a/packages/core/integration-tests/test/inline-requires.js
+++ b/packages/core/integration-tests/test/inline-requires.js
@@ -94,7 +94,7 @@ describe('inline requires', () => {
     );
   });
 
-  it.v2('keeps source-maps working', async () => {
+  it('keeps source-maps working', async () => {
     await fsFixture(overlayFS, __dirname)`
         inline-requires
           dependency/index.js:
@@ -125,9 +125,6 @@ describe('inline requires', () => {
           .parcelrc:
             {
               "extends": "@atlaspack/config-default",
-              "transformers": {
-                "*.js": ["@atlaspack/transformer-js"]
-              },
               "optimizers": {
                 "*.js": ["@atlaspack/optimizer-inline-requires"]
               }


### PR DESCRIPTION
## Motivation

The inline require sourcemaps test specifies the js transformer when it does not need to, since it is already part of the default config. Although this reveals a difference between how v2 / v3 processes config, it's usually expected you specify the full `*.{js,mjs,jsm,jsx,es6,cjs,ts,tsx}` transformer glob when overriding js transformers to avoid issues.

## Changes

Remove js transformer from test fixture

## Checklist

- [x] Existing or new tests cover this change
