### PR TITLE
WIP: Fixing types in integration tests

### DIFF
--- a/packages/core/integration-tests/test/bundle-text.js
+++ b/packages/core/integration-tests/test/bundle-text.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {
@@ -10,6 +11,7 @@ import {
   removeDistDirectory,
   run,
 } from '@atlaspack/test-utils';
+import type {InitialAtlaspackOptions} from '../../types/src';
 
 describe('bundle-text:', function () {
   beforeEach(async () => {
@@ -164,7 +166,7 @@ describe('bundle-text:', function () {
     describe(`when scope hoisting is ${
       scopeHoist ? 'enabled' : 'disabled'
     }`, () => {
-      let options = scopeHoist
+      let options: InitialAtlaspackOptions = scopeHoist
         ? {
             defaultTargetOptions: {
               isLibrary: true,
@@ -172,7 +174,7 @@ describe('bundle-text:', function () {
               shouldScopeHoist: true,
             },
           }
-        : {};
+        : Object.freeze({});
 
       it('can be used with an import that points to the same asset', async function () {
         await fsFixture(overlayFS, __dirname)`
@@ -201,7 +203,7 @@ describe('bundle-text:', function () {
             assets: [
               'index.js',
               'main.js',
-              !scopeHoist && 'esmodule-helpers.js',
+              !scopeHoist ? 'esmodule-helpers.js' : undefined,
             ].filter(Boolean),
           },
           {

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -954,15 +954,12 @@ describe('bundler', function () {
       .find(
         (bundle) => !bundle.getMainEntry() && bundle.name.includes('runtime'),
       );
+    if (aManifestBundle === undefined)
+      return assert(aManifestBundle !== undefined);
 
     let bBundles = b
       .getBundles()
       .filter((bundle) => /b\.HASH_REF/.test(bundle.name));
-
-    if (aManifestBundle === undefined) {
-      assert(aManifestBundle !== undefined);
-      return;
-    }
 
     let aBundleManifestAsset: Asset | void;
     aManifestBundle.traverseAssets((asset, _, {stop}) => {
@@ -1338,11 +1335,7 @@ describe('bundler', function () {
 
     // Asset should not be inlined
     const index = b.getBundles().find((b) => b.name.startsWith('index'));
-
-    if (index === undefined) {
-      assert(index !== undefined);
-      return;
-    }
+    if (index === undefined) return assert(index !== undefined);
 
     const contents = overlayFS.readFileSync(index.filePath, 'utf8');
     assert(

--- a/packages/core/integration-tests/test/compressors.js
+++ b/packages/core/integration-tests/test/compressors.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import zlib from 'zlib';

--- a/packages/core/integration-tests/test/config-merging.js
+++ b/packages/core/integration-tests/test/config-merging.js
@@ -1,3 +1,4 @@
+// @flow
 import {bundle, describe, it, run, outputFS} from '@atlaspack/test-utils';
 import assert from 'assert';
 import path from 'path';

--- a/packages/core/integration-tests/test/contentHashing.js
+++ b/packages/core/integration-tests/test/contentHashing.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -99,10 +100,12 @@ describe('content hashing', function () {
     async () => {
       let a = await _bundle(
         path.join(__dirname, 'integration/hash-distDir/a/index.html'),
+        // $FlowFixMe
         {sourceMaps: true},
       );
       let b = await _bundle(
         path.join(__dirname, 'integration/hash-distDir/b/index.html'),
+        // $FlowFixMe
         {sourceMaps: true},
       );
 
@@ -114,6 +117,10 @@ describe('content hashing', function () {
 
       let aJS = aBundles.find((bundle) => bundle.type === 'js');
       let bJS = bBundles.find((bundle) => bundle.type === 'js');
+
+      if (aJS === undefined) return assert(aJS !== undefined);
+      if (bJS === undefined) return assert(bJS !== undefined);
+
       assert(/index\.[a-f0-9]*\.js/.test(path.basename(aJS.filePath)));
       assert.equal(aJS.name, bJS.name);
     },

--- a/packages/core/integration-tests/test/css-modules.js
+++ b/packages/core/integration-tests/test/css-modules.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -67,11 +68,11 @@ describe('css modules', () => {
     assert(/[_0-9a-zA-Z]+_b-2/.test(output));
 
     let css = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     let includedRules = new Set();
-    postcss.parse(css).walkRules((rule) => {
+    postcss.parse(css, {}).walkRules((rule) => {
       includedRules.add(rule.selector);
     });
     assert(includedRules.has('.page'));
@@ -99,7 +100,7 @@ describe('css modules', () => {
     ]);
 
     let js = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'js').filePath,
+      b.getBundles().find((b) => b.type === 'js')?.filePath || '',
       'utf8',
     );
     assert(!js.includes('unused'));
@@ -108,11 +109,11 @@ describe('css modules', () => {
     assert(/[_0-9a-zA-Z]+_b-2/.test(output));
 
     let css = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     let includedRules = new Set();
-    postcss.parse(css).walkRules((rule) => {
+    postcss.parse(css, {}).walkRules((rule) => {
       includedRules.add(rule.selector);
     });
     assert.deepStrictEqual(
@@ -150,11 +151,11 @@ describe('css modules', () => {
     assert(/[_0-9a-zA-Z]+_b-2/.test(output));
 
     let css = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     let includedRules = new Set();
-    postcss.parse(css).walkRules((rule) => {
+    postcss.parse(css, {}).walkRules((rule) => {
       includedRules.add(rule.selector);
     });
     assert(includedRules.has('body'));
@@ -183,7 +184,7 @@ describe('css modules', () => {
     ]);
 
     let js = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'js').filePath,
+      b.getBundles().find((b) => b.type === 'js')?.filePath || '',
       'utf8',
     );
     assert(js.includes('unused'));
@@ -193,11 +194,11 @@ describe('css modules', () => {
     assert(/[_0-9a-zA-Z]+_unused/.test(output['unused']));
 
     let css = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     let includedRules = new Set();
-    postcss.parse(css).walkRules((rule) => {
+    postcss.parse(css, {}).walkRules((rule) => {
       includedRules.add(rule.selector);
     });
     assert.deepStrictEqual(
@@ -389,6 +390,7 @@ describe('css modules', () => {
   it.v2(
     'should throw an error when importing a missing class',
     async function () {
+      // $FlowFixMe
       await assert.rejects(
         () =>
           bundle(
@@ -681,7 +683,7 @@ describe('css modules', () => {
     assert.deepEqual(res, 'C-gzXq_foo');
 
     let contents = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     assert(contents.includes('.C-gzXq_foo'));
@@ -696,7 +698,7 @@ describe('css modules', () => {
     let res = await run(b);
     assert.deepEqual(res, 'C-gzXq_foo');
     let contents = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     assert(contents.includes('.C-gzXq_foo'));
@@ -714,7 +716,7 @@ describe('css modules', () => {
         {mode: 'production'},
       );
       let contents = await outputFS.readFile(
-        b.getBundles().find((b) => b.type === 'css').filePath,
+        b.getBundles().find((b) => b.type === 'css')?.filePath || '',
         'utf8',
       );
       assert.equal(
@@ -851,7 +853,7 @@ describe('css modules', () => {
       );
 
       let contents = await outputFS.readFile(
-        b.getBundles().find((b) => b.type === 'css').filePath,
+        b.getBundles().find((b) => b.type === 'css')?.filePath || '',
         'utf8',
       );
       assert(contents.includes('.foo'));

--- a/packages/core/integration-tests/test/data-url.js
+++ b/packages/core/integration-tests/test/data-url.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {

--- a/packages/core/integration-tests/test/encodedURI.js
+++ b/packages/core/integration-tests/test/encodedURI.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {bundle, describe, it, outputFS, distDir} from '@atlaspack/test-utils';

--- a/packages/core/integration-tests/test/feature-flags.js
+++ b/packages/core/integration-tests/test/feature-flags.js
@@ -1,6 +1,7 @@
+// @flow
 import assert from 'assert';
-import path from 'node:path';
-import {rimraf} from 'rimraf';
+import path from 'path';
+import rimraf from 'rimraf';
 import {
   bundle,
   describe,

--- a/packages/core/integration-tests/test/globals.js
+++ b/packages/core/integration-tests/test/globals.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 
@@ -56,6 +57,7 @@ describe('globals', function () {
     });
 
     it('when scope hoisting is disabled', async function () {
+      // $FlowFixMe "context" missing in InitialOptions
       let bundleGraph = await bundle(path.join(dir, 'index.js'), {
         defaultTargetOptions: {
           context: 'browser',
@@ -82,6 +84,7 @@ describe('globals', function () {
     });
 
     it.v2('when scope hoisting is enabled', async function () {
+      // $FlowFixMe "context" missing in InitialOptions
       let bundleGraph = await bundle(path.join(dir, 'index.js'), {
         defaultTargetOptions: {
           context: 'browser',

--- a/packages/core/integration-tests/test/glsl.js
+++ b/packages/core/integration-tests/test/glsl.js
@@ -1,4 +1,4 @@
-// flow
+// @flow
 import assert from 'assert';
 import path from 'path';
 import fs from 'fs';

--- a/packages/core/integration-tests/test/glsl.js
+++ b/packages/core/integration-tests/test/glsl.js
@@ -1,3 +1,4 @@
+// flow
 import assert from 'assert';
 import path from 'path';
 import fs from 'fs';

--- a/packages/core/integration-tests/test/graphql.js
+++ b/packages/core/integration-tests/test/graphql.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {bundle, describe, it, run} from '@atlaspack/test-utils';

--- a/packages/core/integration-tests/test/html.js
+++ b/packages/core/integration-tests/test/html.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {
   assertBundles,
@@ -95,7 +96,9 @@ describe('html', function () {
 
     let iconsBundle = b.getBundles().find((b) => b.name.startsWith('icons'));
     assert(
-      html.includes('/' + path.basename(iconsBundle.filePath) + '#icon-code'),
+      html.includes(
+        '/' + path.basename(iconsBundle?.filePath || '') + '#icon-code',
+      ),
     );
 
     let value = null;
@@ -121,7 +124,9 @@ describe('html', function () {
       },
     ]);
 
+    // $FlowFixMe
     assert(await outputFS.exists(path.join(distDir, 'a.html'), 'utf8'));
+    // $FlowFixMe
     assert(await outputFS.exists(path.join(distDir, 'b.html'), 'utf8'));
   });
 
@@ -461,6 +466,7 @@ describe('html', function () {
   it.skip('should insert sibling JS bundles for CSS files in the HEAD', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/html-css-js/index.html'),
+      // $FlowFixMe hmr missing from options
       {
         hmr: true,
       },
@@ -956,23 +962,25 @@ describe('html', function () {
       path.join(__dirname, '/integration/webmanifest/index.html'),
     );
 
-    assertBundles(b, {
-      name: 'index.html',
-      assets: ['index.html'],
-      childBundles: [
-        {
-          type: 'webmanifest',
-          assets: ['manifest.webmanifest'],
-          childBundles: [
-            {
-              type: 'txt',
-              assets: ['some.txt'],
-              childBundles: [],
-            },
-          ],
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html'],
+        childBundles: [
+          {
+            type: 'webmanifest',
+            assets: ['manifest.webmanifest'],
+            childBundles: [
+              {
+                type: 'txt',
+                assets: ['some.txt'],
+                childBundles: [],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
   });
 
   it.skip("should treat webmanifest as an entry module so it doesn't get content hashed", async function () {
@@ -980,16 +988,18 @@ describe('html', function () {
       path.join(__dirname, '/integration/html-manifest/index.html'),
     );
 
-    assertBundles(b, {
-      name: 'index.html',
-      assets: ['index.html'],
-      childBundles: [
-        {
-          type: 'webmanifest',
-          assets: ['manifest.webmanifest'],
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html'],
+        childBundles: [
+          {
+            type: 'webmanifest',
+            assets: ['manifest.webmanifest'],
+          },
+        ],
+      },
+    ]);
 
     const html = await outputFS.readFile(
       path.join(__dirname, '/dist/index.html'),
@@ -1212,7 +1222,7 @@ describe('html', function () {
     let bundles = b.getBundles();
 
     let html = await outputFS.readFile(
-      bundles.find((bundle) => bundle.type === 'html').filePath,
+      bundles.find((bundle) => bundle.type === 'html')?.filePath || '',
       'utf8',
     );
 
@@ -1412,7 +1422,7 @@ describe('html', function () {
   for (let scopeHoist of [false, true]) {
     it.v2(
       'should expose top level declarations globally in inline <script> tags with dependencies with scopeHoist = ' +
-        scopeHoist,
+        scopeHoist.toString(),
       async function () {
         let b = await bundle(
           path.join(
@@ -1633,6 +1643,7 @@ describe('html', function () {
     async function () {
       let b = await bundle(
         path.join(__dirname, '/integration/html-inline-js-module/index.html'),
+        // $FlowFixMe mode does not exist in InitialOptions
         {
           defaultTargetOptions: {
             mode: 'production',
@@ -1670,6 +1681,7 @@ describe('html', function () {
     async function () {
       let b = await bundle(
         path.join(__dirname, '/integration/html-js/index.html'),
+        // $FlowFixMe mode does not exist in InitialOptions
         {
           defaultTargetOptions: {
             mode: 'production',
@@ -1698,7 +1710,7 @@ describe('html', function () {
 
       let bundles = b.getBundles();
       let html = await outputFS.readFile(
-        bundles.find((b) => b.type === 'html').filePath,
+        bundles.find((b) => b.type === 'html')?.filePath || '',
         'utf8',
       );
       assert(html.includes('<script type="module" src='));
@@ -1707,14 +1719,14 @@ describe('html', function () {
       let js = await outputFS.readFile(
         bundles.find(
           (b) => b.type === 'js' && b.env.outputFormat === 'esmodule',
-        ).filePath,
+        )?.filePath || '',
         'utf8',
       );
       assert(/class \$[a-f0-9]+\$var\$Useless \{/.test(js));
 
       js = await outputFS.readFile(
         bundles.find((b) => b.type === 'js' && b.env.outputFormat === 'global')
-          .filePath,
+          ?.filePath || '',
         'utf8',
       );
       assert(!/class \$[a-f0-9]+\$var\$Useless \{/.test(js));
@@ -1748,6 +1760,7 @@ describe('html', function () {
   it('should not add a nomodule version when all browsers support esmodules', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/html-js/index.html'),
+      // $FlowFixMe mode does not exist in InitialOptions
       {
         defaultTargetOptions: {
           mode: 'production',
@@ -1999,6 +2012,7 @@ describe('html', function () {
     let regex = /<script (?:type="[^"]+" )?src="([^"]*)"><\/script>/g;
     let match;
     while ((match = regex.exec(html)) !== null) {
+      if (match === null) continue;
       insertedBundles.push(path.basename(match[1]));
     }
 
@@ -2061,6 +2075,7 @@ describe('html', function () {
     let regex = /<script (?:type="[^"]+" )?src="([^"]*)"><\/script>/g;
     let match;
     while ((match = regex.exec(html)) !== null) {
+      if (match === null) continue;
       insertedBundles.push(path.basename(match[1]));
     }
 
@@ -2136,11 +2151,14 @@ describe('html', function () {
         let regex = /<script ([^>]*)><\/script>/g;
         let match;
         while ((match = regex.exec(html)) !== null) {
+          if (match === null) continue;
           let attributes = new Map(
+            // $FlowFixMe
             match[1].split(' ').map((a) => a.split('=')),
           );
-          let url = attributes.get('src').replace(/"/g, '');
-          assert(url);
+          let url = attributes.get('src')?.replace(/"/g, '');
+          if (!url) return assert(url, 'Could not get src');
+
           if (attributes.get('type') === '"module"') {
             assert.strictEqual(attributes.size, 2);
             moduleScripts.push(path.basename(url));
@@ -2158,13 +2176,13 @@ describe('html', function () {
             b
               .getBundles()
               .find((b) => b.filePath.endsWith(scripts[0]))
-              .getMainEntry() == null,
+              ?.getMainEntry() == null,
           );
           assert(
             b
               .getBundles()
               .find((b) => b.filePath.endsWith(scripts[1]))
-              .getMainEntry(),
+              ?.getMainEntry(),
           );
         }
       }
@@ -2258,6 +2276,7 @@ describe('html', function () {
     });
 
     // could run in either order.
+    // $FlowFixMe
     assert(output.sort(), ['a', 'b', 'c']);
   });
 
@@ -2317,6 +2336,7 @@ describe('html', function () {
       });
 
       // could run in either order.
+      // $FlowFixMe
       assert(output.sort(), ['a', 'b', 'c']);
     },
   );
@@ -2436,7 +2456,9 @@ describe('html', function () {
     let regex = /<script (?:type="[^"]+" )?src="([^"]*)"><\/script>/g;
     let match;
     while ((match = regex.exec(html)) !== null) {
+      if (!match) continue;
       let bundle = bundles.find(
+        // $FlowFixMe still thinks "match" can be undefined
         (b) => path.basename(b.filePath) === path.basename(match[1]),
       );
 
@@ -2572,12 +2594,19 @@ describe('html', function () {
     ]);
 
     let htmlBundle = b.getBundles().find((b) => b.type === 'html');
+    if (!htmlBundle) return assert(false, 'No HTML Bundle');
+
     let htmlSiblings = b.getReferencedBundles(htmlBundle);
+    if (!htmlSiblings) return assert(false, 'No HTML siblings');
+
     assert.equal(htmlSiblings.length, 2);
     assert(htmlSiblings.some((b) => b.type === 'js'));
     assert(htmlSiblings.some((b) => b.type === 'css'));
 
-    let worker = b.getChildBundles(htmlSiblings.find((b) => b.type === 'js'));
+    let htmlSibling = htmlSiblings.find((b) => b.type === 'js');
+    if (!htmlSibling) return assert(false, 'No HTML siblings');
+
+    let worker = b.getChildBundles(htmlSibling);
     assert.equal(worker.length, 1);
     let workerSiblings = b.getReferencedBundles(worker[0]);
     assert.equal(workerSiblings.length, 0);
@@ -2647,6 +2676,7 @@ describe('html', function () {
 
       for (let htmlBundle of b.getBundles().filter((b) => b.type === 'html')) {
         let htmlSiblings = b
+          // $FlowFixMe bool is not compatible with object
           .getReferencedBundles(htmlBundle, true)
           .map((b) => b.type)
           .sort();
@@ -2772,10 +2802,11 @@ describe('html', function () {
 
     let bundles = b.getBundles();
     let cssBundle = path.basename(
-      bundles.find((bundle) => bundle.filePath.endsWith('.css')).filePath,
+      bundles.find((bundle) => bundle.filePath.endsWith('.css'))?.filePath ||
+        '',
     );
     let jsBundle = path.basename(
-      bundles.find((bundle) => bundle.filePath.endsWith('.js')).filePath,
+      bundles.find((bundle) => bundle.filePath.endsWith('.js'))?.filePath || '',
     );
 
     assert(
@@ -2889,7 +2920,7 @@ describe('html', function () {
     );
 
     let contents = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'html').filePath,
+      b.getBundles().find((b) => b.type === 'html')?.filePath || '',
       'utf8',
     );
     assert.equal(
@@ -2902,6 +2933,7 @@ describe('html', function () {
     let dir = path.join(__dirname, 'integration/invalid-bundler-config');
     let pkg = path.join(dir, 'package.json');
     let code = await inputFS.readFileSync(pkg, 'utf8');
+    // $FlowFixMe
     await assert.rejects(() => bundle(path.join(dir, 'index.html')), {
       name: 'BuildError',
       diagnostics: [
@@ -2976,6 +3008,7 @@ describe('html', function () {
 
     let youngerSibling; // bundle containing younger sibling, b.js
     let olderSibling; // bundle containing old sibling, a.js
+
     b.traverseBundles((bundle) => {
       bundle.traverseAssets((asset) => {
         if (asset.filePath.includes('b.js')) {
@@ -2985,6 +3018,8 @@ describe('html', function () {
         }
       });
     });
+
+    if (!youngerSibling) return assert(false, 'No younger sibling found');
 
     assert(
       b.getReferencedBundles(youngerSibling).filter((b) => b == olderSibling)
@@ -3081,6 +3116,7 @@ describe('html', function () {
   it.v2(
     'should throw error with empty string reference to other resource',
     async function () {
+      // $FlowFixMe
       await assert.rejects(
         () =>
           bundle(

--- a/packages/core/integration-tests/test/image.js
+++ b/packages/core/integration-tests/test/image.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {extname, join} from 'path';
 
@@ -103,6 +104,7 @@ describe('images', function () {
       },
     });
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b
       .getBundles()
       .find((b) => ['jpg', 'jpeg'].includes(b.type));
@@ -126,6 +128,7 @@ describe('images', function () {
       logLevel: 'verbose',
     });
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b
       .getBundles()
       .find((b) => ['jpg', 'jpeg'].includes(b.type));
@@ -151,6 +154,7 @@ describe('images', function () {
       },
     });
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b.getBundles().find((b) => b.type === 'png');
 
     let input = await inputFS.readFile(img);
@@ -166,6 +170,7 @@ describe('images', function () {
   it.v2('retain EXIF data when resized with a query string', async () => {
     let b = await bundle(join(__dirname, '/integration/image-exif/resized.js'));
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b
       .getBundles()
       .find((b) => ['jpg', 'jpeg'].includes(b.type));
@@ -191,6 +196,7 @@ describe('images', function () {
       },
     );
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b
       .getBundles()
       .find((b) => ['jpg', 'jpeg'].includes(b.type));
@@ -204,6 +210,7 @@ describe('images', function () {
   it.v2('uses the EXIF orientation tag when resizing', async () => {
     let b = await bundle(join(__dirname, '/integration/image-exif/resized.js'));
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b
       .getBundles()
       .find((b) => ['jpg', 'jpeg'].includes(b.type));
@@ -226,6 +233,7 @@ describe('images', function () {
       },
     );
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b.getBundles().find((b) => b.type === 'jpeg');
 
     let buffer = await outputFS.readFile(filePath);
@@ -247,6 +255,7 @@ describe('images', function () {
       },
     );
 
+    // $FlowFixMe "filePath" does not exist in Bundle
     let {filePath} = b.getBundles().find((b) => b.type === 'png');
 
     let buffer = await outputFS.readFile(filePath);

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import expect from 'expect';
 import path from 'path';
@@ -131,7 +132,8 @@ describe('javascript', function () {
       },
     ]);
 
-    let txtBundle = b.getBundles().find((b) => b.type === 'txt').filePath;
+    let txtBundle =
+      b.getBundles().find((b) => b.type === 'txt')?.filePath || '';
 
     let output = await run(b);
     assert.strictEqual(path.basename(output), path.basename(txtBundle));
@@ -247,15 +249,18 @@ describe('javascript', function () {
   it.skip('should not bundle node_modules on --target=electron', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/node_require/main.js'),
+      // $FlowFixMe target missing in options
       {
         target: 'electron',
       },
     );
 
-    assertBundles(b, {
-      name: 'main.js',
-      assets: ['main.js', 'local.js'],
-    });
+    assertBundles(b, [
+      {
+        name: 'main.js',
+        assets: ['main.js', 'local.js'],
+      },
+    ]);
 
     await outputFS.mkdirp(path.join(distDir, 'node_modules/testmodule'));
     await outputFS.writeFile(
@@ -375,16 +380,19 @@ describe('javascript', function () {
   it.skip('should bundle node_modules on --target=electron and --bundle-node-modules', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/node_require/main.js'),
+      // $FlowFixMe target missing in options
       {
         target: 'electron',
         bundleNodeModules: true,
       },
     );
 
-    assertBundles(b, {
-      name: 'main.js',
-      assets: ['main.js', 'local.js', 'index.js'],
-    });
+    assertBundles(b, [
+      {
+        name: 'main.js',
+        assets: ['main.js', 'local.js', 'index.js'],
+      },
+    ]);
 
     let output = await run(b);
     assert.equal(typeof output, 'function');
@@ -581,15 +589,19 @@ describe('javascript', function () {
         __dirname,
         '/integration/dynamic-subdirectory/subdirectory/index.js',
       ),
+      // $FlowFixMe target missing in options
       {
         target: 'browser',
       },
     );
+
     // Set the rootDir to make sure subdirectory is preserved
+    // $FlowFixMe options missing in Atlaspack
     bu.options.rootDir = path.join(
       __dirname,
       '/integration/dynamic-subdirectory',
     );
+    // $FlowFixMe bundle() missing in Atlaspack
     let b = await bu.bundle();
     let output = await run(b);
     assert.equal(typeof output, 'function');
@@ -932,7 +944,7 @@ describe('javascript', function () {
     assert.equal(typeof output, 'function');
     assert(/^http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output()));
     let stats = await outputFS.stat(
-      path.join(distDir, url.parse(output()).pathname),
+      path.join(distDir, url.parse(output()).pathname || ''),
     );
     assert.equal(stats.size, 9);
   });
@@ -1033,6 +1045,7 @@ describe('javascript', function () {
         'integration/import-raw-import-meta-url/missing.js',
       );
       let code = await inputFS.readFileSync(fixture, 'utf8');
+      // $FlowFixMe rejects does not exist on assert
       await assert.rejects(() => bundle(fixture), {
         name: 'BuildError',
         diagnostics: [
@@ -1105,7 +1118,7 @@ describe('javascript', function () {
     assert.equal(typeof output, 'function');
     assert(/^http:\/\/localhost\/test\.[0-9a-f]+\.txt$/.test(output()));
     let stats = await outputFS.stat(
-      path.join(distDir, url.parse(output()).pathname),
+      path.join(distDir, url.parse(output()).pathname || ''),
     );
     assert.equal(stats.size, assetSizeBytes);
   });
@@ -1630,6 +1643,7 @@ describe('javascript', function () {
 
   it.v2('should error on process.env mutations', async function () {
     let filePath = path.join(__dirname, '/integration/env-mutate/index.js');
+    // $FlowFixMe
     await assert.rejects(bundle(filePath), {
       diagnostics: [
         {
@@ -1914,10 +1928,12 @@ describe('javascript', function () {
     assert.equal(output(), true);
     // Running the bundled code has the side effect of setting process.browser = true, which can mess
     // up the instantiation of typescript.sys within validator-typescript, so we want to reset it.
+    // $FlowFixMe browser does not exist on process
     process.browser = undefined;
   });
 
   it.skip('should support adding implicit dependencies', async function () {
+    // $FlowFixMe
     let b = await bundle(path.join(__dirname, '/integration/json/index.js'), {
       delegate: {
         getImplicitDependencies(asset) {
@@ -1928,19 +1944,21 @@ describe('javascript', function () {
       },
     });
 
-    assertBundles(b, {
-      name: 'index.js',
-      assets: ['index.js', 'local.json', 'index.css'],
-      childBundles: [
-        {
-          type: 'css',
-          assets: ['index.css'],
-        },
-        {
-          type: 'map',
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'local.json', 'index.css'],
+        childBundles: [
+          {
+            type: 'css',
+            assets: ['index.css'],
+          },
+          {
+            type: 'map',
+          },
+        ],
+      },
+    ]);
 
     let output = await run(b);
     assert.equal(typeof output, 'function');
@@ -2005,20 +2023,23 @@ describe('javascript', function () {
   it.skip('should not resolve the browser field for --target=node', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/resolve-entries/browser.js'),
+      // $FlowFixMe
       {
         target: 'node',
       },
     );
 
-    assertBundles(b, {
-      name: 'browser.js',
-      assets: ['browser.js', 'node-module.js'],
-      childBundles: [
-        {
-          type: 'map',
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'browser.js',
+        assets: ['browser.js', 'node-module.js'],
+        childBundles: [
+          {
+            type: 'map',
+          },
+        ],
+      },
+    ]);
 
     let output = await run(b);
 
@@ -2031,19 +2052,21 @@ describe('javascript', function () {
       path.join(__dirname, '/integration/resolve-entries/browser-multiple.js'),
     );
 
-    assertBundles(b, {
-      name: 'browser-multiple.js',
-      assets: [
-        'browser-multiple.js',
-        'projected-browser.js',
-        'browser-entry.js',
-      ],
-      childBundles: [
-        {
-          type: 'map',
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'browser-multiple.js',
+        assets: [
+          'browser-multiple.js',
+          'projected-browser.js',
+          'browser-entry.js',
+        ],
+        childBundles: [
+          {
+            type: 'map',
+          },
+        ],
+      },
+    ]);
 
     let {test: output} = await run(b);
 
@@ -2056,20 +2079,23 @@ describe('javascript', function () {
   it.skip('should not resolve advanced browser resolution with --target=node', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/resolve-entries/browser-multiple.js'),
+      // $FlowFixMe
       {
         target: 'node',
       },
     );
 
-    assertBundles(b, {
-      name: 'browser-multiple.js',
-      assets: ['browser-multiple.js', 'node-entry.js', 'projected.js'],
-      childBundles: [
-        {
-          type: 'map',
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'browser-multiple.js',
+        assets: ['browser-multiple.js', 'node-entry.js', 'projected.js'],
+        childBundles: [
+          {
+            type: 'map',
+          },
+        ],
+      },
+    ]);
 
     let {test: output} = await run(b);
 
@@ -2194,10 +2220,10 @@ describe('javascript', function () {
       error = err;
     }
     assert.equal(
-      error.message,
+      error?.message,
       `Cannot resolve dependency 'vue/thisDoesNotExist'`,
     );
-    assert.equal(error.code, 'MODULE_NOT_FOUND');
+    assert.equal(error?.code, 'MODULE_NOT_FOUND');
   });
 
   it.skip('should not autoinstall if resolve failed on aliased module', async function () {
@@ -2213,10 +2239,10 @@ describe('javascript', function () {
       error = err;
     }
     assert.equal(
-      error.message,
+      error?.message,
       `Cannot resolve dependency 'aliasVue/thisDoesNotExist'`,
     );
-    assert.equal(error.code, 'MODULE_NOT_FOUND');
+    assert.equal(error?.code, 'MODULE_NOT_FOUND');
   });
 
   it('should ignore require if it is defined in the scope', async function () {
@@ -2261,6 +2287,7 @@ describe('javascript', function () {
       test = f();
     };
     mockDefine.amd = true;
+    if (!test) return assert(false);
 
     await run(b, {define: mockDefine, module: undefined});
     assert.equal(test(), 'Test!');
@@ -2269,6 +2296,7 @@ describe('javascript', function () {
   it.skip('should expose variable with --browser-global', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/entry-point/index.js'),
+      // $FlowFixMe
       {
         global: 'testing',
       },
@@ -2410,6 +2438,7 @@ describe('javascript', function () {
   it.skip('should not dedupe imports with different contents', async function () {
     let b = await bundle(
       path.join(__dirname, `/integration/js-different-contents/index.js`),
+      // $FlowFixMe
       {
         hmr: false, // enable asset dedupe in JSPackager
       },
@@ -2425,6 +2454,7 @@ describe('javascript', function () {
         __dirname,
         `/integration/js-same-contents-different-dependencies/index.js`,
       ),
+      // $FlowFixMe
       {
         hmr: false, // enable asset dedupe in JSPackager
       },
@@ -2440,11 +2470,15 @@ describe('javascript', function () {
         __dirname,
         `/integration/js-same-contents-same-dependencies/index.js`,
       ),
+      // $FlowFixMe
       {
         hmr: false, // enable asset dedupe in JSPackager
       },
     );
+
+    // $FlowFixMe entryAsset missing
     const {rootDir} = b.entryAsset.options;
+    // $FlowFixMe offsets missing
     const writtenAssets = Array.from(b.offsets.keys()).map(
       (asset) => asset.name,
     );
@@ -2468,11 +2502,14 @@ describe('javascript', function () {
   it.skip('should not dedupe assets that exist in more than one bundle', async function () {
     let b = await bundle(
       path.join(__dirname, `/integration/js-dedup-hoist/index.js`),
+      // $FlowFixMe
       {
         hmr: false, // enable asset dedupe in JSPackager
       },
     );
+    // $FlowFixMe
     const {rootDir} = b.entryAsset.options;
+    // $FlowFixMe
     const writtenAssets = Array.from(b.offsets.keys()).map(
       (asset) => asset.name,
     );
@@ -2495,27 +2532,29 @@ describe('javascript', function () {
       },
     );
 
-    assertBundles(b, {
-      name: 'index.js',
-      assets: ['index.js', 'cacheLoader.js', 'html-loader.js'],
-      childBundles: [
-        {
-          type: 'html',
-          assets: ['other.html'],
-          childBundles: [
-            {
-              type: 'png',
-              assets: ['100x100.png'],
-              childBundles: [],
-            },
-            {
-              type: 'css',
-              assets: ['index.css'],
-            },
-          ],
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'cacheLoader.js', 'html-loader.js'],
+        childBundles: [
+          {
+            type: 'html',
+            assets: ['other.html'],
+            childBundles: [
+              {
+                type: 'png',
+                assets: ['100x100.png'],
+                childBundles: [],
+              },
+              {
+                type: 'css',
+                assets: ['index.css'],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
 
     let output = await run(b);
     assert.equal(typeof output, 'string');
@@ -2526,6 +2565,7 @@ describe('javascript', function () {
   it.skip('should support importing HTML from JS async with --target=node', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/import-html-async/index.js'),
+      // $FlowFixMe
       {
         target: 'node',
         defaultTargetOptions: {
@@ -2534,27 +2574,29 @@ describe('javascript', function () {
       },
     );
 
-    assertBundles(b, {
-      name: 'index.js',
-      assets: ['index.js', 'cacheLoader.js', 'html-loader.js'],
-      childBundles: [
-        {
-          type: 'html',
-          assets: ['other.html'],
-          childBundles: [
-            {
-              type: 'png',
-              assets: ['100x100.png'],
-              childBundles: [],
-            },
-            {
-              type: 'css',
-              assets: ['index.css'],
-            },
-          ],
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'cacheLoader.js', 'html-loader.js'],
+        childBundles: [
+          {
+            type: 'html',
+            assets: ['other.html'],
+            childBundles: [
+              {
+                type: 'png',
+                assets: ['100x100.png'],
+                childBundles: [],
+              },
+              {
+                type: 'css',
+                assets: ['index.css'],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
 
     let output = await run(b);
     assert.equal(typeof output, 'string');
@@ -2572,27 +2614,29 @@ describe('javascript', function () {
       },
     );
 
-    assertBundles(b, {
-      name: 'index.js',
-      assets: ['index.js', 'cacheLoader.js', 'html-loader.js'],
-      childBundles: [
-        {
-          type: 'html',
-          assets: ['other.html'],
-          childBundles: [
-            {
-              type: 'png',
-              assets: ['100x100.png'],
-              childBundles: [],
-            },
-            {
-              type: 'css',
-              assets: ['index.css'],
-            },
-          ],
-        },
-      ],
-    });
+    assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: ['index.js', 'cacheLoader.js', 'html-loader.js'],
+        childBundles: [
+          {
+            type: 'html',
+            assets: ['other.html'],
+            childBundles: [
+              {
+                type: 'png',
+                assets: ['100x100.png'],
+                childBundles: [],
+              },
+              {
+                type: 'css',
+                assets: ['index.css'],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
 
     let {deferred, promise} = makeDeferredWithPromise();
     await run(b, {output: deferred.resolve}, {require: false});
@@ -2605,6 +2649,7 @@ describe('javascript', function () {
   it.skip('should stub require.cache', async function () {
     let b = await bundle(
       path.join(__dirname, '/integration/node_require_cache/main.js'),
+      // $FlowFixMe
       {
         target: 'node',
       },
@@ -2867,7 +2912,7 @@ describe('javascript', function () {
       );
 
       let dist = await outputFS.readFile(
-        b.getBundles().find((b) => b.type === 'js').filePath,
+        b.getBundles().find((b) => b.type === 'js')?.filePath || '',
         'utf8',
       );
 
@@ -2886,7 +2931,7 @@ describe('javascript', function () {
       ),
     );
     let dist = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'js').filePath,
+      b.getBundles().find((b) => b.type === 'js')?.filePath || '',
       'utf8',
     );
 
@@ -3082,11 +3127,13 @@ describe('javascript', function () {
     let getDep = bundles.find((b) => b.name === 'get-dep.js');
 
     assert.deepEqual(
-      await (
+      await // $FlowFixMe
+      (
         await runBundle(b, sameBundle)
       ).default,
       [42, 42, 42],
     );
+    // $FlowFixMe
     assert.deepEqual(await (await runBundle(b, getDep)).default, 42);
   });
 
@@ -3159,7 +3206,8 @@ describe('javascript', function () {
     ]);
 
     assert.equal(
-      await (
+      await // $FlowFixMe
+      (
         await runBundle(
           b,
           b.getBundles().find((bundle) => bundle.name.includes('index.js')),
@@ -3195,6 +3243,7 @@ describe('javascript', function () {
   it.v2('should display a codeframe on a Terser parse error', async () => {
     let fixture = path.join(__dirname, 'integration/terser-codeframe/index.js');
     let code = await inputFS.readFileSync(fixture, 'utf8');
+    // $FlowFixMe
     await assert.rejects(
       () =>
         bundle(fixture, {
@@ -3297,6 +3346,7 @@ describe('javascript', function () {
   it.v2('should throw a diagnostic for unknown pipelines', async function () {
     let fixture = path.join(__dirname, 'integration/pipeline-unknown/a.js');
     let code = await inputFS.readFileSync(fixture, 'utf8');
+    // $FlowFixMe
     await assert.rejects(() => bundle(fixture), {
       name: 'BuildError',
       diagnostics: [
@@ -3755,6 +3805,7 @@ describe('javascript', function () {
         'integration/diagnostic-sourcemap/index.js',
       );
       let code = await inputFS.readFileSync(fixture, 'utf8');
+      // $FlowFixMe
       await assert.rejects(
         () =>
           bundle(fixture, {
@@ -3849,6 +3900,7 @@ describe('javascript', function () {
         __dirname,
         'integration/undeclared-external/package.json',
       );
+      // $FlowFixMe
       await assert.rejects(
         () =>
           bundle(fixture, {
@@ -3926,6 +3978,7 @@ describe('javascript', function () {
         __dirname,
         'integration/undeclared-external/package.json',
       );
+      // $FlowFixMe
       await assert.rejects(
         () =>
           bundle(fixture, {
@@ -4014,11 +4067,12 @@ describe('javascript', function () {
             '@swc/helpers': '^0.3.0',
           },
         },
-        false,
+        null,
         2,
       );
       await overlayFS.mkdirp(path.dirname(pkg));
       await overlayFS.writeFile(pkg, pkgContents);
+      // $FlowFixMe
       await assert.rejects(
         () =>
           bundle(fixture, {
@@ -4412,6 +4466,7 @@ describe('javascript', function () {
       path.join(__dirname, '/integration/js-import-initialization/a.mjs'),
     );
 
+    // $FlowFixMe
     await assert.rejects(
       run(b),
       new ReferenceError("Cannot access 'foo' before initialization"),
@@ -4428,6 +4483,7 @@ describe('javascript', function () {
       },
     );
 
+    // $FlowFixMe
     await assert.rejects(
       run(b),
       /^ReferenceError: Cannot access '(.+)' before initialization$/,
@@ -4647,6 +4703,7 @@ describe('javascript', function () {
       '/js-recoverable-parse-errors/index.js',
     );
 
+    // $FlowFixMe
     await assert.rejects(
       () =>
         bundle(fixture, {
@@ -4734,7 +4791,8 @@ describe('javascript', function () {
           assert.deepEqual(res.output, 2);
 
           let css = await outputFS.readFile(
-            b.getBundles().find((bundle) => bundle.type === 'css').filePath,
+            b.getBundles().find((bundle) => bundle.type === 'css')?.filePath ||
+              '',
             'utf8',
           );
           assert(!css.includes('.b2'));
@@ -5041,6 +5099,8 @@ describe('javascript', function () {
 
           let bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, '12345hello');
 
@@ -5052,6 +5112,7 @@ describe('javascript', function () {
 
           bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, '1234556789');
 
@@ -5074,6 +5135,7 @@ describe('javascript', function () {
 
           let bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, '12345hello');
 
@@ -5085,6 +5147,7 @@ describe('javascript', function () {
 
           bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, '1234556789');
 
@@ -5179,6 +5242,8 @@ describe('javascript', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let called = false;
           let res = await run(
             bundleEvent.bundleGraph,
@@ -5203,6 +5268,8 @@ describe('javascript', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           called = false;
           res = await run(
             bundleEvent.bundleGraph,
@@ -5857,6 +5924,7 @@ describe('javascript', function () {
         {require: false},
       );
 
+      // $FlowFixMe result is "mixed"
       assert.equal(await result.output, 2);
     });
 

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -3126,11 +3126,10 @@ describe('javascript', function () {
     let sameBundle = bundles.find((b) => b.name === 'same-bundle.js');
     let getDep = bundles.find((b) => b.name === 'get-dep.js');
 
+    let result = await await runBundle(b, sameBundle);
     assert.deepEqual(
-      await // $FlowFixMe
-      (
-        await runBundle(b, sameBundle)
-      ).default,
+      // $FlowFixMe
+      result.default,
       [42, 42, 42],
     );
     // $FlowFixMe
@@ -3205,14 +3204,13 @@ describe('javascript', function () {
       {assets: ['async.js']},
     ]);
 
+    let result = await await runBundle(
+      b,
+      b.getBundles().find((bundle) => bundle.name.includes('index.js')),
+    );
     assert.equal(
-      await // $FlowFixMe
-      (
-        await runBundle(
-          b,
-          b.getBundles().find((bundle) => bundle.name.includes('index.js')),
-        )
-      ).default,
+      // $FlowFixMe
+      result.default,
       43,
     );
   });

--- a/packages/core/integration-tests/test/json.js
+++ b/packages/core/integration-tests/test/json.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {

--- a/packages/core/integration-tests/test/json5.js
+++ b/packages/core/integration-tests/test/json5.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {

--- a/packages/core/integration-tests/test/kotlin.js
+++ b/packages/core/integration-tests/test/kotlin.js
@@ -1,11 +1,6 @@
+// @flow
 import assert from 'assert';
-import {
-  assertBundleTree,
-  bundle,
-  describe,
-  it,
-  run,
-} from '@atlaspack/test-utils';
+import {assertBundles, bundle, describe, it, run} from '@atlaspack/test-utils';
 import commandExists from 'command-exists';
 
 describe.skip('kotlin', function () {
@@ -20,10 +15,12 @@ describe.skip('kotlin', function () {
   it('should produce a basic kotlin bundle', async function () {
     let b = await bundle(__dirname + '/integration/kotlin/index.js');
 
-    await assertBundleTree(b, {
-      type: 'js',
-      assets: ['test.kt', 'index.js', 'browser.js', 'kotlin.js'],
-    });
+    await assertBundles(b, [
+      {
+        type: 'js',
+        assets: ['test.kt', 'index.js', 'browser.js', 'kotlin.js'],
+      },
+    ]);
 
     let output = await run(b);
     assert.equal(output, 5);

--- a/packages/core/integration-tests/test/lazy-compile.js
+++ b/packages/core/integration-tests/test/lazy-compile.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -13,13 +14,17 @@ import {
   fsFixture,
   overlayFS,
 } from '@atlaspack/test-utils';
+import type {NamedBundle} from '@atlaspack/types';
 
-const findBundle = (bundleGraph, nameRegex) => {
+const findBundle = (bundleGraph, nameRegex): NamedBundle => {
+  if (!bundleGraph) throw new Error('Missing bundleGraph');
+  if (!nameRegex) throw new Error('Missing nameRegex');
+
   const result = bundleGraph.getBundles().find((b) => nameRegex.test(b.name));
 
   if (!result) {
     throw new Error(
-      `Couldn't find bundle matching '${nameRegex}'. Available bundles are ${bundleGraph
+      `Couldn't find bundle matching '${nameRegex.toString()}'. Available bundles are ${bundleGraph
         ?.getBundles()
         .map((b) => b.name)
         .join(', ')}`,
@@ -41,7 +46,9 @@ const distDirIncludes = async (matches) => {
     } else {
       if (!files.some((file) => match.test(file))) {
         throw new Error(
-          `No file matching ${match} was found in ${files.join(', ')}`,
+          `No file matching ${match.toString()} was found in ${files.join(
+            ', ',
+          )}`,
         );
       }
     }
@@ -64,6 +71,7 @@ describe.v2('lazy compile', function () {
 
     const subscription = await b.watch();
     let result = await getNextBuild(b);
+    if (!result.requestBundle) return assert(false);
 
     // This simulates what happens if index.js is loaded as well as lazy-1 which loads lazy-2.
     // While parallel-lazy-1 is also async imported by index.js, we pretend it wasn't requested (i.e. like
@@ -115,6 +123,8 @@ describe.v2('lazy compile', function () {
 
     const subscription = await b.watch();
     let result = await getNextBuild(b);
+    if (!result.requestBundle) return assert(false);
+
     result = await result.requestBundle(
       findBundle(result.bundleGraph, /^index-sync-async\./),
     );
@@ -151,6 +161,7 @@ describe.v2('lazy compile', function () {
 
     const subscription = await b.watch();
     let result = await getNextBuild(b);
+    if (!result.bundleGraph) return assert(false);
 
     // Expect the bundle graph to only contain `parallel-lazy-1` but not `lazy-1`s children as we're only including lazy-1 in lazy compilation
     // `parallel-lazy-1` which wasn't requested.
@@ -213,6 +224,7 @@ describe.v2('lazy compile', function () {
 
     const subscription = await b.watch();
     let result = await getNextBuild(b);
+    if (!result.requestBundle) return assert(false);
 
     result = await result.requestBundle(
       findBundle(result.bundleGraph, /index.js/),
@@ -256,6 +268,8 @@ describe.v2('lazy compile', function () {
 
     const subscription = await b.watch();
     let result = await getNextBuild(b);
+    if (!result.requestBundle) return assert(false);
+
     result = await result.requestBundle(
       findBundle(result.bundleGraph, /^index-sync-async\./),
     );
@@ -326,6 +340,8 @@ describe.v2('lazy compile', function () {
 
     const subscription = await b.watch();
     let result = await getNextBuild(b);
+    if (!result.requestBundle) return assert(false);
+
     result = await result.requestBundle(
       findBundle(result.bundleGraph, /^index\.js/),
     );

--- a/packages/core/integration-tests/test/less.js
+++ b/packages/core/integration-tests/test/less.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {
@@ -385,6 +386,7 @@ describe.v2('less', function () {
         @import '~library/style.less';
     `;
 
+    // $FlowFixMe
     await assert.rejects(() => bundle('index.less', {inputFS: overlayFS}), {
       message: md`The @import path "${'~library/style.less'}" is using webpack specific syntax, which isn't supported by Parcel.\n\nTo @import files from ${'node_modules'}, use "${'library/style.less'}"`,
     });

--- a/packages/core/integration-tests/test/markdown.js
+++ b/packages/core/integration-tests/test/markdown.js
@@ -1,7 +1,8 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
-  assertBundleTree,
+  assertBundles,
   bundle,
   describe,
   it,
@@ -14,17 +15,19 @@ describe.skip('markdown', function () {
       path.join(__dirname, '/integration/markdown/index.md'),
     );
 
-    await assertBundleTree(b, {
-      name: 'index.html',
-      assets: ['index.md'],
-      childBundles: [
-        {
-          type: 'png',
-          assets: ['100x100.png'],
-          childBundles: [],
-        },
-      ],
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.md'],
+        childBundles: [
+          {
+            type: 'png',
+            assets: ['100x100.png'],
+            childBundles: [],
+          },
+        ],
+      },
+    ]);
 
     let files = await outputFS.readdir(path.join(__dirname, '/dist'));
     let html = await outputFS.readFile(

--- a/packages/core/integration-tests/test/monorepos.js
+++ b/packages/core/integration-tests/test/monorepos.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -606,6 +607,7 @@ describe.v2('monorepos', function () {
 
     subscription = await b.watch();
     let evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
 
     assertBundles(evt.bundleGraph, [
       {
@@ -624,6 +626,8 @@ describe.v2('monorepos', function () {
     );
 
     evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
+
     assertBundles(evt.bundleGraph, [
       {
         name: 'pkg-a.cjs.js',
@@ -668,6 +672,7 @@ describe.v2('monorepos', function () {
 
     subscription = await b.watch();
     let evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
 
     assertBundles(evt.bundleGraph, [
       {
@@ -689,6 +694,8 @@ describe.v2('monorepos', function () {
 
     evt = await getNextBuild(b);
     assert(evt.type === 'buildSuccess');
+    if (!evt.bundleGraph) return assert(false);
+
     assertBundles(evt.bundleGraph, [
       {
         name: 'pkg-a.cjs.js',
@@ -729,6 +736,7 @@ describe.v2('monorepos', function () {
 
     subscription = await b.watch();
     let evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
 
     assertBundles(evt.bundleGraph, [
       {
@@ -753,6 +761,8 @@ describe.v2('monorepos', function () {
     );
 
     evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
+
     assertBundles(evt.bundleGraph, [
       {
         name: 'alt.js',
@@ -1008,6 +1018,7 @@ describe.v2('monorepos', function () {
 
     for (let bundle of b.getBundles()) {
       let res = await runBundle(b, bundle);
+      // $FlowFixMe
       assert.equal(res.default, bundle.name[0]);
     }
   });
@@ -1064,6 +1075,7 @@ describe.v2('monorepos', function () {
 
     for (let bundle of b.getBundles()) {
       let res = await runBundle(b, bundle);
+      // $FlowFixMe
       assert.equal(res.default, bundle.name[0]);
     }
   });
@@ -1097,6 +1109,7 @@ describe.v2('monorepos', function () {
 
     subscription = await b.watch();
     let evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
 
     assertBundles(evt.bundleGraph, [
       {
@@ -1110,6 +1123,8 @@ describe.v2('monorepos', function () {
     `;
 
     evt = await getNextBuild(b);
+    if (!evt.bundleGraph) return assert(false);
+
     assertBundles(evt.bundleGraph, [
       {
         assets: ['a.js'],

--- a/packages/core/integration-tests/test/namer.js
+++ b/packages/core/integration-tests/test/namer.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {bundle, describe, it, outputFS, distDir} from '@atlaspack/test-utils';

--- a/packages/core/integration-tests/test/output-formats.js
+++ b/packages/core/integration-tests/test/output-formats.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {pathToFileURL} from 'url';
@@ -309,7 +310,7 @@ describe('output formats', function () {
         );
 
         let dist = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'js').filePath,
+          b.getBundles().find((b) => b.type === 'js')?.filePath || '',
           'utf8',
         );
         assert(dist.includes('require("./index.css")'));
@@ -322,7 +323,7 @@ describe('output formats', function () {
       );
 
       let index = await outputFS.readFile(
-        b.getBundles().find((b) => b.name.startsWith('index')).filePath,
+        b.getBundles().find((b) => b.name.startsWith('index'))?.filePath || '',
         'utf8',
       );
       assert(/Promise\.resolve\(require\("\.\/async\..+?\.js"\)\)/.test(index));
@@ -342,7 +343,7 @@ describe('output formats', function () {
       );
 
       let index = await outputFS.readFile(
-        b.getBundles().find((b) => b.name.startsWith('index')).filePath,
+        b.getBundles().find((b) => b.name.startsWith('index'))?.filePath || '',
         'utf8',
       );
       assert(
@@ -416,6 +417,7 @@ describe('output formats', function () {
           '/integration/formats/commonjs-sideeffects',
           'missing-export.js',
         );
+        // $FlowFixMe
         await assert.rejects(
           () =>
             bundle(
@@ -464,7 +466,7 @@ describe('output formats', function () {
       );
 
       let dist = await outputFS.readFile(
-        b.getBundles().find((b) => b.type === 'js').filePath,
+        b.getBundles().find((b) => b.type === 'js')?.filePath || '',
         'utf8',
       );
       assert(dist.includes('Object.assign(module.exports'));
@@ -484,7 +486,7 @@ describe('output formats', function () {
         );
 
         let dist = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'js').filePath,
+          b.getBundles().find((b) => b.type === 'js')?.filePath || '',
           'utf8',
         );
         assert(dist.includes('= require("lodash")'));
@@ -536,14 +538,14 @@ describe('output formats', function () {
         assert(
           contents.includes(
             `new Worker(new URL("${path.basename(
-              workerBundle.filePath,
+              workerBundle?.filePath || '',
             )}", "file:" + __filename)`,
           ),
         );
         assert(
           contents.includes(
             `new SharedWorker(new URL("${path.basename(
-              sharedWorkerBundle.filePath,
+              sharedWorkerBundle?.filePath || '',
             )}", "file:" + __filename)`,
           ),
         );
@@ -615,6 +617,7 @@ describe('output formats', function () {
       let external = {
         foo: 1,
         setFoo(f) {
+          // $FlowFixMe
           this.foo = f;
         },
       };
@@ -869,7 +872,7 @@ describe('output formats', function () {
         );
 
         let dist = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'js').filePath,
+          b.getBundles().find((b) => b.type === 'js')?.filePath || '',
           'utf8',
         );
         assert(dist.includes('import "./index.css"'));
@@ -885,7 +888,7 @@ describe('output formats', function () {
       );
 
       let dist = await outputFS.readFile(
-        b.getBundles().find((b) => b.type === 'js').filePath,
+        b.getBundles().find((b) => b.type === 'js')?.filePath || '',
         'utf8',
       );
       assert(!dist.includes('foo'));
@@ -911,7 +914,7 @@ describe('output formats', function () {
       ]);
 
       let dist = await outputFS.readFile(
-        b.getBundles().find((b) => !b.needsStableName).filePath,
+        b.getBundles().find((b) => !b.needsStableName)?.filePath || '',
         'utf8',
       );
       assert(dist.includes('$parcel$interopDefault'));
@@ -936,7 +939,7 @@ describe('output formats', function () {
       );
 
       let index = await outputFS.readFile(
-        b.getBundles().find((b) => b.name.startsWith('index')).filePath,
+        b.getBundles().find((b) => b.name.startsWith('index'))?.filePath || '',
         'utf8',
       );
       assert(/import\("\.\/async\..+?\.js"\)/.test(index));
@@ -955,7 +958,7 @@ describe('output formats', function () {
       );
 
       let async = await outputFS.readFile(
-        b.getBundles().find((b) => b.name.startsWith('c')).filePath,
+        b.getBundles().find((b) => b.name.startsWith('c'))?.filePath || '',
         'utf8',
       );
       assert(!/\$export\$default\s+=/.test(async));
@@ -986,6 +989,7 @@ describe('output formats', function () {
           'integration/formats/esm-sideeffects',
           'missing-export.js',
         );
+        // $FlowFixMe
         await assert.rejects(
           () =>
             bundle(
@@ -1039,7 +1043,7 @@ describe('output formats', function () {
       );
 
       let index = await outputFS.readFile(
-        b.getBundles().find((b) => b.name.startsWith('index')).filePath,
+        b.getBundles().find((b) => b.name.startsWith('index'))?.filePath || '',
         'utf8',
       );
       assert(/import\("\.\/async1\..+?\.js"\)/.test(index));
@@ -1097,11 +1101,13 @@ describe('output formats', function () {
         .find((b) => !b.filePath.includes('async'));
       assert(
         workerBundleContents.includes(
-          `import "./${path.basename(syncBundle.filePath)}"`,
+          `import "./${path.basename(syncBundle?.filePath || '')}"`,
         ),
       );
       assert(
-        workerBundleContents.includes(path.basename(asyncBundle.filePath)),
+        workerBundleContents.includes(
+          path.basename(asyncBundle?.filePath || ''),
+        ),
       );
     });
 
@@ -1113,7 +1119,7 @@ describe('output formats', function () {
         );
 
         let html = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'html').filePath,
+          b.getBundles().find((b) => b.type === 'html')?.filePath || '',
           'utf8',
         );
 
@@ -1125,7 +1131,7 @@ describe('output formats', function () {
             .find(
               (b) =>
                 path.basename(b.filePath) === html.match(/src="\/(.*?)"/)[1],
-            ).filePath,
+            )?.filePath || '',
           'utf8',
         );
 
@@ -1133,7 +1139,9 @@ describe('output formats', function () {
           .getBundles()
           .find((bundle) => bundle.name.startsWith('async'));
         assert(
-          entry.includes(`import("./${path.basename(asyncBundle.filePath)}")`),
+          entry.includes(
+            `import("./${path.basename(asyncBundle?.filePath || '')}")`,
+          ),
         );
 
         let res = await run(b, {output: null}, {require: false});
@@ -1159,7 +1167,7 @@ describe('output formats', function () {
         );
 
         let html = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'html').filePath,
+          b.getBundles().find((b) => b.type === 'html')?.filePath || '',
           'utf8',
         );
 
@@ -1171,7 +1179,7 @@ describe('output formats', function () {
             .find(
               (b) =>
                 path.basename(b.filePath) === html.match(/src="\/(.*?)"/)[1],
-            ).filePath,
+            )?.filePath || '',
           'utf8',
         );
         assert(entry.includes('function importModule'));
@@ -1182,7 +1190,7 @@ describe('output formats', function () {
         assert(
           new RegExp(
             `getBundleURL\\('[a-zA-Z0-9]+'\\) \\+ "` +
-              path.basename(asyncBundle.filePath) +
+              path.basename(asyncBundle?.filePath || '') +
               '"',
           ).test(entry),
         );
@@ -1200,7 +1208,7 @@ describe('output formats', function () {
         );
 
         let html = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'html').filePath,
+          b.getBundles().find((b) => b.type === 'html')?.filePath || '',
           'utf8',
         );
 
@@ -1213,7 +1221,7 @@ describe('output formats', function () {
             .find(
               (b) =>
                 path.basename(b.filePath) === html.match(/src="\/(.*?)"/)[1],
-            ).filePath,
+            )?.filePath || '',
           'utf8',
         );
 
@@ -1227,9 +1235,9 @@ describe('output formats', function () {
         assert(
           new RegExp(
             'Promise.all\\(\\[\\n.+?new URL\\("' +
-              path.basename(asyncCssBundle.filePath) +
+              path.basename(asyncCssBundle?.filePath || '') +
               '", import.meta.url\\).toString\\(\\)\\),\\n\\s*import\\("\\.\\/' +
-              path.basename(asyncJsBundle.filePath) +
+              path.basename(asyncJsBundle?.filePath || '') +
               '"\\)\\n\\s*\\]\\)',
           ).test(entry),
         );
@@ -1238,7 +1246,7 @@ describe('output formats', function () {
           b
             .getBundles()
             .find((b) => b.type === 'js' && b.name.startsWith('async'))
-            .filePath,
+            ?.filePath || '',
           'utf8',
         );
         assert(!async.includes('.css"'));
@@ -1262,7 +1270,7 @@ describe('output formats', function () {
         );
 
         let html = await outputFS.readFile(
-          b.getBundles().find((b) => b.type === 'html').filePath,
+          b.getBundles().find((b) => b.type === 'html')?.filePath || '',
           'utf8',
         );
 
@@ -1272,13 +1280,14 @@ describe('output formats', function () {
         let entry = await outputFS.readFile(
           bundles.find(
             (b) => path.basename(b.filePath) === html.match(/src="\/(.*?)"/)[1],
-          ).filePath,
+          )?.filePath || '',
           'utf8',
         );
 
         let sharedBundle = bundles.find((b) => b.getEntryAssets().length === 0);
         let async1Bundle = bundles.find(
-          (b) => b.name.startsWith('async1') && b.id !== sharedBundle.id,
+          (b) =>
+            (b.name.startsWith('async1') && b.id !== sharedBundle?.id) || '',
         );
         let async2Bundle = bundles.find((b) => b.name.startsWith('async2'));
 
@@ -1302,6 +1311,7 @@ describe('output formats', function () {
           // async import both bundles in parallel for performance
           assert(
             new RegExp(
+              // $FlowFixMe
               `\\$${esmLoaderPublicId}\\("${sharedBundle.publicId}"\\),\\n\\s*\\$${esmLoaderPublicId}\\("${bundle.publicId}"\\)`,
             ).test(entry),
           );
@@ -1350,6 +1360,7 @@ describe('output formats', function () {
         __dirname,
         '/integration/formats/commonjs-esm/require-resolve.js',
       );
+      // $FlowFixMe
       await assert.rejects(() => bundle(source), {
         name: 'BuildError',
         message,
@@ -1416,6 +1427,7 @@ describe('output formats', function () {
           path.join(__dirname, '/integration/formats/esm-import-shadow/a.mjs'),
         );
 
+        // $FlowFixMe
         let _b = await import(
           pathToFileURL(
             path.join(
@@ -1516,14 +1528,14 @@ describe('output formats', function () {
         assert(
           contents.includes(
             `new Worker(new URL("${path.basename(
-              workerBundle.filePath,
+              workerBundle?.filePath || '',
             )}", import.meta.url)`,
           ),
         );
         assert(
           contents.includes(
             `new SharedWorker(new URL("${path.basename(
-              sharedWorkerBundle.filePath,
+              sharedWorkerBundle?.filePath || '',
             )}", import.meta.url)`,
           ),
         );
@@ -1704,6 +1716,7 @@ describe('output formats', function () {
       );
       assert.strictEqual(res.output, 3);
       res = await runBundle(b, workerBundle, {output: null}, {require: false});
+      // $FlowFixMe
       assert.strictEqual(res.output, 30);
     });
 
@@ -1729,6 +1742,7 @@ describe('output formats', function () {
         __dirname,
         'integration/formats/global-external/index.js',
       );
+      // $FlowFixMe
       await assert.rejects(() => bundle(source), {
         name: 'BuildError',
         message,

--- a/packages/core/integration-tests/test/packager.js
+++ b/packages/core/integration-tests/test/packager.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import nullthrows from 'nullthrows';

--- a/packages/core/integration-tests/test/parser.js
+++ b/packages/core/integration-tests/test/parser.js
@@ -1,7 +1,8 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
-  assertBundleTree,
+  assertBundles,
   bundle,
   describe,
   inputFS as fs,
@@ -17,41 +18,43 @@ describe.skip('parser', function () {
       ),
     );
 
-    await assertBundleTree(b, {
-      name: 'index.html',
-      assets: ['index.html'],
-      childBundles: [
-        {
-          type: 'svg',
-          assets: ['icons.SVG'],
-          childBundles: [],
-        },
-        {
-          type: 'css',
-          assets: ['index.cSs'],
-          childBundles: [
-            {
-              type: 'map',
-            },
-          ],
-        },
-        {
-          type: 'html',
-          assets: ['other.HTM'],
-          childBundles: [
-            {
-              type: 'js',
-              assets: ['index.js'],
-              childBundles: [
-                {
-                  type: 'map',
-                },
-              ],
-            },
-          ],
-        },
-      ],
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.html',
+        assets: ['index.html'],
+        childBundles: [
+          {
+            type: 'svg',
+            assets: ['icons.SVG'],
+            childBundles: [],
+          },
+          {
+            type: 'css',
+            assets: ['index.cSs'],
+            childBundles: [
+              {
+                type: 'map',
+              },
+            ],
+          },
+          {
+            type: 'html',
+            assets: ['other.HTM'],
+            childBundles: [
+              {
+                type: 'js',
+                assets: ['index.js'],
+                childBundles: [
+                  {
+                    type: 'map',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ]);
 
     let files = await fs.readdir(path.join(__dirname, '/dist'));
     let html = await fs.readFile(path.join(__dirname, '/dist/index.html'));

--- a/packages/core/integration-tests/test/pnp.js
+++ b/packages/core/integration-tests/test/pnp.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import Module from 'module';
 import path from 'path';
@@ -18,16 +19,21 @@ describe.v2('pnp', function () {
     let dir = path.join(__dirname, 'integration/pnp-require');
 
     let origPnpVersion = process.versions.pnp;
-    process.versions.pnp = 42;
+    process.versions.pnp = `${42}`;
 
+    // $FlowFixMe
     let origModuleResolveFilename = Module._resolveFilename;
+    // $FlowFixMe
     Module.findPnpApi = () => require(path.join(dir, '.pnp.js'));
+    // $FlowFixMe
     Module._resolveFilename = (name, ...args) =>
       name === 'pnpapi'
         ? path.join(dir, '.pnp.js')
         : origModuleResolveFilename(name, ...args);
 
+    // $FlowFixMe
     let origReadFileSync = inputFS.readFileSync;
+    // $FlowFixMe
     inputFS.readFileSync = (p, ...args) => {
       return origReadFileSync.call(inputFS, p.replace(ZIPFS, ''), ...args);
     };
@@ -56,7 +62,9 @@ describe.v2('pnp', function () {
       assert.equal(output(), 3);
     } finally {
       process.versions.pnp = origPnpVersion;
+      // $FlowFixMe
       Module._resolveFilename = origModuleResolveFilename;
+      // $FlowFixMe
       inputFS.readFileSync = origReadFileSync;
       inputFS.statSync = origStatSync;
       inputFS.realpathSync = origRealpathSync;
@@ -67,10 +75,13 @@ describe.v2('pnp', function () {
     let dir = path.join(__dirname, 'integration/pnp-builtin');
 
     let origPnpVersion = process.versions.pnp;
-    process.versions.pnp = 42;
+    process.versions.pnp = `${42}`;
 
+    // $FlowFixMe
     let origModuleResolveFilename = Module._resolveFilename;
+    // $FlowFixMe
     Module.findPnpApi = () => require(path.join(dir, '.pnp.js'));
+    // $FlowFixMe
     Module._resolveFilename = (name, ...args) =>
       name === 'pnpapi'
         ? path.join(dir, '.pnp.js')
@@ -90,6 +101,7 @@ describe.v2('pnp', function () {
       assert.equal(output(), 3);
     } finally {
       process.versions.pnp = origPnpVersion;
+      // $FlowFixMe
       Module._resolveFilename = origModuleResolveFilename;
     }
   });

--- a/packages/core/integration-tests/test/postcss.js
+++ b/packages/core/integration-tests/test/postcss.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -234,6 +235,7 @@ describe.v2('postcss', () => {
     let subscription = await b.watch();
     let buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
 
     let contents = await outputFS.readFile(
       buildEvent.bundleGraph.getBundles()[0].filePath,
@@ -253,6 +255,7 @@ describe.v2('postcss', () => {
 
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
 
     contents = await outputFS.readFile(
       buildEvent.bundleGraph.getBundles()[0].filePath,
@@ -272,6 +275,7 @@ describe.v2('postcss', () => {
 
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
 
     contents = await outputFS.readFile(
       buildEvent.bundleGraph.getBundles()[0].filePath,
@@ -288,6 +292,7 @@ describe.v2('postcss', () => {
 
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
 
     contents = await outputFS.readFile(
       buildEvent.bundleGraph.getBundles()[0].filePath,
@@ -308,6 +313,7 @@ describe.v2('postcss', () => {
       '/integration/postcss-modules-config-invalid/.postcssrc',
     );
     let code = await inputFS.readFile(configFilePath, 'utf8');
+    // $FlowFixMe
     await assert.rejects(
       () =>
         bundle(

--- a/packages/core/integration-tests/test/posthtml.js
+++ b/packages/core/integration-tests/test/posthtml.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {
   bundle,
@@ -83,6 +84,8 @@ describe.v2('posthtml', function () {
     const b = await bundle(
       path.join(__dirname, '/integration/posthtml-assets/index.html'),
     );
+
+    // $FlowFixMe assets missing
     const asset = b.assets.values().next().value;
     const other = path.join(
       __dirname,
@@ -96,6 +99,8 @@ describe.v2('posthtml', function () {
     const b = await bundle(
       path.join(__dirname, '/integration/posthtml-plugin-deps/index.html'),
     );
+
+    // $FlowFixMe assets missing
     const asset = b.assets.values().next().value;
     const other = path.join(
       __dirname,

--- a/packages/core/integration-tests/test/pug.js
+++ b/packages/core/integration-tests/test/pug.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {

--- a/packages/core/integration-tests/test/reason.js
+++ b/packages/core/integration-tests/test/reason.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {bundle, run} from '@atlaspack/test-utils';
@@ -6,7 +7,10 @@ describe.skip('reason', function () {
   it('should produce a bundle', async function () {
     let b = await bundle(path.join(__dirname, '/integration/reason/index.js'));
 
+    // $FlowFixMe assets missing
     assert.equal(b.assets.size, 2);
+
+    // $FlowFixMe childBundles missing
     assert.equal(b.childBundles.size, 1);
 
     let output = await run(b);

--- a/packages/core/integration-tests/test/rust.js
+++ b/packages/core/integration-tests/test/rust.js
@@ -1,10 +1,11 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
   bundle,
   bundler,
   run,
-  assertBundleTree,
+  assertBundles,
   outputFS,
 } from '@atlaspack/test-utils';
 import commandExists from 'command-exists';
@@ -22,66 +23,73 @@ describe.skip('rust', function () {
     this.timeout(500000);
     let b = await bundle(path.join(__dirname, '/integration/rust/index.js'));
 
-    await assertBundleTree(b, {
-      name: 'index.js',
-      assets: [
-        'bundle-loader.js',
-        'bundle-url.js',
-        'index.js',
-        'wasm-loader.js',
-      ],
-      childBundles: [
-        {
-          type: 'wasm',
-          assets: ['add.rs'],
-          childBundles: [],
-        },
-        {
-          type: 'map',
-        },
-      ],
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'bundle-loader.js',
+          'bundle-url.js',
+          'index.js',
+          'wasm-loader.js',
+        ],
+        childBundles: [
+          {
+            type: 'wasm',
+            assets: ['add.rs'],
+            childBundles: [],
+          },
+          {
+            type: 'map',
+          },
+        ],
+      },
+    ]);
 
     var res = await await run(b);
     assert.equal(res, 5);
 
     // not minified
     assert(
+      // $FlowFixMe childBundles missing
       (await outputFS.stat(Array.from(b.childBundles)[0].name)).size > 500,
     );
   });
 
   it('should generate a wasm file from a rust file with rustc with --target=node', async function () {
     this.timeout(500000);
+    // $FlowFixMe target missing
     let b = await bundle(path.join(__dirname, '/integration/rust/index.js'), {
       target: 'node',
     });
 
-    await assertBundleTree(b, {
-      name: 'index.js',
-      assets: [
-        'bundle-loader.js',
-        'bundle-url.js',
-        'index.js',
-        'wasm-loader.js',
-      ],
-      childBundles: [
-        {
-          type: 'wasm',
-          assets: ['add.rs'],
-          childBundles: [],
-        },
-        {
-          type: 'map',
-        },
-      ],
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'bundle-loader.js',
+          'bundle-url.js',
+          'index.js',
+          'wasm-loader.js',
+        ],
+        childBundles: [
+          {
+            type: 'wasm',
+            assets: ['add.rs'],
+            childBundles: [],
+          },
+          {
+            type: 'map',
+          },
+        ],
+      },
+    ]);
 
     var res = await run(b);
     assert.equal(res, 5);
 
     // not minified
     assert(
+      // $FlowFixMe childBundles missing
       (await outputFS.stat(Array.from(b.childBundles)[0].name)).size > 500,
     );
   });
@@ -89,27 +97,30 @@ describe.skip('rust', function () {
   it('should support rust files with dependencies via rustc', async function () {
     this.timeout(500000);
     let b = bundler(path.join(__dirname, '/integration/rust-deps/index.js'));
+    // $FlowFixMe bundle missing
     let bundle = await b.bundle();
 
-    await assertBundleTree(bundle, {
-      name: 'index.js',
-      assets: [
-        'bundle-loader.js',
-        'bundle-url.js',
-        'index.js',
-        'wasm-loader.js',
-      ],
-      childBundles: [
-        {
-          type: 'map',
-        },
-        {
-          type: 'wasm',
-          assets: ['test.rs'],
-          childBundles: [],
-        },
-      ],
-    });
+    await assertBundles(bundle, [
+      {
+        name: 'index.js',
+        assets: [
+          'bundle-loader.js',
+          'bundle-url.js',
+          'index.js',
+          'wasm-loader.js',
+        ],
+        childBundles: [
+          {
+            type: 'map',
+          },
+          {
+            type: 'wasm',
+            assets: ['test.rs'],
+            childBundles: [],
+          },
+        ],
+      },
+    ]);
 
     var res = await run(bundle);
     assert.equal(res, 10);
@@ -121,25 +132,27 @@ describe.skip('rust', function () {
       path.join(__dirname, '/integration/rust-cargo/src/index.js'),
     );
 
-    await assertBundleTree(b, {
-      name: 'index.js',
-      assets: [
-        'bundle-loader.js',
-        'bundle-url.js',
-        'index.js',
-        'wasm-loader.js',
-      ],
-      childBundles: [
-        {
-          type: 'map',
-        },
-        {
-          type: 'wasm',
-          assets: ['lib.rs'],
-          childBundles: [],
-        },
-      ],
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'bundle-loader.js',
+          'bundle-url.js',
+          'index.js',
+          'wasm-loader.js',
+        ],
+        childBundles: [
+          {
+            type: 'map',
+          },
+          {
+            type: 'wasm',
+            assets: ['lib.rs'],
+            childBundles: [],
+          },
+        ],
+      },
+    ]);
 
     var res = await run(b);
     assert.equal(res, 5);
@@ -154,25 +167,27 @@ describe.skip('rust', function () {
       ),
     );
 
-    await assertBundleTree(b, {
-      name: 'index.js',
-      assets: [
-        'bundle-loader.js',
-        'bundle-url.js',
-        'index.js',
-        'wasm-loader.js',
-      ],
-      childBundles: [
-        {
-          type: 'map',
-        },
-        {
-          type: 'wasm',
-          assets: ['lib.rs'],
-          childBundles: [],
-        },
-      ],
-    });
+    await assertBundles(b, [
+      {
+        name: 'index.js',
+        assets: [
+          'bundle-loader.js',
+          'bundle-url.js',
+          'index.js',
+          'wasm-loader.js',
+        ],
+        childBundles: [
+          {
+            type: 'map',
+          },
+          {
+            type: 'wasm',
+            assets: ['lib.rs'],
+            childBundles: [],
+          },
+        ],
+      },
+    ]);
 
     var res = await run(b);
     assert.equal(res, 5);

--- a/packages/core/integration-tests/test/sass.js
+++ b/packages/core/integration-tests/test/sass.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {

--- a/packages/core/integration-tests/test/scope-hoisting.js
+++ b/packages/core/integration-tests/test/scope-hoisting.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import nullthrows from 'nullthrows';
@@ -11,6 +12,7 @@ import {
   describe,
   distDir,
   findAsset,
+  findAssetOrThrow,
   findDependency,
   getNextBuild,
   it,
@@ -403,9 +405,11 @@ describe('scope hoisting', function () {
       let contents = await outputFS.readFile(
         b
           .getBundles()
+          // $FlowFixMe filePath could be undefined
           .find((b) => b.getMainEntry().filePath.endsWith('index.js')).filePath,
         'utf8',
       );
+      // $FlowFixMe match missing
       assert.match(contents, /output="foo bar"/);
     });
 
@@ -845,6 +849,8 @@ describe('scope hoisting', function () {
         {output: null},
         {require: false},
       );
+
+      // $FlowFixMe notype ctx
       assert.deepEqual(ctx.output, 'aaa');
     });
 
@@ -1516,12 +1522,14 @@ describe('scope hoisting', function () {
           }
 
           let contents = await outputFS.readFile(
+            // $FlowFixMe nullcheck filepath
             b.getBundles().find((b) => b.name.startsWith('b1')).filePath,
             'utf8',
           );
           assert(!contents.includes('bar'));
 
           contents = await outputFS.readFile(
+            // $FlowFixMe nullcheck filepath
             b.getBundles().find((b) => b.name.startsWith('b2')).filePath,
             'utf8',
           );
@@ -1543,12 +1551,14 @@ describe('scope hoisting', function () {
           }
 
           let contents = await outputFS.readFile(
+            // $FlowFixMe nullcheck filepath
             b.getBundles().find((b) => b.name.startsWith('b1')).filePath,
             'utf8',
           );
           assert(!contents.includes('bar'));
 
           contents = await outputFS.readFile(
+            // $FlowFixMe nullcheck filepath
             b.getBundles().find((b) => b.name.startsWith('b2')).filePath,
             'utf8',
           );
@@ -1570,12 +1580,14 @@ describe('scope hoisting', function () {
           }
 
           let contents = await outputFS.readFile(
+            // $FlowFixMe nullcheck filepath
             b.getBundles().find((b) => b.name.startsWith('b1')).filePath,
             'utf8',
           );
           assert(!contents.includes('bar'));
 
           contents = await outputFS.readFile(
+            // $FlowFixMe nullcheck filepath
             b.getBundles().find((b) => b.name.startsWith('b2')).filePath,
             'utf8',
           );
@@ -1607,8 +1619,10 @@ describe('scope hoisting', function () {
         assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
 
         let contents = await outputFS.readFile(
+          // $FlowFixMe nullcheck filepath
           b
             .getBundles()
+            // $FlowFixMe nullcheck filepath
             .find((b) => b.getMainEntry().filePath.endsWith('async.js'))
             .filePath,
           'utf8',
@@ -1640,8 +1654,10 @@ describe('scope hoisting', function () {
         assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
 
         let contents = await outputFS.readFile(
+          // $FlowFixMe nullcheck filepath
           b
             .getBundles()
+            // $FlowFixMe nullcheck filepath
             .find((b) => b.getMainEntry().filePath.endsWith('async.js'))
             .filePath,
           'utf8',
@@ -1673,8 +1689,10 @@ describe('scope hoisting', function () {
         assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
 
         let contents = await outputFS.readFile(
+          // $FlowFixMe nullcheck filepath
           b
             .getBundles()
+            // $FlowFixMe nullcheck filepath
             .find((b) => b.getMainEntry().filePath.endsWith('async.js'))
             .filePath,
           'utf8',
@@ -1758,8 +1776,10 @@ describe('scope hoisting', function () {
         assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
 
         let contents = await outputFS.readFile(
+          // $FlowFixMe nullcheck filepath
           b
             .getBundles()
+            // $FlowFixMe nullcheck filepath
             .find((b) => b.getMainEntry().filePath.endsWith('async.js'))
             .filePath,
           'utf8',
@@ -1791,8 +1811,10 @@ describe('scope hoisting', function () {
         assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
 
         let contents = await outputFS.readFile(
+          // $FlowFixMe nullcheck filepath
           b
             .getBundles()
+            // $FlowFixMe nullcheck filepath
             .find((b) => b.getMainEntry().filePath.endsWith('async.js'))
             .filePath,
           'utf8',
@@ -1855,8 +1877,10 @@ describe('scope hoisting', function () {
         assert(b.isDependencySkipped(findDependency(b, 'async.js', './a1.js')));
 
         let contents = await outputFS.readFile(
+          // $FlowFixMe nullcheck filepath
           b
             .getBundles()
+            // $FlowFixMe nullcheck filepath
             .find((b) => b.getMainEntry().filePath.endsWith('async.js'))
             .filePath,
           'utf8',
@@ -1868,6 +1892,7 @@ describe('scope hoisting', function () {
       it.skip('throws an error for missing exports for dynamic import: destructured await assignment', async function () {
         let source = 'await-assignment-error.js';
         let message = `async.js does not export 'missing'`;
+        // $FlowFixMe missing rejects
         await assert.rejects(
           () =>
             bundle(
@@ -1917,6 +1942,7 @@ describe('scope hoisting', function () {
             'await-declaration-error.js',
           );
           let message = `async.js does not export 'missing'`;
+          // $FlowFixMe missing rejects
           await assert.rejects(
             () =>
               bundle(
@@ -1968,6 +1994,7 @@ describe('scope hoisting', function () {
             'await-declaration-namespace-error.js',
           );
           let message = `async.js does not export 'missing'`;
+          // $FlowFixMe missing rejects
           await assert.rejects(
             () =>
               bundle(
@@ -2019,6 +2046,7 @@ describe('scope hoisting', function () {
             'then-error.js',
           );
           let message = `async.js does not export 'missing'`;
+          // $FlowFixMe missing rejects
           await assert.rejects(
             () =>
               bundle(
@@ -2070,6 +2098,7 @@ describe('scope hoisting', function () {
             'then-namespace-error.js',
           );
           let message = `async.js does not export 'missing'`;
+          // $FlowFixMe missing rejects
           await assert.rejects(
             () =>
               bundle(
@@ -2585,6 +2614,7 @@ describe('scope hoisting', function () {
 
         let bar = findAsset(b, 'real-bar.js');
         assert(bar);
+        // $FlowFixMe nullcheck sideEffects
         assert.strictEqual(bar.sideEffects, false);
       });
 
@@ -2601,6 +2631,7 @@ describe('scope hoisting', function () {
 
         let bar = findAsset(b, 'real-bar.js');
         assert(bar);
+        // $FlowFixMe nullcheck sideEffects
         assert.strictEqual(bar.sideEffects, false);
       });
     });
@@ -2628,6 +2659,8 @@ describe('scope hoisting', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, 123);
 
@@ -2675,13 +2708,15 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, 123);
 
           assert.deepStrictEqual(
             new Set(
               bundleEvent.bundleGraph.getUsedSymbols(
-                findAsset(bundleEvent.bundleGraph, 'b.js'),
+                findAssetOrThrow(bundleEvent.bundleGraph, 'b.js'),
               ),
             ),
             new Set(['foo']),
@@ -2713,6 +2748,8 @@ describe('scope hoisting', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [123]);
 
@@ -2723,13 +2760,15 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [123, 789]);
 
           assert.deepStrictEqual(
             new Set(
               bundleEvent.bundleGraph.getUsedSymbols(
-                findAsset(bundleEvent.bundleGraph, 'c.js'),
+                findAssetOrThrow(bundleEvent.bundleGraph, 'c.js'),
               ),
             ),
             new Set(['c']),
@@ -2742,6 +2781,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [123]);
 
@@ -2773,6 +2814,8 @@ describe('scope hoisting', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [123]);
 
@@ -2790,6 +2833,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [
             123,
@@ -2818,6 +2863,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [123]);
 
@@ -2854,6 +2901,8 @@ describe('scope hoisting', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [
             789,
@@ -2881,6 +2930,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [
             123,
@@ -2909,6 +2960,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, [
             789,
@@ -2955,6 +3008,8 @@ describe('scope hoisting', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, 123);
 
@@ -2973,6 +3028,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, 1);
 
@@ -2991,6 +3048,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           output = await run(bundleEvent.bundleGraph);
           assert.deepEqual(output, 123);
 
@@ -3030,6 +3089,8 @@ describe('scope hoisting', function () {
         try {
           let bundleEvent = await getNextBuild(b);
           assert(bundleEvent.type === 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           let res = await run(
             bundleEvent.bundleGraph,
             {output: null},
@@ -3040,7 +3101,7 @@ describe('scope hoisting', function () {
           assert.deepStrictEqual(
             new Set(
               bundleEvent.bundleGraph.getUsedSymbols(
-                findAsset(bundleEvent.bundleGraph, 'themeConstants.js'),
+                findAssetOrThrow(bundleEvent.bundleGraph, 'themeConstants.js'),
               ),
             ),
             new Set(['gridSize']),
@@ -3054,6 +3115,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           res = await run(
             bundleEvent.bundleGraph,
             {output: null},
@@ -3067,7 +3130,7 @@ describe('scope hoisting', function () {
           assert.deepStrictEqual(
             new Set(
               bundleEvent.bundleGraph.getUsedSymbols(
-                findAsset(bundleEvent.bundleGraph, 'themeConstants.js'),
+                findAssetOrThrow(bundleEvent.bundleGraph, 'themeConstants.js'),
               ),
             ),
             new Set(['borderRadius', 'gridSize']),
@@ -3082,6 +3145,8 @@ describe('scope hoisting', function () {
 
           bundleEvent = await getNextBuild(b);
           assert.strictEqual(bundleEvent.type, 'buildSuccess');
+          if (!bundleEvent.bundleGraph) return assert(false);
+
           res = await run(
             bundleEvent.bundleGraph,
             {output: null},
@@ -3092,12 +3157,12 @@ describe('scope hoisting', function () {
           assert.deepStrictEqual(
             new Set(
               bundleEvent.bundleGraph.getUsedSymbols(
-                findAsset(bundleEvent.bundleGraph, 'themeConstants.js'),
+                findAssetOrThrow(bundleEvent.bundleGraph, 'themeConstants.js'),
               ),
             ),
             new Set(['gridSize']),
           );
-          assert(!findAsset(bundleEvent.bundleGraph, 'themeColors.js'));
+          assert(!findAssetOrThrow(bundleEvent.bundleGraph, 'themeColors.js'));
         } finally {
           await subscription.unsubscribe();
         }
@@ -3217,6 +3282,7 @@ describe('scope hoisting', function () {
         'integration/scope-hoisting/es6/import-local-assign/named.js',
       );
 
+      // $FlowFixMe missing assert.rejects
       await assert.rejects(() => bundle(source), {
         name: 'BuildError',
         message: 'Assignment to an import specifier is not allowed',
@@ -3265,6 +3331,7 @@ describe('scope hoisting', function () {
         'integration/scope-hoisting/es6/import-local-assign/default.js',
       );
 
+      // $FlowFixMe missing assert.rejects
       await assert.rejects(() => bundle(source), {
         name: 'BuildError',
         message: 'Assignment to an import specifier is not allowed',
@@ -3315,6 +3382,7 @@ describe('scope hoisting', function () {
           'integration/scope-hoisting/es6/import-local-assign/namespace.js',
         );
 
+        // $FlowFixMe missing assert.rejects
         await assert.rejects(() => bundle(source), {
           name: 'BuildError',
           message: 'Assignment to an import specifier is not allowed',
@@ -3366,6 +3434,7 @@ describe('scope hoisting', function () {
           'integration/scope-hoisting/es6/import-local-assign/destructure-assign.js',
         );
 
+        // $FlowFixMe missing assert.rejects
         await assert.rejects(() => bundle(source), {
           name: 'BuildError',
           message: 'Assignment to an import specifier is not allowed',
@@ -3417,6 +3486,7 @@ describe('scope hoisting', function () {
           'integration/scope-hoisting/es6/import-local-assign/multiple.js',
         );
 
+        // $FlowFixMe missing assert.rejects
         await assert.rejects(() => bundle(source), {
           name: 'BuildError',
           message: 'Assignment to an import specifier is not allowed',
@@ -4171,14 +4241,14 @@ describe('scope hoisting', function () {
         'utf8',
       );
 
-      assert(contents.split('f1_var').length - 1, 1);
-      assert(contents.split('f2_var').length - 1, 1);
-      assert(contents.split('f3_var').length - 1, 1);
-      assert(contents.split('f4_var').length - 1, 1);
-      assert(contents.split('c1_var').length - 1, 1);
-      assert(contents.split('c2_var').length - 1, 1);
-      assert(contents.split('BigIntSupported').length - 1, 4);
-      assert(contents.split('inner_let').length - 1, 2);
+      assert(contents.split('f1_var').length - 1, `${1}`);
+      assert(contents.split('f2_var').length - 1, `${1}`);
+      assert(contents.split('f3_var').length - 1, `${1}`);
+      assert(contents.split('f4_var').length - 1, `${1}`);
+      assert(contents.split('c1_var').length - 1, `${1}`);
+      assert(contents.split('c2_var').length - 1, `${1}`);
+      assert(contents.split('BigIntSupported').length - 1, `${4}`);
+      assert(contents.split('inner_let').length - 1, `${2}`);
 
       let output = await run(b);
       assert.equal(output, true);
@@ -4368,6 +4438,7 @@ describe('scope hoisting', function () {
       );
 
       let entryAsset = b.getBundles()[0].getMainEntry();
+      if (!entryAsset) return assert(false);
 
       // TODO: this test doesn't currently work in older browsers since babel
       // replaces the typeof calls before we can get to them.
@@ -4388,6 +4459,8 @@ describe('scope hoisting', function () {
         __dirname,
         '/integration/scope-hoisting/commonjs/require-resolve/a.js',
       );
+
+      // $FlowFixMe missing assert.rejects
       await assert.rejects(() => bundle(source), {
         name: 'BuildError',
         message,
@@ -4914,6 +4987,7 @@ describe('scope hoisting', function () {
       let obj = {
         test: 2,
       };
+      // $FlowFixMe missing default
       obj.default = obj;
       assert.deepEqual(output.default, obj);
     });
@@ -5484,6 +5558,7 @@ describe('scope hoisting', function () {
     );
 
     let mainBundle = b.getBundles().find((b) => b.name === 'index.js');
+    // $FlowFixMe nullcheck filePath
     let contents = await outputFS.readFile(mainBundle.filePath, 'utf8');
     // We wrap for other reasons now, so this is broken
     assert(!contents.includes(`if (parcelRequire == null) {`));
@@ -5504,15 +5579,19 @@ describe('scope hoisting', function () {
       .getBundles()
       .sort((a, b) => b.stats.size - a.stats.size)
       .find((b) => b.name !== 'index.js');
+    // $FlowFixMe nullcheck filePath
     let contents = await outputFS.readFile(sharedBundle.filePath, 'utf8');
     assert(contents.includes(`if (parcelRequire == null) {`));
 
     let workerBundle = b
       .getBundles()
       .find((b) => b.name.startsWith('worker-b'));
+
+    // $FlowFixMe nullcheck filePath
     contents = await outputFS.readFile(workerBundle.filePath, 'utf8');
     assert(
       contents.includes(
+        // $FlowFixMe nullcheck filePath
         `importScripts("./${path.basename(sharedBundle.filePath)}")`,
       ),
     );
@@ -5854,6 +5933,8 @@ describe('scope hoisting', function () {
 
     let bundleEvent = await getNextBuild(b);
     assert(bundleEvent.type === 'buildSuccess');
+    if (!bundleEvent.bundleGraph) return assert(false);
+
     let output = await run(bundleEvent.bundleGraph);
     assert.deepEqual(output, 'foo');
 
@@ -5865,6 +5946,8 @@ describe('scope hoisting', function () {
 
     bundleEvent = await getNextBuild(b);
     assert(bundleEvent.type === 'buildSuccess');
+    if (!bundleEvent.bundleGraph) return assert(false);
+
     output = await run(bundleEvent.bundleGraph);
     assert.deepEqual(output, 'foobar');
 
@@ -6064,6 +6147,7 @@ describe('scope hoisting', function () {
       let bundleHashDelayFoo = b
         .getBundles()
         .find((b) => b.filePath.endsWith('.js') && b.filePath.includes('index'))
+        // $FlowFixMe nullcheck filePath
         .filePath.split('.')[1];
 
       let slowBarFS = new Proxy(overlayFS, waitHandler('bar.js', 'foo.js'));
@@ -6078,6 +6162,7 @@ describe('scope hoisting', function () {
       let bundleHashDelayBar = b2
         .getBundles()
         .find((b) => b.filePath.endsWith('.js') && b.filePath.includes('index'))
+        // $FlowFixMe nullcheck filePath
         .filePath.split('.')[1];
 
       assert.strictEqual(bundleHashDelayFoo, bundleHashDelayBar);
@@ -6149,6 +6234,7 @@ describe('scope hoisting', function () {
     );
 
     let contents = await outputFS.readFile(
+      // $FlowFixMe nullcheck filePath
       b.getBundles().find((b) => /index.*\.js/.test(b.filePath)).filePath,
       'utf8',
     );
@@ -6289,6 +6375,7 @@ describe('scope hoisting', function () {
     try {
       await run(b);
     } catch (e) {
+      // $FlowFixMe missing assert.fail
       assert.fail('Expected the empty bundle to still run');
     }
   });

--- a/packages/core/integration-tests/test/svg-react.js
+++ b/packages/core/integration-tests/test/svg-react.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {bundle, describe, it, outputFS} from '@atlaspack/test-utils';
 import path from 'path';

--- a/packages/core/integration-tests/test/svg.js
+++ b/packages/core/integration-tests/test/svg.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {
   assertBundles,
@@ -53,7 +54,7 @@ describe('svg', function () {
     ]);
 
     let file = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'svg').filePath,
+      b.getBundles().find((b) => b.type === 'svg')?.filePath || '',
       'utf-8',
     );
     assert(file.includes('<a href="/other1.html">'));
@@ -61,14 +62,16 @@ describe('svg', function () {
     assert(
       file.includes(
         `<use xlink:href="/${path.basename(
-          b.getBundles().find((b) => b.name.startsWith('square')).filePath,
+          b.getBundles().find((b) => b.name.startsWith('square'))?.filePath ||
+            '',
         )}#square"`,
       ),
     );
     assert(
       file.includes(
         `fill="url('/${path.basename(
-          b.getBundles().find((b) => b.name.startsWith('gradient')).filePath,
+          b.getBundles().find((b) => b.name.startsWith('gradient'))?.filePath ||
+            '',
         )}#myGradient')"`,
       ),
     );
@@ -78,7 +81,7 @@ describe('svg', function () {
           b
             .getBundles()
             .find((b) => b.type === 'js' && b.env.sourceType === 'script')
-            .filePath,
+            ?.filePath || '',
         )}"`,
       ),
     );
@@ -88,14 +91,14 @@ describe('svg', function () {
           b
             .getBundles()
             .find((b) => b.type === 'js' && b.env.sourceType === 'module')
-            .filePath,
+            ?.filePath || '',
         )}"`,
       ),
     );
     assert(
       file.includes(
         `<?xml-stylesheet href="/${path.basename(
-          b.getBundles().find((b) => b.type === 'css').filePath,
+          b.getBundles().find((b) => b.type === 'css')?.filePath || '',
         )}"?>`,
       ),
     );
@@ -109,7 +112,7 @@ describe('svg', function () {
     });
 
     let file = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'svg').filePath,
+      b.getBundles().find((b) => b.type === 'svg')?.filePath || '',
       'utf-8',
     );
     assert(!file.includes('comment'));
@@ -126,7 +129,7 @@ describe('svg', function () {
     );
 
     let file = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'svg').filePath,
+      b.getBundles().find((b) => b.type === 'svg')?.filePath || '',
       'utf-8',
     );
     assert(!file.includes('inkscape'));
@@ -156,7 +159,7 @@ describe('svg', function () {
       ]);
 
       let file = await outputFS.readFile(
-        b.getBundles().find((b) => b.type === 'svg').filePath,
+        b.getBundles().find((b) => b.type === 'svg')?.filePath || '',
         'utf-8',
       );
 
@@ -200,7 +203,8 @@ describe('svg', function () {
     assert(
       svg.includes(
         `"fill: url(&quot;${path.basename(
-          b.getBundles().find((b) => b.name.startsWith('gradient')).filePath,
+          b.getBundles().find((b) => b.name.startsWith('gradient'))?.filePath ||
+            '',
         )}#myGradient&quot;)`,
       ),
     );

--- a/packages/core/integration-tests/test/symbol-propagation.js
+++ b/packages/core/integration-tests/test/symbol-propagation.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -24,6 +25,7 @@ describe.v2('symbol propagation', () => {
       shouldDisableCache: false,
     });
 
+    // $FlowFixMe
     await assert.rejects(() => b.run(), {
       message: `Failed to resolve './missing.js' from './broken.js'`,
     });

--- a/packages/core/integration-tests/test/tailwind-tests.js
+++ b/packages/core/integration-tests/test/tailwind-tests.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {bundle, describe, it, outputFS} from '@atlaspack/test-utils';
@@ -8,7 +9,7 @@ describe.v2('tailwind', function () {
     let b = await bundle(path.join(fixture, 'index.html'));
 
     let css = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'css').filePath,
+      b.getBundles().find((b) => b.type === 'css')?.filePath || '',
       'utf8',
     );
     assert(css.includes('.p-2'));

--- a/packages/core/integration-tests/test/toml.js
+++ b/packages/core/integration-tests/test/toml.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {

--- a/packages/core/integration-tests/test/ts-types.js
+++ b/packages/core/integration-tests/test/ts-types.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -333,6 +334,7 @@ describe.v2('typescript types', function () {
     let message = md`Return type of exported function has or is using name 'Snapshot' from external module "${normalizeSeparators(
       path.join(__dirname, '/integration/ts-types/error/file2'),
     )}" but cannot be named.`;
+    // $FlowFixMe
     await assert.rejects(
       () =>
         bundle(path.join(__dirname, '/integration/ts-types/error/index.ts')),

--- a/packages/core/integration-tests/test/ts-validation.js
+++ b/packages/core/integration-tests/test/ts-validation.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -93,6 +94,8 @@ describe.v2('ts-validator', function () {
     });
     subscription = await b.watch();
     let buildEvent = await getNextBuild(b);
+    if (!buildEvent.diagnostics) return assert(false);
+
     assert.equal(buildEvent.type, 'buildFailure');
     assert.equal(buildEvent.diagnostics.length, 1);
     assert.equal(
@@ -106,6 +109,8 @@ describe.v2('ts-validator', function () {
     );
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
+
     let output = await run(buildEvent.bundleGraph);
     assert.equal(output.message, 'The type error is fixed!');
 
@@ -115,6 +120,8 @@ describe.v2('ts-validator', function () {
     );
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildFailure');
+    if (!buildEvent.diagnostics) return assert(false);
+
     assert.equal(buildEvent.diagnostics.length, 1);
     assert.equal(
       buildEvent.diagnostics[0].message,
@@ -146,6 +153,8 @@ describe.v2('ts-validator', function () {
 
     let buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
+
     let output = await run(buildEvent.bundleGraph);
     assert.equal(output.output, 'My Message!');
 
@@ -162,6 +171,8 @@ describe.v2('ts-validator', function () {
 
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
+
     output = await run(buildEvent.bundleGraph);
     assert.equal(output.output, 123456);
   });
@@ -190,6 +201,8 @@ describe.v2('ts-validator', function () {
 
     let buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildFailure');
+    if (!buildEvent.diagnostics) return assert(false);
+
     assert.equal(buildEvent.diagnostics.length, 2);
     assert.equal(
       buildEvent.diagnostics[1].message,
@@ -209,6 +222,8 @@ describe.v2('ts-validator', function () {
 
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildFailure');
+    if (!buildEvent.diagnostics) return assert(false);
+
     assert.equal(buildEvent.diagnostics.length, 1);
     assert.equal(
       buildEvent.diagnostics[0].message,
@@ -240,6 +255,8 @@ describe.v2('ts-validator', function () {
 
     let buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildSuccess');
+    if (!buildEvent.bundleGraph) return assert(false);
+
     let output = await run(buildEvent.bundleGraph);
     assert.equal(output.output, 'My Message!');
 
@@ -250,6 +267,8 @@ describe.v2('ts-validator', function () {
 
     buildEvent = await getNextBuild(b);
     assert.equal(buildEvent.type, 'buildFailure');
+    if (!buildEvent.diagnostics) return assert(false);
+
     assert.equal(buildEvent.diagnostics.length, 1);
     assert.equal(
       buildEvent.diagnostics[0].message,

--- a/packages/core/integration-tests/test/wasm.js
+++ b/packages/core/integration-tests/test/wasm.js
@@ -1,13 +1,11 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
-import {
-  assertBundleTree,
-  bundle,
-  deferred,
-  describe,
-  it,
-  run,
-} from '@atlaspack/test-utils';
+import {assertBundles, bundle, describe, it, run} from '@atlaspack/test-utils';
+
+function deferred() {
+  throw new Error('stub');
+}
 
 describe.skip('wasm', function () {
   if (typeof WebAssembly === 'undefined') {
@@ -19,30 +17,33 @@ describe.skip('wasm', function () {
       it('should preload a wasm file for a sync require', async function () {
         let b = await bundle(
           path.join(__dirname, '/integration/wasm-sync/index.js'),
+          // $FlowFixMe
           {
             target,
           },
         );
 
-        await assertBundleTree(b, {
-          name: 'index.js',
-          assets: [
-            'index.js',
-            'bundle-loader.js',
-            'bundle-url.js',
-            'wasm-loader.js',
-          ],
-          childBundles: [
-            {
-              type: 'wasm',
-              assets: ['add.wasm'],
-              childBundles: [],
-            },
-            {
-              type: 'map',
-            },
-          ],
-        });
+        await assertBundles(b, [
+          {
+            name: 'index.js',
+            assets: [
+              'index.js',
+              'bundle-loader.js',
+              'bundle-url.js',
+              'wasm-loader.js',
+            ],
+            childBundles: [
+              {
+                type: 'wasm',
+                assets: ['add.wasm'],
+                childBundles: [],
+              },
+              {
+                type: 'map',
+              },
+            ],
+          },
+        ]);
 
         let promise = deferred();
         await run(b, {output: promise.resolve}, {require: false});
@@ -52,30 +53,33 @@ describe.skip('wasm', function () {
       it('should load a wasm file asynchronously with dynamic import', async function () {
         let b = await bundle(
           path.join(__dirname, '/integration/wasm-async/index.js'),
+          // $FlowFixMe
           {
             target,
           },
         );
 
-        await assertBundleTree(b, {
-          name: 'index.js',
-          assets: [
-            'index.js',
-            'bundle-loader.js',
-            'bundle-url.js',
-            'wasm-loader.js',
-          ],
-          childBundles: [
-            {
-              type: 'wasm',
-              assets: ['add.wasm'],
-              childBundles: [],
-            },
-            {
-              type: 'map',
-            },
-          ],
-        });
+        await assertBundles(b, [
+          {
+            name: 'index.js',
+            assets: [
+              'index.js',
+              'bundle-loader.js',
+              'bundle-url.js',
+              'wasm-loader.js',
+            ],
+            childBundles: [
+              {
+                type: 'wasm',
+                assets: ['add.wasm'],
+                childBundles: [],
+              },
+              {
+                type: 'map',
+              },
+            ],
+          },
+        ]);
 
         var res = await run(b);
         assert.equal(await res, 5);
@@ -84,40 +88,43 @@ describe.skip('wasm', function () {
       it('should load a wasm file in parallel with a dynamic JS import', async function () {
         let b = await bundle(
           path.join(__dirname, '/integration/wasm-dynamic/index.js'),
+          // $FlowFixMe
           {
             target,
           },
         );
 
-        await assertBundleTree(b, {
-          name: 'index.js',
-          assets: [
-            'index.js',
-            'bundle-loader.js',
-            'bundle-url.js',
-            'js-loader.js',
-            'wasm-loader.js',
-          ],
-          childBundles: [
-            {
-              type: 'js',
-              assets: ['dynamic.js'],
-              childBundles: [
-                {
-                  type: 'wasm',
-                  assets: ['add.wasm'],
-                  childBundles: [],
-                },
-                {
-                  type: 'map',
-                },
-              ],
-            },
-            {
-              type: 'map',
-            },
-          ],
-        });
+        await assertBundles(b, [
+          {
+            name: 'index.js',
+            assets: [
+              'index.js',
+              'bundle-loader.js',
+              'bundle-url.js',
+              'js-loader.js',
+              'wasm-loader.js',
+            ],
+            childBundles: [
+              {
+                type: 'js',
+                assets: ['dynamic.js'],
+                childBundles: [
+                  {
+                    type: 'wasm',
+                    assets: ['add.wasm'],
+                    childBundles: [],
+                  },
+                  {
+                    type: 'map',
+                  },
+                ],
+              },
+              {
+                type: 'map',
+              },
+            ],
+          },
+        ]);
 
         var res = await run(b);
         assert.equal(await res, 5);

--- a/packages/core/integration-tests/test/webextension.js
+++ b/packages/core/integration-tests/test/webextension.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -53,7 +54,7 @@ describe.v2('webextension', function () {
     );
     const manifest = JSON.parse(
       await outputFS.readFile(
-        b.getBundles().find((b) => b.name == 'manifest.json').filePath,
+        b.getBundles().find((b) => b.name == 'manifest.json')?.filePath || '',
         'utf8',
       ),
     );
@@ -101,7 +102,7 @@ describe.v2('webextension', function () {
     ]);
     const manifest = JSON.parse(
       await outputFS.readFile(
-        b.getBundles().find((b) => b.name == 'manifest.json').filePath,
+        b.getBundles().find((b) => b.name == 'manifest.json')?.filePath || '',
         'utf8',
       ),
     );

--- a/packages/core/integration-tests/test/webmanifest.js
+++ b/packages/core/integration-tests/test/webmanifest.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -44,7 +45,7 @@ describe.v2('webmanifest', function () {
     ]);
 
     const manifest = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'webmanifest').filePath,
+      b.getBundles().find((b) => b.type === 'webmanifest')?.filePath || '',
       'utf8',
     );
     assert(/screenshot\.[0-9a-f]+\.png/.test(manifest));
@@ -86,7 +87,7 @@ describe.v2('webmanifest', function () {
     ]);
 
     const manifest = await outputFS.readFile(
-      b.getBundles().find((b) => b.type === 'webmanifest').filePath,
+      b.getBundles().find((b) => b.type === 'webmanifest')?.filePath || '',
       'utf8',
     );
     assert(/screenshot\.[0-9a-f]+\.png/.test(manifest));
@@ -102,6 +103,7 @@ describe.v2('webmanifest', function () {
     );
     let manifest = await inputFS.readFileSync(manifestPath, 'utf8');
 
+    // $FlowFixMe
     await assert.rejects(
       () =>
         bundle(
@@ -214,6 +216,7 @@ describe.v2('webmanifest', function () {
 
     let message = md`Failed to resolve 'icon.png' from '${manifestPathRelative}'`;
 
+    // $FlowFixMe
     await assert.rejects(
       () =>
         bundle(

--- a/packages/core/integration-tests/test/worklets.js
+++ b/packages/core/integration-tests/test/worklets.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -69,7 +70,7 @@ describe('atlaspack', function () {
         },
       },
     });
-    assert(/^http:\/\/localhost\/worklet\.[0-9a-f]+\.js$/.test(url));
+    assert(/^http:\/\/localhost\/worklet\.[0-9a-f]+\.js$/.test(url || ''));
 
     let name;
     await runBundle(
@@ -115,7 +116,7 @@ describe('atlaspack', function () {
         },
       },
     });
-    assert(/^http:\/\/localhost\/worklet\.[0-9a-f]+\.js$/.test(url));
+    assert(/^http:\/\/localhost\/worklet\.[0-9a-f]+\.js$/.test(url || ''));
 
     let name;
     await runBundle(

--- a/packages/core/integration-tests/test/xml.js
+++ b/packages/core/integration-tests/test/xml.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import path from 'path';
 import {
@@ -43,14 +44,14 @@ describe.v2('xml', function () {
     assert(
       contents.includes(
         `<?xml-stylesheet type="text/xsl" href="http://example.org/${path.basename(
-          b.getBundles().find((b) => b.type === 'xsl').filePath,
+          b.getBundles().find((b) => b.type === 'xsl')?.filePath || '',
         )}"?>`,
       ),
     );
     assert(
       contents.includes(
         `<img src="http://example.org/${path.basename(
-          b.getBundles().find((b) => b.type === 'png').filePath,
+          b.getBundles().find((b) => b.type === 'png')?.filePath || '',
         )}"/>`,
       ),
     );
@@ -94,14 +95,14 @@ describe.v2('xml', function () {
     assert(
       contents.includes(
         `<?xml-stylesheet type="text/xsl" href="http://example.org/${path.basename(
-          b.getBundles().find((b) => b.type === 'xsl').filePath,
+          b.getBundles().find((b) => b.type === 'xsl')?.filePath || '',
         )}"?>`,
       ),
     );
     assert(
       contents.includes(
         `<img src="http://example.org/${path.basename(
-          b.getBundles().find((b) => b.type === 'png').filePath,
+          b.getBundles().find((b) => b.type === 'png')?.filePath || '',
         )}"/>`,
       ),
     );
@@ -144,7 +145,7 @@ describe.v2('xml', function () {
     assert(
       contents.includes(
         `&lt;img src="http://example.org/${path.basename(
-          b.getBundles().find((b) => b.type === 'png').filePath,
+          b.getBundles().find((b) => b.type === 'png')?.filePath || '',
         )}">`,
       ),
     );

--- a/packages/core/integration-tests/test/yaml.js
+++ b/packages/core/integration-tests/test/yaml.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -445,11 +445,14 @@ export async function runBundles(
 
 export async function runBundle(
   bundleGraph: BundleGraph<PackagedBundle>,
-  bundle: PackagedBundle,
+  bundle: ?PackagedBundle,
   globals: mixed,
   opts: RunOpts = {},
   externalModules?: ExternalModules,
 ): Promise<mixed> {
+  if (!bundle) {
+    throw new Error('No bundle supplied');
+  }
   if (bundle.type === 'html') {
     let code = await overlayFS.readFile(nullthrows(bundle.filePath), 'utf8');
     let ast = postHtmlParse(code, {

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -163,6 +163,17 @@ export function findAsset(
   });
 }
 
+export function findAssetOrThrow(
+  bundleGraph: BundleGraph<PackagedBundle>,
+  assetFileName: string,
+): Asset {
+  let asset = findAsset(bundleGraph, assetFileName);
+  if (!asset) {
+    throw new Error('No Asset Found');
+  }
+  return asset;
+}
+
 export function findDependency(
   bundleGraph: BundleGraph<PackagedBundle>,
   assetFileName: string,

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -556,14 +556,16 @@ export type ChildBundle = {|
   childBundles?: Array<ChildBundle>,
 |};
 
+export type BundleAssert = {|
+  name?: string | RegExp,
+  type?: string,
+  assets: Array<string>,
+  childBundles?: Array<ChildBundle>,
+|};
+
 export function assertBundles(
   bundleGraph: BundleGraph<PackagedBundle>,
-  expectedBundles: Array<{|
-    name?: string | RegExp,
-    type?: string,
-    assets: Array<string>,
-    childBundles?: Array<ChildBundle>,
-  |}>,
+  expectedBundles: Array<BundleAssert>,
 ) {
   let actualBundles = [];
   const byAlphabet = (a, b) => (a.toLowerCase() < b.toLowerCase() ? -1 : 1);

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -550,12 +550,19 @@ export function expectBundles(
   expect(bundleData).toEqual(expectedBundles);
 }
 
+export type ChildBundle = {|
+  type?: string,
+  assets?: Array<string>,
+  childBundles?: Array<ChildBundle>,
+|};
+
 export function assertBundles(
   bundleGraph: BundleGraph<PackagedBundle>,
   expectedBundles: Array<{|
     name?: string | RegExp,
     type?: string,
     assets: Array<string>,
+    childBundles?: Array<ChildBundle>,
   |}>,
 ) {
   let actualBundles = [];

--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -1,9 +1,11 @@
 const parcelBabelPreset = require('@atlaspack/babel-preset');
 const path = require('path');
+const fs = require('fs');
 
 require('@babel/register')({
   cwd: path.join(__dirname, '../../..'),
   ignore: [
+    // Exclude node_modules
     (filepath) => filepath.includes(path.sep + 'node_modules' + path.sep),
     // Don't run babel over ignore integration tests fixtures.
     // These may include relative babel plugins, and running babel on those causes
@@ -11,6 +13,9 @@ require('@babel/register')({
     (filepath) =>
       filepath.endsWith('.js') &&
       filepath.includes('/core/integration-tests/test/integration'),
+    // Include integration tests
+    (filepath) =>
+      !fs.readFileSync(filepath, 'utf8').trim().startsWith('// @flow'),
   ],
   only: [path.join(__dirname, '../../..')],
   presets: [parcelBabelPreset],


### PR DESCRIPTION
This PR enables Flow type checking in the integration tests which will help with writing tests, migrating to typescript and ensuring tests remain in-sync with changes to the public API.