### PR TITLE
Copy new TypeScript files to lib

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -28,7 +28,11 @@ const paths = {
     '!**/dev-prelude.js',
     ...IGNORED_PACKAGES,
   ],
-  packageOther: ['packages/*/*/src/**/dev-prelude.js'],
+  packageOther: [
+    'packages/*/*/src/**/dev-prelude.js',
+    // This has to have some glob syntax so that vinyl.base will be right
+    'packages/{runtimes,}/js/src/helpers/*.ts',
+  ],
   packages: 'packages/',
 };
 


### PR DESCRIPTION
When adding [domain sharding][ds], I migrated the bundle-url files to TypeScript so I would know what was going on in them.

Unfortunately this causes them to be skipped by the babel step in the gulpfile, which is [only looking for `*.js`][glob].

Adding TS into the babel compile step turned out to be a massive headache, so I've just added them to the copyOthers step.

When getting renamed later in the file, they depend on `vinyl.base` being `packages/`, so I've had to add some kind of glob syntax in that second path segment.

[glob]: https://github.com/atlassian-labs/atlaspack/blob/fix-missing-ts-files/gulpfile.js#L27
[ds]: https://github.com/atlassian-labs/atlaspack/pull/268