### PR TITLE
Mitigate missing dir race condition in conditional manifest reporter

### DIFF
--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -1,5 +1,5 @@
 // @flow strict-local
-import {relative, join} from 'path';
+import {relative, join, dirname} from 'path';
 import {Reporter} from '@atlaspack/plugin';
 import type {
   Async,
@@ -58,6 +58,8 @@ async function report({
         null,
         2,
       );
+
+      await options.outputFS.mkdirp(dirname(conditionalManifestFilename));
 
       await options.outputFS.writeFile(
         conditionalManifestFilename,


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Thanks @MonicaOlejniczak for figuring this one out!

Turns out in CI that we have a race condition for creating the manifest. While we'd expect the fragment directory has already been created, this seems to not be guaranteed in CI.

## Changes

Make sure the directory exists before writing to it

## Checklist

- [x] Existing or new tests cover this change
