### PR TITLE
Cancel stale CI builds and add CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
     branches:
       - main
 
+concurrency:
+  # This causes the workflow to be cancelled if a newer commit is pushed to the
+  # pull request while it's still being built. Builds on main are not cancelled.
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -76,6 +82,7 @@ jobs:
 
   integration_tests:
     name: Integration tests (${{ matrix.version == 'v3' && 'v3, ' || '' }}${{ matrix.os }}, Node ${{ matrix.node }})
+    timeout-minutes: 35
     strategy:
       matrix:
         node: [18, 20]


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

We've seen some issues lately where integration tests are hanging for extended periods of times, hogging the agents in the pool. We've also been getting queued by running tests on stale commits when PRs are being pushed to actively.

## Changes

- Add a concurrency group so stale commits still being built will be cancelled when a newer commit is pushed
- Add a timeout (35 mins) to integration tests to ensure they don't run for extended periods if they hang

## Checklist

- [ ] Existing or new tests cover this change
