### PR TITLE
Reliability: Flow types for tests

### DIFF
--- a/packages/core/cache/test/LMDBLiteCache.test.js
+++ b/packages/core/cache/test/LMDBLiteCache.test.js
@@ -1,8 +1,9 @@
-import * as path from 'node:path';
+// @flow
+import * as path from 'path';
 import {tmpdir} from 'os';
 import {LMDBLiteCache} from '../src/index';
-import {deserialize, serialize} from 'node:v8';
-import assert from 'node:assert';
+import {deserialize, serialize} from 'v8';
+import assert from 'assert';
 
 const cacheDir = path.join(tmpdir(), 'lmdb-lite-cache-tests');
 

--- a/packages/core/codeframe/test/codeframe.test.js
+++ b/packages/core/codeframe/test/codeframe.test.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {readFileSync} from 'fs';
 import {join as joinPath} from 'path';

--- a/packages/core/core/src/Dependency.js
+++ b/packages/core/core/src/Dependency.js
@@ -57,15 +57,15 @@ export function createDependencyId({
   priority,
   packageConditions,
 }: {|
-  sourceAssetId: string | void,
+  sourceAssetId?: string | void,
   specifier: DependencySpecifier,
   env: Environment,
-  target: Target | void,
-  pipeline: ?string,
+  target?: Target | void,
+  pipeline?: ?string,
   specifierType: $Keys<typeof SpecifierType>,
-  bundleBehavior: ?IBundleBehavior,
-  priority: $Keys<typeof Priority> | void,
-  packageConditions: Array<string> | void,
+  bundleBehavior?: ?IBundleBehavior,
+  priority?: $Keys<typeof Priority> | void,
+  packageConditions?: Array<string> | void,
 |}): string {
   assert(typeof specifierType === 'string');
   assert(typeof priority === 'string' || priority == null);

--- a/packages/core/core/test/Dependency.test.js
+++ b/packages/core/core/test/Dependency.test.js
@@ -1,6 +1,8 @@
+// @flow
 import expect from 'expect';
 import {createDependencyId} from '../src/Dependency';
 import {createEnvironment} from '../src/Environment';
+import type {ProjectPath} from '../src/projectPath';
 
 describe('Dependency', () => {
   describe('createDependencyId', () => {
@@ -9,11 +11,23 @@ describe('Dependency', () => {
         specifier: 'foo',
         env: createEnvironment(),
         specifierType: 'esm',
+        bundleBehavior: undefined,
+        packageConditions: undefined,
+        pipeline: undefined,
+        priority: undefined,
+        sourceAssetId: undefined,
+        target: undefined,
       });
       let id2 = createDependencyId({
         specifier: 'foo',
         env: createEnvironment(),
         specifierType: 'esm',
+        bundleBehavior: undefined,
+        packageConditions: undefined,
+        pipeline: undefined,
+        priority: undefined,
+        sourceAssetId: undefined,
+        target: undefined,
       });
       expect(id1).toEqual(id2);
     });
@@ -25,11 +39,16 @@ describe('Dependency', () => {
         specifierType: 'esm',
         target: {
           name: 'test-1234',
-          distDir: 'dist-dir',
+          distDir: (('dist-dir': any): ProjectPath),
           env: createEnvironment(),
           publicUrl: 'public-url',
           source: '1234',
         },
+        bundleBehavior: undefined,
+        packageConditions: undefined,
+        pipeline: undefined,
+        priority: undefined,
+        sourceAssetId: undefined,
       });
       let id2 = createDependencyId({
         specifier: 'foo',
@@ -37,11 +56,16 @@ describe('Dependency', () => {
         specifierType: 'esm',
         target: {
           name: 'test-1234',
-          distDir: 'dist-dir',
+          distDir: (('dist-dir': any): ProjectPath),
           env: createEnvironment(),
           publicUrl: 'public-url',
           source: '5678', // <- this is different
         },
+        bundleBehavior: undefined,
+        packageConditions: undefined,
+        pipeline: undefined,
+        priority: undefined,
+        sourceAssetId: undefined,
       });
       expect(id1).not.toEqual(id2);
     });

--- a/packages/core/core/test/Dependency.test.js
+++ b/packages/core/core/test/Dependency.test.js
@@ -11,23 +11,11 @@ describe('Dependency', () => {
         specifier: 'foo',
         env: createEnvironment(),
         specifierType: 'esm',
-        bundleBehavior: undefined,
-        packageConditions: undefined,
-        pipeline: undefined,
-        priority: undefined,
-        sourceAssetId: undefined,
-        target: undefined,
       });
       let id2 = createDependencyId({
         specifier: 'foo',
         env: createEnvironment(),
         specifierType: 'esm',
-        bundleBehavior: undefined,
-        packageConditions: undefined,
-        pipeline: undefined,
-        priority: undefined,
-        sourceAssetId: undefined,
-        target: undefined,
       });
       expect(id1).toEqual(id2);
     });
@@ -44,11 +32,6 @@ describe('Dependency', () => {
           publicUrl: 'public-url',
           source: '1234',
         },
-        bundleBehavior: undefined,
-        packageConditions: undefined,
-        pipeline: undefined,
-        priority: undefined,
-        sourceAssetId: undefined,
       });
       let id2 = createDependencyId({
         specifier: 'foo',
@@ -61,11 +44,6 @@ describe('Dependency', () => {
           publicUrl: 'public-url',
           source: '5678', // <- this is different
         },
-        bundleBehavior: undefined,
-        packageConditions: undefined,
-        pipeline: undefined,
-        priority: undefined,
-        sourceAssetId: undefined,
       });
       expect(id1).not.toEqual(id2);
     });

