### PR TITLE
Add domain sharding to js runtime

### DIFF
--- a/packages/core/integration-tests/test/BundleGraph.js
+++ b/packages/core/integration-tests/test/BundleGraph.js
@@ -64,7 +64,11 @@ describe('BundleGraph', () => {
       },
       {
         type: 'asset',
-        value: 'bundle-url.js',
+        value: 'bundle-url.ts',
+      },
+      {
+        type: 'asset',
+        value: 'bundle-url-common.ts',
       },
       {
         type: 'asset',
@@ -76,7 +80,11 @@ describe('BundleGraph', () => {
       },
       {
         type: 'asset',
-        value: 'bundle-url.js',
+        value: 'bundle-url.ts',
+      },
+      {
+        type: 'asset',
+        value: 'bundle-url-common.ts',
       },
       {
         type: 'asset',

--- a/packages/core/integration-tests/test/bundle-text.js
+++ b/packages/core/integration-tests/test/bundle-text.js
@@ -244,7 +244,8 @@ describe('bundle-text:', function () {
               : [
                   'index.js',
                   'esmodule-helpers.js',
-                  'bundle-url.js',
+                  'bundle-url.ts',
+                  'bundle-url-common.ts',
                   'cacheLoader.js',
                   'js-loader.js',
                 ],

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -70,7 +70,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -159,7 +160,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -253,7 +255,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -344,7 +347,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -462,7 +466,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -540,7 +545,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -618,7 +624,8 @@ describe('bundler', function () {
           assets: [
             'inline-module.js',
             'local.html',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
           ],
@@ -648,7 +655,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'esmodule-helpers.js',
@@ -700,7 +708,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'esmodule-helpers.js',
@@ -751,7 +760,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'esmodule-helpers.js',
@@ -805,7 +815,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'esmodule-helpers.js',
@@ -858,7 +869,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'esmodule-helpers.js',
@@ -933,7 +945,7 @@ describe('bundler', function () {
         ],
       },
       {
-        assets: ['bundle-manifest.js', 'bundle-url.js'], // manifest bundle
+        assets: ['bundle-manifest.js', 'bundle-url.ts', 'bundle-url-common.ts'], // manifest bundle
       },
       {
         assets: [
@@ -945,7 +957,7 @@ describe('bundler', function () {
         ],
       },
       {
-        assets: ['bundle-manifest.js', 'bundle-url.js'], // manifest bundle
+        assets: ['bundle-manifest.js', 'bundle-url.ts', 'bundle-url-common.ts'], // manifest bundle
       },
       {
         assets: ['c.js'],
@@ -1001,7 +1013,8 @@ describe('bundler', function () {
         assets: [
           'a.js',
           'b.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
@@ -1072,7 +1085,8 @@ describe('bundler', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -1414,7 +1428,8 @@ describe('bundler', function () {
         {
           assets: [
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'css-loader.js',
             'esmodule-helpers.js',
@@ -1581,7 +1596,8 @@ describe('bundler', function () {
         {
           assets: [
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'css-loader.js',
             'esmodule-helpers.js',
@@ -1882,7 +1898,8 @@ describe('bundler', function () {
           {
             assets: [
               'bundle-manifest.js',
-              'bundle-url.js',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
               'cacheLoader.js',
               'index.js',
               'js-loader.js',
@@ -1959,7 +1976,8 @@ describe('bundler', function () {
           {
             assets: [
               'bundle-manifest.js',
-              'bundle-url.js',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
               'cacheLoader.js',
               'index.js',
               'js-loader.js',
@@ -2040,7 +2058,8 @@ describe('bundler', function () {
           {
             assets: [
               'bundle-manifest.js',
-              'bundle-url.js',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
               'cacheLoader.js',
               'index.js',
               'js-loader.js',
@@ -2328,7 +2347,8 @@ describe('bundler', function () {
           assets: [
             'a.js',
             'b.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'esmodule-helpers.js',
             'js-loader.js',

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -4998,7 +4998,8 @@ describe.v2('cache', function () {
                   assets: [
                     'index.js',
                     'c.js',
-                    'bundle-url.js',
+                    'bundle-url.ts',
+                    'bundle-url-common.ts',
                     'cacheLoader.js',
                     'js-loader.js',
                     'bundle-manifest.js',
@@ -5036,7 +5037,8 @@ describe.v2('cache', function () {
             assets: [
               'index.js',
               'c.js',
-              'bundle-url.js',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
               'cacheLoader.js',
               'js-loader.js',
               'bundle-manifest.js',
@@ -5112,7 +5114,8 @@ describe.v2('cache', function () {
                   assets: [
                     'index.js',
                     'c.js',
-                    'bundle-url.js',
+                    'bundle-url.ts',
+                    'bundle-url-common.ts',
                     'cacheLoader.js',
                     'js-loader.js',
                     'bundle-manifest.js',
@@ -5150,7 +5153,8 @@ describe.v2('cache', function () {
             assets: [
               'index.js',
               'c.js',
-              'bundle-url.js',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
               'cacheLoader.js',
               'js-loader.js',
               'bundle-manifest.js',
@@ -5190,7 +5194,8 @@ describe.v2('cache', function () {
                   assets: [
                     'index.js',
                     'c.js',
-                    'bundle-url.js',
+                    'bundle-url.ts',
+                    'bundle-url-common.ts',
                     'cacheLoader.js',
                     'js-loader.js',
                     'bundle-manifest.js',
@@ -5222,7 +5227,8 @@ describe.v2('cache', function () {
             assets: [
               'index.js',
               'c.js',
-              'bundle-url.js',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
               'cacheLoader.js',
               'js-loader.js',
               'bundle-manifest.js',

--- a/packages/core/integration-tests/test/css.js
+++ b/packages/core/integration-tests/test/css.js
@@ -79,7 +79,13 @@ describe('css', () => {
       {
         name: 'entry.js',
         type: 'js',
-        assets: ['bundle-url.js', 'cacheLoader.js', 'entry.js', 'js-loader.js'],
+        assets: [
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'entry.js',
+          'js-loader.js',
+        ],
       },
       {
         type: 'js',
@@ -101,7 +107,8 @@ describe('css', () => {
         name: 'entry.js',
         type: 'js',
         assets: [
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'entry.js',
@@ -125,7 +132,8 @@ describe('css', () => {
       {
         name: 'index.js',
         assets: [
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'index.js',

--- a/packages/core/integration-tests/test/glob.js
+++ b/packages/core/integration-tests/test/glob.js
@@ -82,7 +82,7 @@ describe('glob', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', '*.js', 'bundle-url.js'],
+        assets: ['index.js', '*.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         type: 'txt',
@@ -116,7 +116,8 @@ describe('glob', function () {
         assets: [
           'index.js',
           '*.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -239,7 +240,8 @@ describe('glob', function () {
           assets: [
             '*.js',
             '*.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'index.js',
             'js-loader.js',

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -479,7 +479,8 @@ describe('html', function () {
         type: 'js',
         assets: [
           'index.css',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'css-loader.js',
           'hmr-runtime.js',
         ],
@@ -1867,7 +1868,8 @@ describe('html', function () {
           type: 'js',
           assets: [
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'index.js',
             'index.js',
@@ -2193,7 +2195,8 @@ describe('html', function () {
         type: 'js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'index.js',
           'js-loader.js',
@@ -2216,7 +2219,8 @@ describe('html', function () {
         type: 'js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'index.js',
           'js-loader.js',
@@ -2287,7 +2291,8 @@ describe('html', function () {
           assets: [
             'a.js',
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
           ],
@@ -2296,7 +2301,8 @@ describe('html', function () {
           assets: [
             'b.js',
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
           ],
@@ -2563,7 +2569,8 @@ describe('html', function () {
         type: 'js',
         assets: [
           'a.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'esmodule-helpers.js',
           'get-worker-url.js',
           'index.js',

--- a/packages/core/integration-tests/test/incremental-bundling.js
+++ b/packages/core/integration-tests/test/incremental-bundling.js
@@ -593,7 +593,7 @@ console.log(a, b);
 
         let event = await getNextBuildSuccess(b);
         let assets = Array.from(event.changedAssets.values());
-        assertChangedAssets(getChangedAssetsBeforeRuntimes(assets).length, 3);
+        assertChangedAssets(getChangedAssetsBeforeRuntimes(assets).length, 2);
         assertTimesBundled(defaultBundlerSpy.callCount, 2);
 
         // original bundle and new dynamic import bundle JS bundle

--- a/packages/core/integration-tests/test/incremental-bundling.js
+++ b/packages/core/integration-tests/test/incremental-bundling.js
@@ -593,7 +593,7 @@ console.log(a, b);
 
         let event = await getNextBuildSuccess(b);
         let assets = Array.from(event.changedAssets.values());
-        assertChangedAssets(getChangedAssetsBeforeRuntimes(assets).length, 2);
+        assertChangedAssets(getChangedAssetsBeforeRuntimes(assets).length, 3);
         assertTimesBundled(defaultBundlerSpy.callCount, 2);
 
         // original bundle and new dynamic import bundle JS bundle

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -411,7 +411,13 @@ describe('javascript', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['local.js'],
@@ -649,7 +655,8 @@ describe('javascript', function () {
         assets: [
           'index.js',
           'bar.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'foo.js',
@@ -687,7 +694,13 @@ describe('javascript', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['local.js', 'esmodule-helpers.js'],
@@ -712,7 +725,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -742,7 +756,13 @@ describe('javascript', function () {
       },
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
     ]);
 
@@ -774,7 +794,8 @@ describe('javascript', function () {
         assets: [
           'index.js',
           'c.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'bundle-manifest.js',
@@ -801,7 +822,8 @@ describe('javascript', function () {
         assets: [
           'index.js',
           'common.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -828,13 +850,20 @@ describe('javascript', function () {
       },
       {
         name: 'b.js',
-        assets: ['b.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'b.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         name: 'a.js',
         assets: [
           'a.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'common.js',
           'cacheLoader.js',
           'esmodule-helpers.js',
@@ -857,7 +886,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
@@ -891,7 +921,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -920,7 +951,7 @@ describe('javascript', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js'],
+        assets: ['index.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         type: 'txt',
@@ -950,7 +981,12 @@ describe('javascript', function () {
       assertBundles(b, [
         {
           name: 'index.js',
-          assets: ['index.js', 'bundle-url.js', 'esmodule-helpers.js'],
+          assets: [
+            'index.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
+            'esmodule-helpers.js',
+          ],
         },
         {
           type: 'txt',
@@ -983,7 +1019,12 @@ describe('javascript', function () {
       assertBundles(b, [
         {
           name: 'cjs.js',
-          assets: ['cjs.js', 'bundle-url.js', 'esmodule-helpers.js'],
+          assets: [
+            'cjs.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
+            'esmodule-helpers.js',
+          ],
         },
         {
           type: 'txt',
@@ -1093,7 +1134,7 @@ describe('javascript', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js'],
+        assets: ['index.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         type: 'txt',
@@ -2623,7 +2664,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'esmodule-helpers.js',
           'js-loader.js',
@@ -2706,7 +2748,13 @@ describe('javascript', function () {
     assertBundles(b, [
       {
         name: 'ts.js',
-        assets: ['ts.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'ts.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['async.js'],
@@ -2726,7 +2774,8 @@ describe('javascript', function () {
         name: 'ts-interop.js',
         assets: [
           'ts-interop.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -2755,7 +2804,8 @@ describe('javascript', function () {
         name: 'ts-interop-arrow.js',
         assets: [
           'ts-interop-arrow.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -2782,7 +2832,8 @@ describe('javascript', function () {
         name: 'rollup.js',
         assets: [
           'rollup.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -2820,7 +2871,8 @@ describe('javascript', function () {
         name: 'resolve-chain.js',
         assets: [
           'resolve-chain.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -2843,7 +2895,8 @@ describe('javascript', function () {
         name: 'atlaspack.js',
         assets: [
           'atlaspack.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -3000,7 +3053,8 @@ describe('javascript', function () {
         name: 'entry2.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'child.js',
           'entry2.js',
@@ -3021,7 +3075,8 @@ describe('javascript', function () {
         name: 'same-ancestry.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'dep.js',
           'js-loader.js',
@@ -3068,7 +3123,8 @@ describe('javascript', function () {
         name: 'get-dep.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'get-dep.js',
           'js-loader.js',
@@ -3124,7 +3180,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'index.js',
           'js-loader.js',
@@ -3148,7 +3205,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
@@ -3179,7 +3237,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
@@ -3249,7 +3308,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'esmodule-helpers.js',
@@ -3259,7 +3319,8 @@ describe('javascript', function () {
         name: 'other-entry.js',
         assets: [
           'other-entry.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -3702,7 +3763,13 @@ describe('javascript', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['async1.js', 'shared.js', 'esmodule-helpers.js'],
@@ -3729,7 +3796,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
           'bundle-manifest.js',
@@ -3815,7 +3883,8 @@ describe('javascript', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'esmodule-helpers.js',
@@ -4157,7 +4226,8 @@ describe('javascript', function () {
             'static-dynamic-url.js',
             'other.js',
             'esmodule-helpers.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
           ],
@@ -4228,7 +4298,8 @@ describe('javascript', function () {
           assets: [
             'dynamic-url.js',
             'esmodule-helpers.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
           ],
@@ -4340,7 +4411,8 @@ describe('javascript', function () {
         name: 'entry-a.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'entry-a.js',
           'js-loader.js',
@@ -4350,7 +4422,8 @@ describe('javascript', function () {
         name: 'entry-b.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'entry-b.js',
           'js-loader.js',

--- a/packages/core/integration-tests/test/lazy-compile.js
+++ b/packages/core/integration-tests/test/lazy-compile.js
@@ -82,7 +82,13 @@ describe.v2('lazy compile', function () {
     // `parallel-lazy-1` which wasn't requested.
     assertBundles(result.bundleGraph, [
       {
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['lazy-1.js', 'esmodule-helpers.js'],
@@ -157,7 +163,13 @@ describe.v2('lazy compile', function () {
     assertBundles(result.bundleGraph, [
       {
         name: /^index.*/,
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         // This will be a placeholder, but that info isn't available in the BundleGraph
@@ -221,7 +233,13 @@ describe.v2('lazy compile', function () {
     assertBundles(result.bundleGraph, [
       {
         name: /^index.*/,
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {
         assets: ['lazy-1.js', 'esmodule-helpers.js'],

--- a/packages/core/integration-tests/test/rust.js
+++ b/packages/core/integration-tests/test/rust.js
@@ -26,7 +26,8 @@ describe.skip('rust', function () {
       name: 'index.js',
       assets: [
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'index.js',
         'wasm-loader.js',
       ],
@@ -61,7 +62,8 @@ describe.skip('rust', function () {
       name: 'index.js',
       assets: [
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'index.js',
         'wasm-loader.js',
       ],
@@ -95,7 +97,8 @@ describe.skip('rust', function () {
       name: 'index.js',
       assets: [
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'index.js',
         'wasm-loader.js',
       ],
@@ -125,7 +128,8 @@ describe.skip('rust', function () {
       name: 'index.js',
       assets: [
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'index.js',
         'wasm-loader.js',
       ],
@@ -158,7 +162,8 @@ describe.skip('rust', function () {
       name: 'index.js',
       assets: [
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'index.js',
         'wasm-loader.js',
       ],

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -2381,7 +2381,8 @@ describe('scope hoisting', function () {
             'foo.js',
             'bar.js',
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
           ],
@@ -4347,7 +4348,7 @@ describe('scope hoisting', function () {
       assertBundles(b, [
         {
           type: 'js',
-          assets: ['a.js', 'b.js', 'bundle-url.js'],
+          assets: ['a.js', 'b.js', 'bundle-url.ts', 'bundle-url-common.ts'],
         },
         {
           type: 'txt',
@@ -5616,7 +5617,8 @@ describe('scope hoisting', function () {
         name: 'same-ancestry-scope-hoisting.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'dep.js',
           'js-loader.js',
@@ -5643,7 +5645,8 @@ describe('scope hoisting', function () {
         assets: [
           'index.js',
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -5683,7 +5686,8 @@ describe('scope hoisting', function () {
         name: 'get-dep-scope-hoisting.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'get-dep-scope-hoisting.js',
           'js-loader.js',
@@ -5730,7 +5734,8 @@ describe('scope hoisting', function () {
         name: 'scope-hoisting.js',
         assets: [
           'bundle-manifest.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'scope-hoisting.js',
           'js-loader.js',
@@ -5782,7 +5787,8 @@ describe('scope hoisting', function () {
         name: 'scope-hoisting.js',
         assets: [
           'scope-hoisting.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -5810,7 +5816,8 @@ describe('scope hoisting', function () {
         name: 'scope-hoisting.js',
         assets: [
           'scope-hoisting.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -5819,7 +5826,8 @@ describe('scope hoisting', function () {
         name: 'other-entry.js',
         assets: [
           'other-entry.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],

--- a/packages/core/integration-tests/test/server.js
+++ b/packages/core/integration-tests/test/server.js
@@ -586,7 +586,8 @@ describe.v2('server', function () {
       {
         name: 'index.js',
         assets: [
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'index.js',
@@ -626,7 +627,8 @@ describe.v2('server', function () {
       {
         name: 'index.js',
         assets: [
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'css-loader.js',
           'index.js',

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -242,7 +242,7 @@ describe('svg', function () {
 
     assertBundles(b, [
       {
-        assets: ['index.js', 'bundle-url.js'],
+        assets: ['index.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         assets: ['circle.svg'],

--- a/packages/core/integration-tests/test/typescript.js
+++ b/packages/core/integration-tests/test/typescript.js
@@ -111,7 +111,12 @@ describe('typescript', function () {
         assertBundles(b, [
           {
             name: 'index.js',
-            assets: ['index.ts', 'bundle-url.js', 'esmodule-helpers.js'],
+            assets: [
+              'index.ts',
+              'bundle-url.ts',
+              'bundle-url-common.ts',
+              'esmodule-helpers.js',
+            ],
           },
           {
             type: 'txt',

--- a/packages/core/integration-tests/test/wasm.js
+++ b/packages/core/integration-tests/test/wasm.js
@@ -29,7 +29,8 @@ describe.skip('wasm', function () {
           assets: [
             'index.js',
             'bundle-loader.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'wasm-loader.js',
           ],
           childBundles: [
@@ -62,7 +63,8 @@ describe.skip('wasm', function () {
           assets: [
             'index.js',
             'bundle-loader.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'wasm-loader.js',
           ],
           childBundles: [
@@ -94,7 +96,8 @@ describe.skip('wasm', function () {
           assets: [
             'index.js',
             'bundle-loader.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'js-loader.js',
             'wasm-loader.js',
           ],

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -152,7 +152,8 @@ describe.v2('watcher', function () {
         'common.js',
         'common-dep.js',
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'js-loader.js',
       ],
       childBundles: [
@@ -189,7 +190,13 @@ describe.v2('watcher', function () {
     bundle = await nextBundle(b);
     await assertBundleTree(bundle, {
       name: 'index.js',
-      assets: ['index.js', 'bundle-loader.js', 'bundle-url.js', 'js-loader.js'],
+      assets: [
+        'index.js',
+        'bundle-loader.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
+        'js-loader.js',
+      ],
       childBundles: [
         {
           assets: ['a.js', 'common.js', 'common-dep.js'],
@@ -258,7 +265,8 @@ describe.v2('watcher', function () {
         'common.js',
         'common-dep.js',
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'js-loader.js',
       ],
       childBundles: [
@@ -300,7 +308,8 @@ describe.v2('watcher', function () {
         'index.js',
         'common.js',
         'bundle-loader.js',
-        'bundle-url.js',
+        'bundle-url.ts',
+        'bundle-url-common.ts',
         'js-loader.js',
       ],
       childBundles: [
@@ -415,7 +424,13 @@ describe.v2('watcher', function () {
     assertBundles(bundleGraph, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {assets: ['local.js']},
     ]);
@@ -431,7 +446,13 @@ describe.v2('watcher', function () {
     assertBundles(bundleGraph, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'cacheLoader.js',
+          'js-loader.js',
+        ],
       },
       {assets: ['local.js']},
       {assets: ['other.js']},

--- a/packages/core/integration-tests/test/webextension.js
+++ b/packages/core/integration-tests/test/webextension.js
@@ -121,7 +121,14 @@ describe.v2('webextension', function () {
       {assets: ['background.js']},
       {assets: ['popup.html']},
       {assets: ['popup.css']},
-      {assets: ['popup.js', 'esmodule-helpers.js', 'bundle-url.js']},
+      {
+        assets: [
+          'popup.js',
+          'esmodule-helpers.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+        ],
+      },
       {assets: ['side-panel.html']},
       {assets: ['content-script.js']},
       {assets: ['other-content-script.js']},

--- a/packages/core/integration-tests/test/workers.js
+++ b/packages/core/integration-tests/test/workers.js
@@ -32,7 +32,8 @@ describe('atlaspack', function () {
           'worker-client.js',
           'feature.js',
           'get-worker-url.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
         ],
       },
       {
@@ -55,12 +56,18 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: [
           'worker.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -99,12 +106,18 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: [
           'worker.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -132,12 +145,18 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index-nested.js',
-        assets: ['index-nested.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index-nested.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: [
           'worker-nested.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'cacheLoader.js',
           'js-loader.js',
@@ -146,7 +165,8 @@ describe('atlaspack', function () {
       {
         assets: [
           'worker.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -178,7 +198,8 @@ describe('atlaspack', function () {
         name: 'index-async.js',
         assets: [
           'index-async.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'cacheLoader.js',
           'js-loader.js',
@@ -187,7 +208,8 @@ describe('atlaspack', function () {
       {
         assets: [
           'worker.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'cacheLoader.js',
           'js-loader.js',
         ],
@@ -220,7 +242,8 @@ describe('atlaspack', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'workerHelpers.js',
           'esmodule-helpers.js',
@@ -229,7 +252,8 @@ describe('atlaspack', function () {
       {
         assets: [
           'workerHelpers.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'esmodule-helpers.js',
         ],
@@ -248,7 +272,8 @@ describe('atlaspack', function () {
       {
         assets: [
           'import-meta.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'esmodule-helpers.js',
         ],
@@ -256,7 +281,8 @@ describe('atlaspack', function () {
       {
         assets: [
           'import-meta.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'esmodule-helpers.js',
         ],
@@ -289,7 +315,8 @@ describe('atlaspack', function () {
         name: 'index.js',
         assets: [
           'index.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'bundle-manifest.js',
         ],
@@ -354,7 +381,8 @@ describe('atlaspack', function () {
           name: 'index.js',
           assets: [
             'index.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'get-worker-url.js',
             'bundle-manifest.js',
           ],
@@ -571,7 +599,8 @@ describe('atlaspack', function () {
           'common.js',
           'worker-client.js',
           'feature.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
         ],
       },
@@ -697,7 +726,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         type: 'js',
-        assets: ['index-variable.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index-variable.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         type: 'js',
@@ -720,7 +754,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         type: 'js',
-        assets: ['index-external.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index-external.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         type: 'js',
@@ -740,7 +779,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'index.js', 'bundle-url.js'],
+        assets: [
+          'index.js',
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+        ],
       },
       {
         assets: ['worker-nested.js'],
@@ -764,7 +808,7 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'module.js',
-        assets: ['module.js', 'bundle-url.js'],
+        assets: ['module.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         assets: ['module-worker.js'],
@@ -793,7 +837,7 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'scope.js',
-        assets: ['bundle-url.js', 'scope.js'],
+        assets: ['bundle-url.ts', 'bundle-url-common.ts', 'scope.js'],
       },
       {
         assets: ['module-worker.js'],
@@ -900,7 +944,7 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'manifest.js',
-        assets: ['manifest.js', 'bundle-url.js'],
+        assets: ['manifest.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         assets: ['manifest-worker.js', 'service-worker.js'],
@@ -931,7 +975,7 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js'],
+        assets: ['index.js', 'bundle-url.ts', 'bundle-url-common.ts'],
       },
       {
         assets: ['worker.js'],
@@ -1058,7 +1102,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: ['worker.js', 'worker-dep.js'],
@@ -1074,7 +1123,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['index.js', 'bundle-url.js', 'get-worker-url.js'],
+        assets: [
+          'index.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+        ],
       },
       {
         assets: ['worker.js'],
@@ -1216,7 +1270,8 @@ describe('atlaspack', function () {
         assets: [
           'index.js',
           'lodash.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'bundle-manifest.js',
           'esmodule-helpers.js',
@@ -1225,7 +1280,8 @@ describe('atlaspack', function () {
       {
         assets: [
           'worker-a.js',
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'bundle-manifest.js',
         ],
@@ -1272,11 +1328,16 @@ describe('atlaspack', function () {
             'get-worker-url.js',
             'lodash.js',
             'esmodule-helpers.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
           ],
         },
         {
-          assets: ['bundle-manifest.js', 'bundle-url.js'],
+          assets: [
+            'bundle-manifest.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
+          ],
         },
         {
           assets: ['worker.js', 'lodash.js', 'esmodule-helpers.js'],
@@ -1338,7 +1399,8 @@ describe('atlaspack', function () {
         {
           assets: [
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'get-worker-url.js',
             'index.js',
@@ -1349,7 +1411,8 @@ describe('atlaspack', function () {
         {
           assets: [
             'bundle-manifest.js',
-            'bundle-url.js',
+            'bundle-url.ts',
+            'bundle-url-common.ts',
             'cacheLoader.js',
             'js-loader.js',
             'large.js',
@@ -1391,11 +1454,17 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'index.js',
-        assets: ['bundle-url.js', 'get-worker-url.js', 'index.js'],
+        assets: [
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'get-worker-url.js',
+          'index.js',
+        ],
       },
       {
         assets: [
-          'bundle-url.js',
+          'bundle-url.ts',
+          'bundle-url-common.ts',
           'get-worker-url.js',
           'worker1.js',
           'worker2.js',

--- a/packages/core/integration-tests/test/worklets.js
+++ b/packages/core/integration-tests/test/worklets.js
@@ -51,7 +51,7 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'url-worklet.js',
-        assets: ['bundle-url.js', 'url-worklet.js'],
+        assets: ['bundle-url.ts', 'bundle-url-common.ts', 'url-worklet.js'],
       },
       {
         type: 'js',
@@ -97,7 +97,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'pipeline.js',
-        assets: ['bundle-url.js', 'pipeline.js', 'bundle-manifest.js'],
+        assets: [
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'pipeline.js',
+          'bundle-manifest.js',
+        ],
       },
       {
         type: 'js',
@@ -138,7 +143,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'url.js',
-        assets: ['bundle-url.js', 'esmodule-helpers.js', 'url.js'],
+        assets: [
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'esmodule-helpers.js',
+          'url.js',
+        ],
       },
       {
         type: 'js',
@@ -236,7 +246,12 @@ describe('atlaspack', function () {
     assertBundles(b, [
       {
         name: 'worklet-pipeline.js',
-        assets: ['bundle-url.js', 'bundle-manifest.js', 'worklet-pipeline.js'],
+        assets: [
+          'bundle-url.ts',
+          'bundle-url-common.ts',
+          'bundle-manifest.js',
+          'worklet-pipeline.js',
+        ],
       },
       {
         type: 'js',

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -594,16 +594,16 @@ export function assertBundles(
     'expected number of bundles mismatched',
   );
 
-  for (let bundle of expectedBundles) {
-    let name = bundle.name;
-    let found = actualBundles.some((b) => {
-      if (name != null && b.name != null) {
+  for (let expectedBundle of expectedBundles) {
+    let name = expectedBundle.name;
+    let found = actualBundles.some((actualBundle) => {
+      if (name != null && actualBundle.name != null) {
         if (typeof name === 'string') {
-          if (name !== b.name) {
+          if (name !== actualBundle.name) {
             return false;
           }
         } else if (name instanceof RegExp) {
-          if (!name.test(b.name)) {
+          if (!name.test(actualBundle.name)) {
             return false;
           }
         } else {
@@ -612,14 +612,17 @@ export function assertBundles(
         }
       }
 
-      if (bundle.type != null && bundle.type !== b.type) {
+      if (
+        expectedBundle.type != null &&
+        expectedBundle.type !== actualBundle.type
+      ) {
         return false;
       }
 
       return (
-        bundle.assets &&
-        bundle.assets.length === b.assets.length &&
-        bundle.assets.every((a, i) => a === b.assets[i])
+        expectedBundle.assets &&
+        expectedBundle.assets.length === actualBundle.assets.length &&
+        expectedBundle.assets.every((a, i) => a === actualBundle.assets[i])
       );
     });
 
@@ -627,7 +630,7 @@ export function assertBundles(
       // $FlowFixMe[incompatible-call]
       assert.fail(
         `Could not find expected bundle: \n\n${util.inspect(
-          bundle,
+          expectedBundle,
         )} \n\nActual bundles: \n\n${util.inspect(actualBundles)}`,
       );
     }

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -536,7 +536,6 @@ export function expectBundles(
   expect(bundleData).toEqual(expectedBundles);
 }
 
-const esmoduleHelpersName = 'esmodule-helpers.js';
 export function assertBundles(
   bundleGraph: BundleGraph<PackagedBundle>,
   expectedBundles: Array<{|
@@ -620,21 +619,10 @@ export function assertBundles(
         return false;
       }
 
-      // If we aren't explicitly expecting esmodule-helpers, then ignore it
-      let assetsToCompare = actualBundle.assets;
-      if (
-        expectedBundle.assets.indexOf(esmoduleHelpersName) === -1 &&
-        actualBundle.assets.indexOf(esmoduleHelpersName) !== -1
-      ) {
-        assetsToCompare = actualBundle.assets.filter(
-          (a) => a !== 'esmodule-helpers.js',
-        );
-      }
-
       return (
         expectedBundle.assets &&
-        expectedBundle.assets.length === assetsToCompare.length &&
-        expectedBundle.assets.every((a, i) => a === assetsToCompare[i])
+        expectedBundle.assets.length === actualBundle.assets.length &&
+        expectedBundle.assets.every((a, i) => a === actualBundle.assets[i])
       );
     });
 

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -536,6 +536,7 @@ export function expectBundles(
   expect(bundleData).toEqual(expectedBundles);
 }
 
+const esmoduleHelpersName = 'esmodule-helpers.js';
 export function assertBundles(
   bundleGraph: BundleGraph<PackagedBundle>,
   expectedBundles: Array<{|
@@ -619,10 +620,21 @@ export function assertBundles(
         return false;
       }
 
+      // If we aren't explicitly expecting esmodule-helpers, then ignore it
+      let assetsToCompare = actualBundle.assets;
+      if (
+        expectedBundle.assets.indexOf(esmoduleHelpersName) === -1 &&
+        actualBundle.assets.indexOf(esmoduleHelpersName) !== -1
+      ) {
+        assetsToCompare = actualBundle.assets.filter(
+          (a) => a !== 'esmodule-helpers.js',
+        );
+      }
+
       return (
         expectedBundle.assets &&
-        expectedBundle.assets.length === actualBundle.assets.length &&
-        expectedBundle.assets.every((a, i) => a === actualBundle.assets[i])
+        expectedBundle.assets.length === assetsToCompare.length &&
+        expectedBundle.assets.every((a, i) => a === assetsToCompare[i])
       );
     });
 

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -74,6 +74,10 @@ let bundleDependencies = new WeakMap<
 
 type JSRuntimeConfig = {|
   splitManifestThreshold: number,
+  domainSharding?: {|
+    maxShards: number,
+    cookieName: string,
+  |},
 |};
 
 let defaultConfig: JSRuntimeConfig = {
@@ -85,6 +89,19 @@ const CONFIG_SCHEMA: SchemaEntity = {
   properties: {
     splitManifestThreshold: {
       type: 'number',
+    },
+    domainSharding: {
+      type: 'object',
+      properties: {
+        maxShards: {
+          type: 'number',
+        },
+        cookieName: {
+          type: 'string',
+        },
+      },
+      additionalProperties: false,
+      required: ['maxShards', 'cookieName'],
     },
   },
   additionalProperties: false,

--- a/packages/runtimes/js/src/helpers/bundle-url-common.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-common.ts
@@ -1,0 +1,4 @@
+// Get the URL without the filename (last / segment)
+export function getBaseURL(url: string) {
+  return url.slice(0, url.lastIndexOf('/')) + '/';
+}

--- a/packages/runtimes/js/src/helpers/bundle-url-common.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-common.ts
@@ -2,3 +2,6 @@
 export function getBaseURL(url: string) {
   return url.slice(0, url.lastIndexOf('/')) + '/';
 }
+
+export const stackTraceUrlRegexp =
+  /(https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/[^)\n]+/g;

--- a/packages/runtimes/js/src/helpers/bundle-url-common.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-common.ts
@@ -1,7 +1,10 @@
 // Get the URL without the filename (last / segment)
-export function getBaseURL(url: string) {
+function getBaseURL(url: string) {
   return url.slice(0, url.lastIndexOf('/')) + '/';
 }
 
-export const stackTraceUrlRegexp =
+const stackTraceUrlRegexp =
   /(https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/[^)\n]+/g;
+
+exports.getBaseURL = getBaseURL;
+exports.stackTraceUrlRegexp = stackTraceUrlRegexp;

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -1,4 +1,8 @@
-import {getBaseURL} from './bundle-url-common';
+import {
+  getBaseURL,
+  stackTraceUrlRegexp,
+  stackTraceUrlRegexp,
+} from './bundle-url-common';
 
 const bundleURL: Record<string, string> = {};
 
@@ -18,9 +22,7 @@ export function getShardedBundleURL(
   try {
     throw inputError ?? new Error();
   } catch (err) {
-    var matches = ('' + err.stack).match(
-      /(https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/[^)\n]+/g,
-    );
+    var matches = ('' + err.stack).match(stackTraceUrlRegexp);
 
     if (!matches) {
       return '/';

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -1,8 +1,8 @@
-import {getBaseURL, stackTraceUrlRegexp} from './bundle-url-common';
+const {getBaseURL, stackTraceUrlRegexp} = require('./bundle-url-common');
 
 const bundleURL: Record<string, string> = {};
 
-export function getShardedBundleURL(
+function getShardedBundleURL(
   bundleName: string,
   cookieName: string,
   cookieString: string,
@@ -91,3 +91,5 @@ function removeTrailingShard(subdomain: string) {
   const shardIdx = subdomain.lastIndexOf('-');
   return subdomain.slice(0, shardIdx);
 }
+
+exports.getShardedBundleURL = getShardedBundleURL;

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -1,3 +1,5 @@
+import {getBaseURL} from './bundle-url-common';
+
 const bundleURL: Record<string, string> = {};
 
 export function getShardedBundleURL(
@@ -90,13 +92,4 @@ function removeTrailingShard(subdomain: string) {
 
   const shardIdx = subdomain.lastIndexOf('-');
   return subdomain.slice(0, shardIdx);
-}
-
-// Get the URL without the filename (last / segment)
-export function getBaseURL(url: string) {
-  return url.slice(0, url.lastIndexOf('/')) + '/';
-}
-
-export function getOrigin(url: string) {
-  return new URL(url).origin;
 }

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -1,8 +1,4 @@
-import {
-  getBaseURL,
-  stackTraceUrlRegexp,
-  stackTraceUrlRegexp,
-} from './bundle-url-common';
+import {getBaseURL, stackTraceUrlRegexp} from './bundle-url-common';
 
 const bundleURL: Record<string, string> = {};
 

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -3,13 +3,13 @@ import {getBaseURL} from './bundle-url-common';
 const bundleURL: Record<string, string> = {};
 
 export function getShardedBundleURL(
-  bundleId: string,
+  bundleName: string,
   cookieName: string,
   cookieString: string,
   maxShards: number,
   inputError?: string,
 ): string {
-  let value = bundleURL[bundleId];
+  let value = bundleURL[bundleName];
 
   if (value) {
     return value;
@@ -36,7 +36,7 @@ export function getShardedBundleURL(
       return baseUrl;
     }
 
-    const shardNumber = getDomainShardIndex(bundleId, maxShards);
+    const shardNumber = getDomainShardIndex(bundleName, maxShards);
     const url = new URL(baseUrl);
 
     const shardedDomain = getShardedDomain(url.hostname, shardNumber);
@@ -44,7 +44,7 @@ export function getShardedBundleURL(
 
     value = url.toString();
 
-    bundleURL[bundleId] = value;
+    bundleURL[bundleName] = value;
     return value;
   }
 }

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -1,0 +1,102 @@
+const bundleURL: Record<string, string> = {};
+
+export function getShardedBundleURL(
+  bundleId: string,
+  cookieName: string,
+  cookieString: string,
+  maxShards: number,
+  inputError?: string,
+): string {
+  let value = bundleURL[bundleId];
+
+  if (value) {
+    return value;
+  }
+
+  try {
+    throw inputError ?? new Error();
+  } catch (err) {
+    var matches = ('' + err.stack).match(
+      /(https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/[^)\n]+/g,
+    );
+
+    if (!matches) {
+      return '/';
+    }
+
+    // The first stack frame will be this function.
+    // Use the 2nd one, which will be a runtime in the original bundle.
+    const stackUrl = matches[1];
+    const baseUrl = getBaseURL(stackUrl);
+
+    // If the cookie doesn't exist then we don't need to shard
+    if (cookieString.indexOf(cookieName) === -1) {
+      return baseUrl;
+    }
+
+    const shardNumber = getDomainShardIndex(bundleId, maxShards);
+    const url = new URL(baseUrl);
+
+    const shardedDomain = getShardedDomain(url.hostname, shardNumber);
+    url.hostname = shardedDomain;
+
+    value = url.toString();
+
+    bundleURL[bundleId] = value;
+    return value;
+  }
+}
+
+function getDomainShardIndex(str: string, maxShards: number) {
+  let shard = str.split('').reduce((a, b) => {
+    const n = (a << maxShards) - a + b.charCodeAt(0);
+
+    // The value returned by << is 64 bit, the & operator coerces to 32,
+    // prevents overflow as we iterate.
+    return n & n;
+  }, 0);
+
+  shard = shard % maxShards;
+
+  // Make number positive
+  if (shard < 0) {
+    shard += maxShards;
+  }
+
+  return shard;
+}
+
+function getShardedDomain(domain: string, shard: number) {
+  let i = domain.indexOf('.');
+
+  // Domains like localhost have no . separators
+  if (i === -1) {
+    return `${removeTrailingShard(domain)}-${shard}`;
+  }
+
+  // If this domain already has a shard number in it, strip it out before adding
+  // the new one
+  const firstSubdomain = removeTrailingShard(domain.slice(0, i));
+
+  return `${firstSubdomain}-${shard}${domain.slice(i)}`;
+}
+
+const trailingShardRegex = /-\d+$/;
+
+function removeTrailingShard(subdomain: string) {
+  if (!trailingShardRegex.test(subdomain)) {
+    return subdomain;
+  }
+
+  const shardIdx = subdomain.lastIndexOf('-');
+  return subdomain.slice(0, shardIdx);
+}
+
+// Get the URL without the filename (last / segment)
+export function getBaseURL(url: string) {
+  return url.slice(0, url.lastIndexOf('/')) + '/';
+}
+
+export function getOrigin(url: string) {
+  return new URL(url).origin;
+}

--- a/packages/runtimes/js/src/helpers/bundle-url.js
+++ b/packages/runtimes/js/src/helpers/bundle-url.js
@@ -35,15 +35,8 @@ function getBaseURL(url) {
   );
 }
 
-// TODO: Replace uses with `new URL(url).origin` when ie11 is no longer supported.
 function getOrigin(url) {
-  let matches = ('' + url).match(
-    /(https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/[^/]+/,
-  );
-  if (!matches) {
-    throw new Error('Origin not found');
-  }
-  return matches[0];
+  return new URL(url).origin;
 }
 
 exports.getBundleURL = getBundleURLCached;

--- a/packages/runtimes/js/src/helpers/bundle-url.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url.ts
@@ -1,6 +1,10 @@
-var bundleURL = {};
-function getBundleURLCached(id) {
-  var value = bundleURL[id];
+import {getBaseURL, getOrigin} from './bundle-url-common';
+
+const bundleURL = {};
+
+function getBundleURLCached(id: string) {
+  let value = bundleURL[id];
+
   if (!value) {
     value = getBundleURL();
     bundleURL[id] = value;
@@ -26,19 +30,8 @@ function getBundleURL() {
   return '/';
 }
 
-function getBaseURL(url) {
-  return (
-    ('' + url).replace(
-      /^((?:https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/.+)\/[^/]+$/,
-      '$1',
-    ) + '/'
-  );
-}
-
-function getOrigin(url) {
+export function getOrigin(url: string) {
   return new URL(url).origin;
 }
 
-exports.getBundleURL = getBundleURLCached;
-exports.getBaseURL = getBaseURL;
-exports.getOrigin = getOrigin;
+export {getBundleURLCached as getBundleURL};

--- a/packages/runtimes/js/src/helpers/bundle-url.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url.ts
@@ -1,4 +1,4 @@
-import {getBaseURL, getOrigin} from './bundle-url-common';
+import {getBaseURL, getOrigin, stackTraceUrlRegexp} from './bundle-url-common';
 
 const bundleURL = {};
 
@@ -17,9 +17,7 @@ function getBundleURL() {
   try {
     throw new Error();
   } catch (err) {
-    var matches = ('' + err.stack).match(
-      /(https?|file|ftp|(chrome|moz|safari-web)-extension):\/\/[^)\n]+/g,
-    );
+    var matches = ('' + err.stack).match(stackTraceUrlRegexp);
     if (matches) {
       // The first two stack frames will be this function and getBundleURLCached.
       // Use the 3rd one, which will be a runtime in the original bundle.

--- a/packages/runtimes/js/src/helpers/bundle-url.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url.ts
@@ -1,4 +1,4 @@
-import {getBaseURL, stackTraceUrlRegexp} from './bundle-url-common';
+const {getBaseURL, stackTraceUrlRegexp} = require('./bundle-url-common');
 
 const bundleURL = {};
 
@@ -28,8 +28,9 @@ function getBundleURL() {
   return '/';
 }
 
-export function getOrigin(url: string) {
+function getOrigin(url: string) {
   return new URL(url).origin;
 }
 
-export {getBundleURLCached as getBundleURL};
+exports.getOrigin = getOrigin;
+exports.getBundleURL = getBundleURLCached;

--- a/packages/runtimes/js/src/helpers/bundle-url.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url.ts
@@ -1,4 +1,4 @@
-import {getBaseURL, getOrigin, stackTraceUrlRegexp} from './bundle-url-common';
+import {getBaseURL, stackTraceUrlRegexp} from './bundle-url-common';
 
 const bundleURL = {};
 

--- a/packages/runtimes/js/test/bundle-url-common.test.js
+++ b/packages/runtimes/js/test/bundle-url-common.test.js
@@ -2,7 +2,7 @@ import assert from 'assert';
 
 import {getBaseURL} from '../src/helpers/bundle-url-common';
 
-describe.only('getBaseUrl', () => {
+describe('getBaseUrl', () => {
   it('should return the URL with the filename removed', () => {
     const testUrl =
       'https://bundle-shard-3.assets.example.com/assets/testBundle.123abc.js';

--- a/packages/runtimes/js/test/bundle-url-common.test.js
+++ b/packages/runtimes/js/test/bundle-url-common.test.js
@@ -1,0 +1,27 @@
+import assert from 'assert';
+
+import {getBaseURL} from '../src/helpers/bundle-url-common';
+
+describe.only('getBaseUrl', () => {
+  it('should return the URL with the filename removed', () => {
+    const testUrl =
+      'https://bundle-shard-3.assets.example.com/assets/testBundle.123abc.js';
+
+    assert.equal(
+      getBaseURL(testUrl),
+      'https://bundle-shard-3.assets.example.com/assets/',
+    );
+  });
+
+  it('should handle domains with no .', () => {
+    const testUrl = 'http://localhost/assets/testBundle.123abc.js';
+
+    assert.equal(getBaseURL(testUrl), 'http://localhost/assets/');
+  });
+
+  it('should handle domains with ports', () => {
+    const testUrl = 'http://localhost:8081/assets/testBundle.123abc.js';
+
+    assert.equal(getBaseURL(testUrl), 'http://localhost:8081/assets/');
+  });
+});

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -8,21 +8,20 @@ import {
 const testingCookieName = 'DOMAIN_SHARDING_TEST';
 
 const createErrorStack = (url) => {
-  // This error stack is copied from a local dev
+  // This error stack is copied from a local dev, with a bunch
+  // of lines trimmed off the end
   return `
 Error
-    at getShardedBundleURL (http://localhost:8081/main-entry-bundle.1a2fa8b7.js:13663:29)
-    at Object.getShardedBundleURLCached [as getShardedBundleURL] (http://localhost:8081/main-entry-bundle.1a2fa8b7.js:13639:17)
-    at jrxWb.d7fe7af8a40b5d68 (${url}?1733635254967:695:74)
-    at newRequire (http://localhost-4:8081/Heartbeat.bc74c821.js?1733635254967:71:24)
-    at localRequire (http://localhost-4:8081/Heartbeat.bc74c821.js?1733635254967:84:35)
-    at loader (http://localhost-4:8081/Heartbeat.bc74c821.js?1733635254967:691:29)
-    at runLoader (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:56535:20)
-    at Object.run (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:56211:28)
-    at TaskManager.<anonymous> (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:56132:33)
-    at invokeFunc (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:53665:23)
-    at trailingEdge (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:53697:42)
-    at timerExpired (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:53689:40)
+    at Object.getShardedBundleURL (http://localhost:8081/main-bundle.1a2fa8b7.js:15688:29)
+    at a7u9v.6d3ceb6ac67fea50 (${url}.1a2fa8b7.js:361466:46)
+    at newRequire (http://localhost:8081/main-bundle.1a2fa8b7.js:71:24)
+    at localRequire (http://localhost:8081/main-bundle.1a2fa8b7.js:84:35)
+    at 7H8wc.react-intl-next (http://localhost:8081/main-bundle.1a2fa8b7.js:279746:28)
+    at newRequire (http://localhost:8081/main-bundle.1a2fa8b7.js:71:24)
+    at localRequire (http://localhost:8081/main-bundle.1a2fa8b7.js:84:35)
+    at 1nL5S../manifest (http://localhost:8081/main-bundle.1a2fa8b7.js:279714:17)
+    at newRequire (http://localhost:8081/main-bundle.1a2fa8b7.js:71:24)
+    at localRequire (http://localhost:8081/main-bundle.1a2fa8b7.js:84:35)
 `.trim();
 };
 

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -9,7 +9,7 @@ const testingCookieName = 'DOMAIN_SHARDING_TEST';
 
 const createErrorStack = (url) => {
   // This error stack is copied from a local dev, with a bunch
-  // of lines trimmed off the end
+  // of lines trimmed off the end so it's not unnecessarily long
   return `
 Error
     at Object.getShardedBundleURL (http://localhost:8081/main-bundle.1a2fa8b7.js:15688:29)
@@ -80,13 +80,13 @@ describe.only('bundle-url-shards helper', () => {
     it('should handle domains with no .', () => {
       const testUrl = 'http://localhost/assets/testBundle.123abc.js';
 
-      assert.equal(getBaseURL(testUrl), 'http://localhost-1/assets/');
+      assert.equal(getBaseURL(testUrl), 'http://localhost/assets/');
     });
 
     it('should handle domains with ports', () => {
       const testUrl = 'http://localhost:8081/assets/testBundle.123abc.js';
 
-      assert.equal(getBaseURL(testUrl), 'http://localhost-1:8081/assets/');
+      assert.equal(getBaseURL(testUrl), 'http://localhost:8081/assets/');
     });
   });
 });

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -1,3 +1,5 @@
+import assert from 'assert';
+
 import {
   getShardedBundleURL,
   getBaseURL,
@@ -5,57 +7,87 @@ import {
 
 const testingCookieName = 'DOMAIN_SHARDING_TEST';
 
-describe('getShardedBundleURL', () => {
-  it('should shard a URL if the cookie is present', () => {
-    const testBundle = 'TestBundle.123abc.js';
+const createErrorStack = (url) => {
+  // This error stack is copied from a local dev
+  return `
+Error
+    at getShardedBundleURL (http://localhost:8081/main-entry-bundle.1a2fa8b7.js:13663:29)
+    at Object.getShardedBundleURLCached [as getShardedBundleURL] (http://localhost:8081/main-entry-bundle.1a2fa8b7.js:13639:17)
+    at jrxWb.d7fe7af8a40b5d68 (${url}?1733635254967:695:74)
+    at newRequire (http://localhost-4:8081/Heartbeat.bc74c821.js?1733635254967:71:24)
+    at localRequire (http://localhost-4:8081/Heartbeat.bc74c821.js?1733635254967:84:35)
+    at loader (http://localhost-4:8081/Heartbeat.bc74c821.js?1733635254967:691:29)
+    at runLoader (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:56535:20)
+    at Object.run (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:56211:28)
+    at TaskManager.<anonymous> (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:56132:33)
+    at invokeFunc (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:53665:23)
+    at trailingEdge (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:53697:42)
+    at timerExpired (http://localhost:8081/dashboard-spa-container-jquery3.40388a2a.js:53689:40)
+`.trim();
+};
 
-    // TODO: mock the error stacktrace somehow
+describe.only('bundle-url-shards helper', () => {
+  describe('getShardedBundleURL', () => {
+    it('should shard a URL if the cookie is present', () => {
+      const testBundle = 'test-bundle.123abc.js';
 
-    const result = getShardedBundleURL(
-      testBundle,
-      testingCookieName,
-      `${testingCookieName}=1`,
-      5,
-    );
+      const err = new Error();
+      err.stack = createErrorStack(
+        'https://bundle-shard.assets.example.com/assets/ParentBundle.cba321.js',
+      );
 
-    expect(result).toBe('https://bundle-shard-3.assets.example.com');
+      const result = getShardedBundleURL(
+        testBundle,
+        testingCookieName,
+        `${testingCookieName}=1`,
+        5,
+        err,
+      );
+
+      assert.equal(result, 'https://bundle-shard-0.assets.example.com/assets/');
+    });
+
+    it('should re-shard a domain that has already been sharded', () => {
+      const testBundle = 'TestBundle.1a2b3c.js';
+
+      const err = new Error();
+      err.stack = createErrorStack(
+        'https://bundle-shard-1.assets.example.com/assets/ParentBundle.cba321.js',
+      );
+
+      const result = getShardedBundleURL(
+        testBundle,
+        testingCookieName,
+        `${testingCookieName}=1`,
+        5,
+        err,
+      );
+
+      assert.equal(result, 'https://bundle-shard-4.assets.example.com/assets/');
+    });
   });
 
-  it('should re-shard a domain that has already been sharded', () => {
-    const testBundle = 'TestBundle.123abc.js';
+  describe('getBaseUrl', () => {
+    it('should return the URL with the filename removed', () => {
+      const testUrl =
+        'https://bundle-shard-3.assets.example.com/assets/testBundle.123abc.js';
 
-    // TODO: mock the error stacktrace somehow
+      assert.equal(
+        getBaseURL(testUrl),
+        'https://bundle-shard-3.assets.example.com/assets/',
+      );
+    });
 
-    const result = getShardedBundleURL(
-      testBundle,
-      testingCookieName,
-      `${testingCookieName}=1`,
-      5,
-    );
+    it('should handle domains with no .', () => {
+      const testUrl = 'http://localhost/assets/testBundle.123abc.js';
 
-    expect(result).toBe('https://bundle-shard-3.assets.example.com');
-  });
-});
+      assert.equal(getBaseURL(testUrl), 'http://localhost-1/assets/');
+    });
 
-describe('getBaseUrl', () => {
-  it('should return the URL with the filename removed', () => {
-    const testUrl =
-      'https://bundle-shard-3.assets.example.com/assets/testBundle.123abc.js';
+    it('should handle domains with ports', () => {
+      const testUrl = 'http://localhost:8081/assets/testBundle.123abc.js';
 
-    expect(getBaseURL(testUrl)).toBe(
-      'https://bundle-shard-3.assets.example.com/assets/',
-    );
-  });
-
-  it('should handle domains with no .', () => {
-    const testUrl = 'http://localhost/assets/testBundle.123abc.js';
-
-    expect(getBaseURL(testUrl)).toBe('http://localhost/assets/');
-  });
-
-  it('should handle domains with ports', () => {
-    const testUrl = 'http://localhost:8081/assets/testBundle.123abc.js';
-
-    expect(getBaseURL(testUrl)).toBe('http://localhost:8081/assets/');
+      assert.equal(getBaseURL(testUrl), 'http://localhost-1:8081/assets/');
+    });
   });
 });

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -64,6 +64,28 @@ describe.only('bundle-url-shards helper', () => {
 
       assert.equal(result, 'https://bundle-shard-4.assets.example.com/assets/');
     });
+
+    it('should not add a shard if the cookie is not present', () => {
+      const testBundle = 'UnshardedBundle.9z8x7y.js';
+
+      const err = new Error();
+      err.stack = createErrorStack(
+        'https://bundle-unsharded.assets.example.com/assets/ParentBundle.cba321.js',
+      );
+
+      const result = getShardedBundleURL(
+        testBundle,
+        testingCookieName,
+        `some.other.cookie=1`,
+        5,
+        err,
+      );
+
+      assert.equal(
+        result,
+        'https://bundle-unsharded.assets.example.com/assets/',
+      );
+    });
   });
 
   describe('getBaseUrl', () => {

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -25,7 +25,7 @@ Error
 `.trim();
 };
 
-describe.only('bundle-url-shards helper', () => {
+describe('bundle-url-shards helper', () => {
   describe('getShardedBundleURL', () => {
     it('should shard a URL if the cookie is present', () => {
       const testBundle = 'test-bundle.123abc.js';

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -2,10 +2,7 @@ import assert from 'assert';
 
 import {fsFixture, overlayFS, bundle} from '@atlaspack/test-utils';
 
-import {
-  getShardedBundleURL,
-  getBaseURL,
-} from '../src/helpers/bundle-url-shards';
+import {getShardedBundleURL} from '../src/helpers/bundle-url-shards';
 
 const testingCookieName = 'DOMAIN_SHARDING_TEST';
 

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -1,0 +1,61 @@
+import {
+  getShardedBundleURL,
+  getBaseURL,
+} from '../src/helpers/bundle-url-shards';
+
+const testingCookieName = 'DOMAIN_SHARDING_TEST';
+
+describe('getShardedBundleURL', () => {
+  it('should shard a URL if the cookie is present', () => {
+    const testBundle = 'TestBundle.123abc.js';
+
+    // TODO: mock the error stacktrace somehow
+
+    const result = getShardedBundleURL(
+      testBundle,
+      testingCookieName,
+      `${testingCookieName}=1`,
+      5,
+    );
+
+    expect(result).toBe('https://bundle-shard-3.assets.example.com');
+  });
+
+  it('should re-shard a domain that has already been sharded', () => {
+    const testBundle = 'TestBundle.123abc.js';
+
+    // TODO: mock the error stacktrace somehow
+
+    const result = getShardedBundleURL(
+      testBundle,
+      testingCookieName,
+      `${testingCookieName}=1`,
+      5,
+    );
+
+    expect(result).toBe('https://bundle-shard-3.assets.example.com');
+  });
+});
+
+describe('getBaseUrl', () => {
+  it('should return the URL with the filename removed', () => {
+    const testUrl =
+      'https://bundle-shard-3.assets.example.com/assets/testBundle.123abc.js';
+
+    expect(getBaseURL(testUrl)).toBe(
+      'https://bundle-shard-3.assets.example.com/assets/',
+    );
+  });
+
+  it('should handle domains with no .', () => {
+    const testUrl = 'http://localhost/assets/testBundle.123abc.js';
+
+    expect(getBaseURL(testUrl)).toBe('http://localhost/assets/');
+  });
+
+  it('should handle domains with ports', () => {
+    const testUrl = 'http://localhost:8081/assets/testBundle.123abc.js';
+
+    expect(getBaseURL(testUrl)).toBe('http://localhost:8081/assets/');
+  });
+});


### PR DESCRIPTION
In order to support domain sharding for HTTP1.1 users, we need to apply shards in two places. Firstly, in the generated HTML, which is done at request time by the SSR server (as we need to know whether this is a 1.1 request or not). Secondly, when requesting bundles from within other bundles we need to shard those requests as well, and not just rely on the parent shard.

To support this, I've made some changes to the JS Runtime, adding in a sharded version of `helpers/bundle-url` which is activated if the domain sharding config is provided in a build.

```json
"@atlaspack/runtime-js": {
  "domainSharding": {
    "maxShards": 5,
    "cookieName": "should.shard.domains"
  }
}
```

`bundle-url-shards` started out as a copy of `bundle-url`, but has been refactored a bit to make the more complicated logic easier to work with. That number of functions also became a little tricky to track, so the file is now a TypeScript file which will be compiled in the client build.

There was a todo in here to migrate `getOrigin` to just using the URL constructor once we didn't need to support IE 11 anymore, which we don't, so I've made that change and brought it across to `bundle-url` also.

Lastly there are a bunch of tests to make sure the sharding logic does what it's meant to, and that the runtime generates the call with the right arguments.