### PR TITLE
[V3] Fix Asset.dependencies mapping

### DIFF
--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -140,8 +140,6 @@ function getAssetGraph(serializedGraph) {
     return envId;
   };
 
-  const dependencyMap = new Map();
-
   for (let node of serializedGraph.nodes) {
     if (node.type === 'root') {
       let index = graph.addNodeByContentKey('@@root', {
@@ -163,17 +161,13 @@ function getAssetGraph(serializedGraph) {
       let asset = node.value;
       let id = asset.id;
 
-      let deps = dependencyMap.get(id);
-      if (!deps) {
-        deps = new Map();
-        dependencyMap.set(id, deps);
-      }
-
       asset.committed = true;
       asset.contentKey = id;
-      asset.dependencies = deps;
       asset.env.id = getEnvId(asset.env);
       asset.mapKey = `map:${asset.id}`;
+
+      // This is populated later when we map the edges between assets and dependencies
+      asset.dependencies = new Map();
 
       // We need to add this property for source map handling, as some assets like runtimes
       // are processed after the Rust transformation and take the v2 code path
@@ -197,13 +191,6 @@ function getAssetGraph(serializedGraph) {
     } else if (node.type === 'dependency') {
       let id = node.value.id;
       let dependency = node.value.dependency;
-
-      let deps = dependencyMap.get(dependency.sourceAssetId);
-      if (!deps) {
-        deps = new Map();
-        dependencyMap.set(dependency.sourceAssetId, deps);
-      }
-      deps.set(id, dependency);
 
       dependency.id = id;
       dependency.env.id = getEnvId(dependency.env);
@@ -239,8 +226,9 @@ function getAssetGraph(serializedGraph) {
     let from = serializedGraph.edges[i];
     let to = serializedGraph.edges[i + 1];
     let fromNode = graph.getNode(from);
+    let toNode = graph.getNode(to);
+
     if (fromNode?.type === 'dependency') {
-      let toNode = graph.getNode(to);
       invariant(toNode?.type === 'asset');
 
       // For backwards compatibility, create asset group node if needed.
@@ -258,6 +246,9 @@ function getAssetGraph(serializedGraph) {
 
       graph.addEdge(from, index);
       graph.addEdge(index, to);
+    } else if (fromNode?.type === 'asset' && toNode?.type === 'dependency') {
+      fromNode.value.dependencies.set(toNode.value.id, toNode.value);
+      graph.addEdge(from, to);
     } else {
       graph.addEdge(from, to);
     }

--- a/packages/core/core/src/requests/AssetGraphRequestRust.js
+++ b/packages/core/core/src/requests/AssetGraphRequestRust.js
@@ -9,7 +9,7 @@ import AssetGraph, {nodeFromAssetGroup} from '../AssetGraph';
 import type {AtlaspackV3} from '../atlaspack-v3';
 import {requestTypes, type StaticRunOpts} from '../RequestTracker';
 import {propagateSymbols} from '../SymbolPropagation';
-import type {Environment} from '../types';
+import type {Environment, Asset} from '../types';
 
 import type {
   AssetGraphRequestInput,
@@ -78,7 +78,11 @@ export function createAssetGraphRequestRust(
   });
 }
 
-function getAssetGraph(serializedGraph) {
+// $FlowFixMe
+export function getAssetGraph(serializedGraph: any): {
+  assetGraph: AssetGraph,
+  changedAssets: Map<string, Asset>,
+} {
   let graph = new AssetGraph({
     _contentKeyToNodeId: new Map(),
     _nodeIdToContentKey: new Map(),
@@ -111,7 +115,6 @@ function getAssetGraph(serializedGraph) {
   }
 
   // See crates/atlaspack_core/src/types/environment.rs
-  let cachedAssets = new Map();
   let changedAssets = new Map();
   let entry = 0;
 
@@ -177,7 +180,6 @@ function getAssetGraph(serializedGraph) {
         asset.symbols = new Map(asset.symbols.map(mapSymbols));
       }
 
-      cachedAssets.set(id, asset.code);
       changedAssets.set(id, asset);
 
       graph.addNodeByContentKey(id, {
@@ -256,7 +258,6 @@ function getAssetGraph(serializedGraph) {
 
   return {
     assetGraph: graph,
-    cachedAssets,
     changedAssets,
   };
 }

--- a/packages/core/core/test/requests/AssetGraphRequestRust.test.js
+++ b/packages/core/core/test/requests/AssetGraphRequestRust.test.js
@@ -1,0 +1,410 @@
+import assert from 'assert';
+import {getAssetGraph} from '../../src/requests/AssetGraphRequestRust';
+
+describe('AssetGraphRequestRust -> getAssetGraph', function () {
+  it('should create a valid AssetGraph', () => {
+    const {assetGraph} = getAssetGraph(getSerializedGraph());
+
+    const indexAsset = assetGraph.getNodeByContentKey('79c128d4f549c408');
+    const libraryDep = assetGraph.getNodeByContentKey('cfe74f65a41af1a7');
+
+    assert(indexAsset?.type === 'asset');
+    assert(libraryDep?.type === 'dependency');
+
+    assert.equal(indexAsset.value.filePath, '/index.ts');
+    assert.equal(libraryDep.value.specifier, './library');
+    assert.deepEqual(
+      indexAsset.value.dependencies.get('cfe74f65a41af1a7')?.specifier,
+      './library',
+    );
+
+    const indexAssetNodeId =
+      assetGraph.getNodeIdByContentKey('79c128d4f549c408');
+    const libraryDepNodeId =
+      assetGraph.getNodeIdByContentKey('cfe74f65a41af1a7');
+    assert.deepEqual(assetGraph.getNodeIdsConnectedFrom(indexAssetNodeId), [
+      libraryDepNodeId,
+    ]);
+  });
+});
+
+function getSerializedGraph() {
+  return {
+    edges: [0, 1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6],
+    nodes: [
+      {
+        type: 'root',
+      },
+      {
+        type: 'dependency',
+        value: {
+          id: 'b01a088f112fa82f',
+          dependency: {
+            bundleBehavior: null,
+            env: {
+              context: 'browser',
+              engines: {
+                browsers: [
+                  'last 1 Chrome version',
+                  'last 1 Safari version',
+                  'last 1 Firefox version',
+                  'last 1 Edge version',
+                ],
+              },
+              includeNodeModules: true,
+              isLibrary: false,
+              loc: null,
+              outputFormat: 'global',
+              shouldScopeHoist: true,
+              shouldOptimize: false,
+              sourceMap: {},
+              sourceType: 'module',
+            },
+            loc: null,
+            meta: {},
+            pipeline: null,
+            priority: 0,
+            range: null,
+            resolveFrom: null,
+            sourceAssetId: null,
+            sourcePath: null,
+            specifier: '/index.html',
+            specifierType: 2,
+            symbols: null,
+            target: {
+              distDir: '/dist',
+              distEntry: null,
+              env: {
+                context: 'browser',
+                engines: {
+                  browsers: [
+                    'last 1 Chrome version',
+                    'last 1 Safari version',
+                    'last 1 Firefox version',
+                    'last 1 Edge version',
+                  ],
+                },
+                includeNodeModules: true,
+                isLibrary: false,
+                loc: null,
+                outputFormat: 'global',
+                shouldScopeHoist: true,
+                shouldOptimize: false,
+                sourceMap: {},
+                sourceType: 'module',
+              },
+              loc: null,
+              name: 'default',
+              publicUrl: '/',
+            },
+            isEntry: true,
+            isOptional: false,
+            needsStableName: true,
+            shouldWrap: false,
+            isEsm: false,
+            placeholder: null,
+          },
+        },
+        has_deferred: false,
+      },
+      {
+        type: 'asset',
+        value: {
+          id: 'e2056518260d7dc7',
+          bundleBehavior: 1,
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: [
+                'last 1 Chrome version',
+                'last 1 Safari version',
+                'last 1 Firefox version',
+                'last 1 Edge version',
+              ],
+            },
+            includeNodeModules: true,
+            isLibrary: false,
+            loc: null,
+            outputFormat: 'global',
+            shouldScopeHoist: true,
+            shouldOptimize: false,
+            sourceMap: {},
+            sourceType: 'module',
+          },
+          filePath: '/index.html',
+          type: 'html',
+          meta: {},
+          pipeline: null,
+          query: null,
+          stats: {
+            size: 93,
+            time: 2,
+          },
+          symbols: null,
+          sideEffects: true,
+          isBundleSplittable: true,
+          isSource: true,
+          hasCjsExports: false,
+          staticExports: false,
+          shouldWrap: false,
+          hasNodeReplacements: false,
+          isConstantModule: false,
+          conditions: [],
+          configPath: null,
+          configKeyPath: null,
+        },
+      },
+      {
+        type: 'dependency',
+        value: {
+          id: 'aece0f57a78d1ef8',
+          dependency: {
+            bundleBehavior: null,
+            env: {
+              context: 'browser',
+              engines: {
+                browsers: [
+                  'last 1 Chrome version',
+                  'last 1 Safari version',
+                  'last 1 Firefox version',
+                  'last 1 Edge version',
+                ],
+              },
+              includeNodeModules: true,
+              isLibrary: false,
+              loc: null,
+              outputFormat: 'esmodule',
+              shouldScopeHoist: true,
+              shouldOptimize: false,
+              sourceMap: {},
+              sourceType: 'module',
+            },
+            loc: null,
+            meta: {},
+            pipeline: null,
+            priority: 1,
+            range: null,
+            resolveFrom: null,
+            sourceAssetId: 'e2056518260d7dc7',
+            sourcePath: '/index.html',
+            specifier: './index.ts',
+            specifierType: 2,
+            sourceAssetType: 'html',
+            symbols: null,
+            target: null,
+            isEntry: false,
+            isOptional: false,
+            needsStableName: false,
+            shouldWrap: false,
+            isEsm: true,
+            placeholder: null,
+          },
+        },
+        has_deferred: false,
+      },
+      {
+        type: 'asset',
+        value: {
+          id: '79c128d4f549c408',
+          bundleBehavior: null,
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: [
+                'last 1 Chrome version',
+                'last 1 Safari version',
+                'last 1 Firefox version',
+                'last 1 Edge version',
+              ],
+            },
+            includeNodeModules: true,
+            isLibrary: false,
+            loc: null,
+            outputFormat: 'esmodule',
+            shouldScopeHoist: true,
+            shouldOptimize: false,
+            sourceMap: {},
+            sourceType: 'module',
+          },
+          filePath: '/index.ts',
+          type: 'js',
+          meta: {
+            hasCJSExports: false,
+            staticExports: true,
+            shouldWrap: false,
+            id: 'cc346b5b74d3d478',
+          },
+          pipeline: null,
+          query: null,
+          stats: {
+            size: 121,
+            time: 39,
+          },
+          symbols: [],
+          sideEffects: true,
+          isBundleSplittable: true,
+          isSource: true,
+          hasCjsExports: false,
+          staticExports: true,
+          shouldWrap: false,
+          hasNodeReplacements: false,
+          isConstantModule: false,
+          conditions: [],
+          configPath: null,
+          configKeyPath: null,
+        },
+      },
+      {
+        type: 'dependency',
+        value: {
+          id: 'cfe74f65a41af1a7',
+          dependency: {
+            bundleBehavior: null,
+            env: {
+              context: 'browser',
+              engines: {
+                browsers: [
+                  'last 1 Chrome version',
+                  'last 1 Safari version',
+                  'last 1 Firefox version',
+                  'last 1 Edge version',
+                ],
+              },
+              includeNodeModules: true,
+              isLibrary: false,
+              loc: null,
+              outputFormat: 'esmodule',
+              shouldScopeHoist: true,
+              shouldOptimize: false,
+              sourceMap: {},
+              sourceType: 'module',
+            },
+            loc: {
+              filePath: '/index.ts',
+              start: {
+                line: 1,
+                column: 21,
+              },
+              end: {
+                line: 1,
+                column: 32,
+              },
+            },
+            meta: {
+              kind: 'Import',
+            },
+            pipeline: null,
+            priority: 0,
+            range: null,
+            resolveFrom: null,
+            sourceAssetId: 'cc346b5b74d3d478',
+            sourcePath: '/index.ts',
+            specifier: './library',
+            specifierType: 0,
+            sourceAssetType: 'ts',
+            symbols: [
+              {
+                local:
+                  '$cc346b5b74d3d478$import$b83d1a328c413a1a$2e2bcd8739ae039',
+                exported: 'default',
+                loc: {
+                  filePath: '/index.ts',
+                  start: {
+                    line: 1,
+                    column: 8,
+                  },
+                  end: {
+                    line: 1,
+                    column: 15,
+                  },
+                },
+                isWeak: false,
+                isEsmExport: false,
+                selfReferenced: false,
+              },
+            ],
+            target: null,
+            isEntry: false,
+            isOptional: false,
+            needsStableName: false,
+            shouldWrap: false,
+            isEsm: true,
+            placeholder: null,
+          },
+        },
+        has_deferred: false,
+      },
+      {
+        type: 'asset',
+        value: {
+          id: '13fc7969eb974fe3',
+          bundleBehavior: null,
+          env: {
+            context: 'browser',
+            engines: {
+              browsers: [
+                'last 1 Chrome version',
+                'last 1 Safari version',
+                'last 1 Firefox version',
+                'last 1 Edge version',
+              ],
+            },
+            includeNodeModules: true,
+            isLibrary: false,
+            loc: null,
+            outputFormat: 'esmodule',
+            shouldScopeHoist: true,
+            shouldOptimize: false,
+            sourceMap: {},
+            sourceType: 'module',
+          },
+          filePath: '/library.ts',
+          type: 'js',
+          meta: {
+            hasCJSExports: false,
+            staticExports: true,
+            shouldWrap: false,
+            id: '579fff58dabc69a5',
+          },
+          pipeline: null,
+          query: null,
+          stats: {
+            size: 58,
+            time: 1,
+          },
+          symbols: [
+            {
+              local: '$579fff58dabc69a5$export$2e2bcd8739ae039',
+              exported: 'default',
+              loc: {
+                filePath: '/library.ts',
+                start: {
+                  line: 1,
+                  column: 1,
+                },
+                end: {
+                  line: 1,
+                  column: 26,
+                },
+              },
+              isWeak: false,
+              isEsmExport: true,
+              selfReferenced: false,
+            },
+          ],
+          sideEffects: true,
+          isBundleSplittable: true,
+          isSource: true,
+          hasCjsExports: false,
+          staticExports: true,
+          shouldWrap: false,
+          hasNodeReplacements: false,
+          isConstantModule: false,
+          conditions: [],
+          configPath: null,
+          configKeyPath: null,
+        },
+      },
+    ],
+  };
+}


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

In cases where an Assets type changed and therefore it's id, the Dependency.sourceAssetId property can become out of sync with the Asset. This causes an issue where some dependencies are missing when using `Asset.getDependenices()` in a reporter. 

This PR changes dependencies to instead use the edge data as the point of truth when mapping `Asset.dependencies` in `getAssetGraph`. 

## Checklist

- [x] Existing or new tests cover this change
