### PR TITLE
[V3] Ensure worker shutdown after asset graph is built

### DIFF
--- a/benchmarks/three-js/scripts/build.mjs
+++ b/benchmarks/three-js/scripts/build.mjs
@@ -228,9 +228,6 @@ async function main() {
     console.error(err);
   } finally {
     await rmrf(tmpDir);
-
-    // TEMP: AtlaspackV3 hangs when exiting
-    process.exit(0);
   }
 }
 

--- a/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
+++ b/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
@@ -60,7 +60,13 @@ export class AtlaspackV3 {
       },
     });
 
-    workerPool.releaseWorkers(workerIds);
+    // In the integration tests we keep the workers alive so they don't need to
+    // be re-initialized for the next test
+    if (process.env.ATLASPACK_BUILD_ENV === 'test') {
+      workerPool.releaseWorkers(workerIds);
+    } else {
+      workerPool.shutdown();
+    }
 
     if (error !== null) {
       throw new ThrowableDiagnostic({


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Ensure worker shutdown after asset graph is built. This will hopefully stop the potential build hanging we've been seeing.

## Checklist

- [x] Existing or new tests cover this change