--- a/packages/core/core/test/requests/AssetGraphRequestRust.test.js
+++ b/packages/core/core/test/requests/AssetGraphRequestRust.test.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {getAssetGraph} from '../../src/requests/AssetGraphRequestRust';
 
@@ -8,8 +9,14 @@ describe('AssetGraphRequestRust -> getAssetGraph', function () {
     const indexAsset = assetGraph.getNodeByContentKey('79c128d4f549c408');
     const libraryDep = assetGraph.getNodeByContentKey('cfe74f65a41af1a7');
 
-    assert(indexAsset?.type === 'asset');
-    assert(libraryDep?.type === 'dependency');
+    if (!indexAsset) return assert(false);
+    if (!libraryDep) return assert(false);
+
+    assert(indexAsset.type === 'asset');
+    assert(libraryDep.type === 'dependency');
+
+    if (indexAsset.type !== 'asset') return assert(false);
+    if (libraryDep.type !== 'dependency') return assert(false);
 
     assert.equal(indexAsset.value.filePath, '/index.ts');
     assert.equal(libraryDep.value.specifier, './library');

--- a/packages/core/core/test/requests/AssetGraphRequestRust.test.js
+++ b/packages/core/core/test/requests/AssetGraphRequestRust.test.js
@@ -9,14 +9,8 @@ describe('AssetGraphRequestRust -> getAssetGraph', function () {
     const indexAsset = assetGraph.getNodeByContentKey('79c128d4f549c408');
     const libraryDep = assetGraph.getNodeByContentKey('cfe74f65a41af1a7');
 
-    if (!indexAsset) return assert(false);
-    if (!libraryDep) return assert(false);
-
-    assert(indexAsset.type === 'asset');
-    assert(libraryDep.type === 'dependency');
-
-    if (indexAsset.type !== 'asset') return assert(false);
-    if (libraryDep.type !== 'dependency') return assert(false);
+    if (indexAsset?.type !== 'asset') return assert(false);
+    if (libraryDep?.type !== 'dependency') return assert(false);
 
     assert.equal(indexAsset.value.filePath, '/index.ts');
     assert.equal(libraryDep.value.specifier, './library');

--- a/packages/core/integration-tests/test/bundle-text.js
+++ b/packages/core/integration-tests/test/bundle-text.js
@@ -204,7 +204,7 @@ describe('bundle-text:', function () {
               'index.js',
               'main.js',
               ...(!scopeHoist ? ['esmodule-helpers.js'] : []),
-            ].filter(Boolean),
+            ],
           },
           {
             type: 'js',

--- a/packages/core/integration-tests/test/bundle-text.js
+++ b/packages/core/integration-tests/test/bundle-text.js
@@ -1,3 +1,4 @@
+// @flow
 import assert from 'assert';
 import {join} from 'path';
 import {
@@ -10,6 +11,7 @@ import {
   removeDistDirectory,
   run,
 } from '@atlaspack/test-utils';
+import type {InitialAtlaspackOptions} from '@atlaspack/types';
 
 describe('bundle-text:', function () {
   beforeEach(async () => {
@@ -164,7 +166,7 @@ describe('bundle-text:', function () {
     describe(`when scope hoisting is ${
       scopeHoist ? 'enabled' : 'disabled'
     }`, () => {
-      let options = scopeHoist
+      let options: InitialAtlaspackOptions = scopeHoist
         ? {
             defaultTargetOptions: {
               isLibrary: true,
@@ -172,7 +174,7 @@ describe('bundle-text:', function () {
               shouldScopeHoist: true,
             },
           }
-        : {};
+        : Object.freeze({});
 
       it('can be used with an import that points to the same asset', async function () {
         await fsFixture(overlayFS, __dirname)`
@@ -201,7 +203,7 @@ describe('bundle-text:', function () {
             assets: [
               'index.js',
               'main.js',
-              !scopeHoist && 'esmodule-helpers.js',
+              ...(!scopeHoist ? ['esmodule-helpers.js'] : []),
             ].filter(Boolean),
           },
           {


### PR DESCRIPTION
Working towards fixing the flakey integration tests. This PR adds type checking to some tests that are missing types.

**Notes:** 

Type checking only occurs on test files that are annotated with `// @flow` however this is not enforced and files not annotated can still be written with flow and will still have their types stripped by babel register. 

This leads to misleading usage of APIs and related problems.

Currently, many of the tests that are not type checked are actually using incorrect type signatures to call Atlaspack APIs making it difficult to refactor the tests to improve their reliability.

In future I will enable type checking enforcement on tests, this will help with tracing the cause of brittle tests and also help with the eventual migration to TypeScript
