### PR TITLE
Switch to using a global property for domain sharding

### DIFF
--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -828,13 +828,7 @@ function getAbsoluteUrlExpr(
   }
 
   if (shardingConfig) {
-    const bundleUrlArgs = [
-      `'${toBundle.name}'`,
-      'Boolean(window.__ATLASPACK_ENABLE_DOMAIN_SHARDS)',
-      shardingConfig.maxShards,
-    ].join(', ');
-
-    return `require('./helpers/bundle-url-shards').getShardedBundleURL(${bundleUrlArgs}) + ${relativePathExpr}`;
+    return `require('./helpers/bundle-url-shards').getShardedBundleURL('${toBundle.name}', ${shardingConfig.maxShards}) + ${relativePathExpr}`;
   }
 
   return `require('./helpers/bundle-url').getBundleURL('${fromBundle.publicId}') + ${relativePathExpr}`;

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -76,7 +76,6 @@ type JSRuntimeConfig = {|
   splitManifestThreshold: number,
   domainSharding?: {|
     maxShards: number,
-    cookieName: string,
   |},
 |};
 
@@ -96,12 +95,9 @@ const CONFIG_SCHEMA: SchemaEntity = {
         maxShards: {
           type: 'number',
         },
-        cookieName: {
-          type: 'string',
-        },
       },
       additionalProperties: false,
-      required: ['maxShards', 'cookieName'],
+      required: ['maxShards'],
     },
   },
   additionalProperties: false,
@@ -834,8 +830,7 @@ function getAbsoluteUrlExpr(
   if (shardingConfig) {
     const bundleUrlArgs = [
       `'${toBundle.name}'`,
-      `'${shardingConfig.cookieName}'`,
-      'document.cookie',
+      'Boolean(window.__ATLASPACK_ENABLE_DOMAIN_SHARDS)',
       shardingConfig.maxShards,
     ].join(', ');
 

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -4,8 +4,7 @@ const bundleURL: Record<string, string> = {};
 
 function getShardedBundleURL(
   bundleName: string,
-  cookieName: string,
-  cookieString: string,
+  enableSharding: boolean,
   maxShards: number,
   inputError?: string,
 ): string {
@@ -29,8 +28,9 @@ function getShardedBundleURL(
     const stackUrl = matches[1];
     const baseUrl = getBaseURL(stackUrl);
 
-    // If the cookie doesn't exist then we don't need to shard
-    if (cookieString.indexOf(cookieName) === -1) {
+    // Only shard the domain if the window key has been set
+    if (!enableSharding) {
+      bundleURL[bundleName] = baseUrl;
       return baseUrl;
     }
 

--- a/packages/runtimes/js/src/helpers/bundle-url-shards.ts
+++ b/packages/runtimes/js/src/helpers/bundle-url-shards.ts
@@ -4,7 +4,6 @@ const bundleURL: Record<string, string> = {};
 
 function getShardedBundleURL(
   bundleName: string,
-  enableSharding: boolean,
   maxShards: number,
   inputError?: string,
 ): string {
@@ -28,8 +27,8 @@ function getShardedBundleURL(
     const stackUrl = matches[1];
     const baseUrl = getBaseURL(stackUrl);
 
-    // Only shard the domain if the window key has been set
-    if (!enableSharding) {
+    // Global variable is set by SSR servers when HTTP1.1 traffic is detected
+    if (!Boolean(globalThis.__ATLASPACK_ENABLE_DOMAIN_SHARDS)) {
       bundleURL[bundleName] = baseUrl;
       return baseUrl;
     }

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -4,8 +4,6 @@ import {fsFixture, overlayFS, bundle} from '@atlaspack/test-utils';
 
 import {getShardedBundleURL} from '../src/helpers/bundle-url-shards';
 
-const testingCookieName = 'DOMAIN_SHARDING_TEST';
-
 const createErrorStack = (url) => {
   // This error stack is copied from a local dev, with a bunch
   // of lines trimmed off the end so it's not unnecessarily long
@@ -34,13 +32,7 @@ describe('bundle-url-shards helper', () => {
         'https://bundle-shard.assets.example.com/assets/ParentBundle.cba321.js',
       );
 
-      const result = getShardedBundleURL(
-        testBundle,
-        testingCookieName,
-        `${testingCookieName}=1`,
-        5,
-        err,
-      );
+      const result = getShardedBundleURL(testBundle, true, 5, err);
 
       assert.equal(result, 'https://bundle-shard-0.assets.example.com/assets/');
     });
@@ -53,13 +45,7 @@ describe('bundle-url-shards helper', () => {
         'https://bundle-shard-1.assets.example.com/assets/ParentBundle.cba321.js',
       );
 
-      const result = getShardedBundleURL(
-        testBundle,
-        testingCookieName,
-        `${testingCookieName}=1`,
-        5,
-        err,
-      );
+      const result = getShardedBundleURL(testBundle, true, 5, err);
 
       assert.equal(result, 'https://bundle-shard-4.assets.example.com/assets/');
     });
@@ -72,13 +58,7 @@ describe('bundle-url-shards helper', () => {
         'https://bundle-unsharded.assets.example.com/assets/ParentBundle.cba321.js',
       );
 
-      const result = getShardedBundleURL(
-        testBundle,
-        testingCookieName,
-        `some.other.cookie=1`,
-        5,
-        err,
-      );
+      const result = getShardedBundleURL(testBundle, false, 5, err);
 
       assert.equal(
         result,
@@ -96,8 +76,7 @@ describe('bundle-url-shards helper', () => {
             "name": "bundle-sharding-test",
             "@atlaspack/runtime-js": {
               "domainSharding": {
-                "maxShards": ${maxShards},
-                "cookieName": "${testingCookieName}"
+                "maxShards": ${maxShards}
               }
             }
           }
@@ -130,7 +109,7 @@ describe('bundle-url-shards helper', () => {
       const code = await overlayFS.readFile(mainBundle.filePath, 'utf-8');
       assert.ok(
         code.includes(
-          `require("449af90f11ccd363").getShardedBundleURL('b.8575baaf.js', '${testingCookieName}', document.cookie, ${maxShards}) + "b.8575baaf.js"`,
+          `require("e73f1ec3075dec82").getShardedBundleURL('b.8575baaf.js', Boolean(window.__ATLASPACK_ENABLE_DOMAIN_SHARDS), ${maxShards}) + "b.8575baaf.js"`,
         ),
         'Expected generated code for getShardedBundleURL was not found',
       );

--- a/packages/runtimes/js/test/bundle-url-shards.test.js
+++ b/packages/runtimes/js/test/bundle-url-shards.test.js
@@ -24,15 +24,21 @@ Error
 
 describe('bundle-url-shards helper', () => {
   describe('getShardedBundleURL', () => {
-    it('should shard a URL if the cookie is present', () => {
+    beforeEach(() => {
+      delete globalThis.__ATLASPACK_ENABLE_DOMAIN_SHARDS;
+    });
+
+    it('should shard a URL if the global variable is set', () => {
       const testBundle = 'test-bundle.123abc.js';
+
+      globalThis.__ATLASPACK_ENABLE_DOMAIN_SHARDS = true;
 
       const err = new Error();
       err.stack = createErrorStack(
         'https://bundle-shard.assets.example.com/assets/ParentBundle.cba321.js',
       );
 
-      const result = getShardedBundleURL(testBundle, true, 5, err);
+      const result = getShardedBundleURL(testBundle, 5, err);
 
       assert.equal(result, 'https://bundle-shard-0.assets.example.com/assets/');
     });
@@ -40,12 +46,14 @@ describe('bundle-url-shards helper', () => {
     it('should re-shard a domain that has already been sharded', () => {
       const testBundle = 'TestBundle.1a2b3c.js';
 
+      globalThis.__ATLASPACK_ENABLE_DOMAIN_SHARDS = true;
+
       const err = new Error();
       err.stack = createErrorStack(
         'https://bundle-shard-1.assets.example.com/assets/ParentBundle.cba321.js',
       );
 
-      const result = getShardedBundleURL(testBundle, true, 5, err);
+      const result = getShardedBundleURL(testBundle, 5, err);
 
       assert.equal(result, 'https://bundle-shard-4.assets.example.com/assets/');
     });
@@ -58,7 +66,7 @@ describe('bundle-url-shards helper', () => {
         'https://bundle-unsharded.assets.example.com/assets/ParentBundle.cba321.js',
       );
 
-      const result = getShardedBundleURL(testBundle, false, 5, err);
+      const result = getShardedBundleURL(testBundle, 5, err);
 
       assert.equal(
         result,
@@ -109,7 +117,7 @@ describe('bundle-url-shards helper', () => {
       const code = await overlayFS.readFile(mainBundle.filePath, 'utf-8');
       assert.ok(
         code.includes(
-          `require("e73f1ec3075dec82").getShardedBundleURL('b.8575baaf.js', Boolean(window.__ATLASPACK_ENABLE_DOMAIN_SHARDS), ${maxShards}) + "b.8575baaf.js"`,
+          `require("e3ed71d88565db").getShardedBundleURL('b.8575baaf.js', ${maxShards}) + "b.8575baaf.js"`,
         ),
         'Expected generated code for getShardedBundleURL was not found',
       );


### PR DESCRIPTION
Originally domain sharding was set up to work by looking for the presence of some specified cookie to decide whether to shard or not, as this is what the CFE SSR server does already.

However that's a little less easy to use, and other products would prefer to use a key on the `window` object instead.

Now, the runtime looks for a boolean value in `window.__ATLASPACK_ENABLE_DOMAIN_SHARDS` as its switch.

SSR servers can inject an inline script tag at the top of the document if sharding is required.

```html
<script>
  window.__ATLASPACK_ENABLE_DOMAIN_SHARDS = true;
</script>
```

Or, if cookie based logic is still preferred
```html
<script>
  window.__ATLASPACK_ENABLE_DOMAIN_SHARDS = document.cookie.indexOf('existing.cookie.name') !== -1;
</script>
```