### PR TITLE
WIP Reliability: Enforce type checking on tests

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -3,14 +3,14 @@ const args = process.argv.slice(2);
 
 function isFileArg(file) {
   return (
-    /\.(j|t)s$/.test(file) ||
+    /\.(j|t|cj|mj|ct|mt)s$/.test(file) ||
     (fs.existsSync(file) && fs.statSync(file).isDirectory())
   );
 }
 
 const spec = args.some(isFileArg)
   ? args.filter(isFileArg)
-  : 'packages/*/!(integration-tests)/test/{*.{js,ts},**/*.{test,spec}.{js,ts}}';
+  : 'packages/*/!(integration-tests)/test/{*.{js,ts,cts,mts,cjs,mjs},**/*.{test,spec}.{js,ts,mts,cts,cjs,mjs}}';
 
 module.exports = {
   spec,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:js": "yarn test:js:unit && yarn test:integration",
     "test:js:coverage": "yarn nyc yarn test:js:unit",
     "test:js:coverage:report": "yarn nyc report --reporter=html-spa",
-    "test:js:unit": "cross-env NODE_ENV=test mocha --conditions=development --timeout 5000",
+    "test:js:unit": "cross-env NODE_ENV=test mocha --conditions=\"@atlaspack::sources\" --timeout 5000",
     "test:unit": "yarn test:js:unit && cargo test",
     "dev:release": "SKIP_PLUGIN_COMPATIBILITY_CHECK=true lerna publish -y --canary --preid dev --dist-tag=dev --exact --force-publish=* --no-git-tag-version --no-push",
     "canary:release": "SKIP_PLUGIN_COMPATIBILITY_CHECK=true lerna publish -y --canary --preid canary --dist-tag=canary --exact --force-publish=* --no-git-tag-version --no-push",

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -59,7 +59,7 @@
     "./*": "./*",
     ".": "./lib/index.js",
     "./worker": {
-      "development": "./src/worker.js",
+      "@atlaspack::sources": "./src/worker.js",
       "default": "./lib/worker.js"
     }
   },

--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/atlassian-labs/atlaspack.git"
   },
   "scripts": {
-    "test": "cross-env NODE_ENV=test ATLASPACK_BUILD_ENV=test mocha --conditions=development --experimental-vm-modules",
+    "test": "cross-env NODE_ENV=test ATLASPACK_BUILD_ENV=test mocha --conditions=\"@atlaspack::sources\" --experimental-vm-modules",
     "test-ci": "yarn test --config .mocharc.ci.json"
   },
   "devDependencies": {

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -1458,14 +1458,14 @@ describe('bundler', function () {
           {
             "extends": "@atlaspack/config-default",
             "transformers": {
-              "*.js": ["./transformer.js", "..."],
+              "*.js": ["./transformer.cjs", "..."],
             }
           }
 
-        transformer.js:
-          import { Transformer } from '@atlaspack/plugin';
+        transformer.cjs:
+          const { Transformer } = require('@atlaspack/plugin');
 
-          export default new Transformer({
+          module.exports = new Transformer({
             transform({asset}) {
               if (asset.filePath.endsWith('.html')) {
                 asset.isBundleSplittable = false;

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -6160,15 +6160,15 @@ describe.v2('cache', function () {
         .parcelrc:
           {
             "extends": "@atlaspack/config-default",
-            "bundler": "./test-bundler.js"
+            "bundler": "./test-bundler.cjs"
           }
-        test-bundler.js:
-          import {Bundler} from '@atlaspack/plugin'
-          import DefaultBundler from '@atlaspack/bundler-default'
+        test-bundler.cjs:
+          const {Bundler} = require('@atlaspack/plugin')
+          const DefaultBundler = require('@atlaspack/bundler-default').default
 
           const CONFIG = Symbol.for('parcel-plugin-config');
 
-          export default new Bundler({
+          module.exports = new Bundler({
             loadConfig({config, options}) {
               return DefaultBundler[CONFIG].loadConfig({config, options});
             },

--- a/packages/core/integration-tests/test/library-bundler.js
+++ b/packages/core/integration-tests/test/library-bundler.js
@@ -141,7 +141,7 @@ describe.v2('library bundler', function () {
         export {foo, bar} from './foo';
 
       foo.js:
-        import {css} from './macro' with {type: 'macro'};
+        import {css} from './macro.cjs' with {type: 'macro'};
         export function foo() {
           return css('.a { color: red }');
         }
@@ -150,8 +150,8 @@ describe.v2('library bundler', function () {
           return css('.b { color: pink }');
         }
 
-      macro.js:
-        export function css(content) {
+      macro.cjs:
+        module.exports.css = function css(content) {
           this.addAsset({type: 'css', content});
           return 'hi';
         }

--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -13,7 +13,7 @@ import {
   getNextBuild,
 } from '@atlaspack/test-utils';
 
-describe('macros', function () {
+describe.v2('macros', function () {
   let count = 0;
   let dir;
   beforeEach(async () => {

--- a/packages/core/integration-tests/test/macros.js
+++ b/packages/core/integration-tests/test/macros.js
@@ -13,7 +13,7 @@ import {
   getNextBuild,
 } from '@atlaspack/test-utils';
 
-describe.v2('macros', function () {
+describe('macros', function () {
   let count = 0;
   let dir;
   beforeEach(async () => {
@@ -28,12 +28,12 @@ describe.v2('macros', function () {
   it('should support named imports', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { hash } from "./macro" with { type: "macro" };
+        import { hash } from "./macro.cjs" with { type: "macro" };
         output = hash('hi');
 
-      macro.js:
-        import {hashString} from '@atlaspack/rust';
-        export function hash(s) {
+      macro.cjs:
+        const {hashString} = require('@atlaspack/rust');
+        module.exports.hash = function hash(s) {
           return hashString(s);
         }
     `;
@@ -66,12 +66,13 @@ describe.v2('macros', function () {
   it('should support default imports', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import test from "./macro.js" with { type: "macro" };
+        import test from "./macro.cjs" with { type: "macro" };
         output = test('hi');
 
-      macro.js:
-        import {hashString} from '@atlaspack/rust';
-        export default function test(s) {
+      macro.cjs:
+        const {hashString} = require('@atlaspack/rust');
+
+        module.exports = function test(s) {
           return hashString(s);
         }
     `;
@@ -88,11 +89,11 @@ describe.v2('macros', function () {
   it('should support default interop with CommonJS modules', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import test from "./macro.js" with { type: "macro" };
+        import test from "./macro.cjs" with { type: "macro" };
         output = test('hi');
 
-      macro.js:
-        import {hashString} from '@atlaspack/rust';
+      macro.cjs:
+        const {hashString} = require('@atlaspack/rust');
         module.exports = function(s) {
           return hashString(s);
         }
@@ -126,12 +127,12 @@ describe.v2('macros', function () {
   it('should support various JS value types', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test(undefined, null, true, false, 1, 0, -2, 'hi', /yo/i, [1, {test: 8}]);
 
-      macro.js:
-        import {inspect} from 'util';
-        export function test(...args) {
+      macro.cjs:
+        const {inspect} = require('util');
+        module.exports.test = function test(...args) {
           return inspect(args);
         }
     `;
@@ -162,11 +163,11 @@ describe.v2('macros', function () {
   it('should support returning various JS value types', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test();
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return [undefined, null, true, false, 1, 0, -2, 'hi', /yo/i, [1, {test: 8}]];
         }
     `;
@@ -194,11 +195,11 @@ describe.v2('macros', function () {
   it('should support evaluating expressions', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test(1 + 2, 'foo ' + 'bar', 3 + 'em', 'test'.length, 'test'['length'], 'test'[1], !true, [1, ...[2, 3]], {x: 2, ...{y: 3}}, true ? 1 : 0, typeof false, null ?? 2);
 
-      macro.js:
-        export function test(...args) {
+      macro.cjs:
+        module.exports.test = function test(...args) {
           return args;
         }
     `;
@@ -228,7 +229,7 @@ describe.v2('macros', function () {
   it('should dead code eliminate falsy branches', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
 
         if (test()) {
           console.log('bad');
@@ -236,8 +237,8 @@ describe.v2('macros', function () {
           console.log('good');
         }
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return false;
         }
     `;
@@ -255,11 +256,11 @@ describe.v2('macros', function () {
   it('should support async macros', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test();
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return Promise.resolve(2);
         }
     `;
@@ -280,11 +281,11 @@ describe.v2('macros', function () {
         output = test;
 
       node_modules/foo/index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         export default test();
 
-      node_modules/foo/macro.js:
-        export function test() {
+      node_modules/foo/macro.cjs:
+        module.exports.test = function test() {
           return 2;
         }
     `;
@@ -300,11 +301,11 @@ describe.v2('macros', function () {
   it('should throw a diagnostic when an argument cannot be converted', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test(1, foo);
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return 2;
         }
     `;
@@ -346,11 +347,11 @@ describe.v2('macros', function () {
   it('should throw a diagnostic when a macro errors', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test(1);
 
-      macro.js:
-        exports.test = function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           throw new Error('test');
         }
     `;
@@ -439,11 +440,11 @@ describe.v2('macros', function () {
   it('should support returning functions', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test(1, 2)(3);
 
-      macro.js:
-        export function test(a, b) {
+      macro.cjs:
+        module.exports.test = function test(a, b) {
           return new Function('c', \`return \${a} + \${b} + c\`);
         }
     `;
@@ -530,11 +531,11 @@ describe.v2('macros', function () {
   it('should invalidate the cache when changing a macro', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test();
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return 2;
         }
     `;
@@ -549,8 +550,8 @@ describe.v2('macros', function () {
     assert(res.includes('output=2'));
 
     await fsFixture(overlayFS, dir)`
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return 3;
         }
     `;
@@ -568,11 +569,11 @@ describe.v2('macros', function () {
   it('should invalidate the cache on build', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test('test.txt');
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           this.invalidateOnBuild();
           return Date.now();
         }
@@ -603,12 +604,12 @@ describe.v2('macros', function () {
   it('should only error once if a macro errors during loading', async function () {
     await fsFixture(overlayFS, dir)`
       index.js:
-        import { test } from "./macro.js" with { type: "macro" };
+        import { test } from "./macro.cjs" with { type: "macro" };
         output = test(1, 2);
         output2 = test(1, 3);
 
-      macro.js:
-        export function test() {
+      macro.cjs:
+        module.exports.test = function test() {
           return Date.now(
         }
     `;
@@ -673,7 +674,7 @@ describe.v2('macros', function () {
     await fsFixture(overlayFS, dir)`
       index.js:
         import { hashString } from "@atlaspack/rust" with { type: "macro" };
-        import { test, test2 } from './macro' with { type: "macro" };
+        import { test, test2 } from './macro.cjs' with { type: "macro" };
         const hi = "hi";
         const ref = hi;
         const arr = [hi];
@@ -697,13 +698,13 @@ describe.v2('macros', function () {
         output13 = hashString(res);
         output14 = test2(obj)();
 
-      macro.js:
-        import { hashString } from "@atlaspack/rust";
-        export function test() {
+      macro.cjs:
+        const { hashString } = require("@atlaspack/rust");
+        module.exports.test = function test() {
           return "hi";
         }
 
-        export function test2(obj) {
+        module.exports.test2 = function test2(obj) {
           return new Function('return "' + hashString(obj.a.b) + '"');
         }
     `;

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -12,6 +12,12 @@
   },
   "main": "lib/Logger.js",
   "source": "src/Logger.js",
+  "exports": {
+    ".": {
+      "@atlaspack::sources": "./src/Logger.js",
+      "default": "./lib/Logger.js"
+    }
+  },
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -16,6 +16,20 @@
   "engines": {
     "node": ">= 16.0.0"
   },
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "@atlaspack::sources": "./src/index.js",
+      "default": "./lib/index.js"
+    }
+  },
+  "imports": {
+    "#atlaspack/workers": {
+      "types": "./index.d.ts",
+      "@atlaspack::sources": "./src/index.js",
+      "default": "./lib/index.js"
+    }
+  },
   "dependencies": {
     "@atlaspack/build-cache": "2.12.0",
     "@atlaspack/diagnostic": "2.12.0",

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -23,13 +23,6 @@
       "default": "./lib/index.js"
     }
   },
-  "imports": {
-    "#atlaspack/workers": {
-      "types": "./index.d.ts",
-      "@atlaspack::sources": "./src/index.js",
-      "default": "./lib/index.js"
-    }
-  },
   "dependencies": {
     "@atlaspack/build-cache": "2.12.0",
     "@atlaspack/diagnostic": "2.12.0",

--- a/packages/core/workers/test/integration/workerfarm/console.js
+++ b/packages/core/workers/test/integration/workerfarm/console.js
@@ -1,4 +1,5 @@
-const WorkerFarm = require('#atlaspack/workers').default;
+// eslint-disable-next-line @atlaspack/no-self-package-imports
+const WorkerFarm = require('@atlaspack/workers').default;
 
 function run() {
   if (WorkerFarm.isWorker()) {

--- a/packages/core/workers/test/integration/workerfarm/console.js
+++ b/packages/core/workers/test/integration/workerfarm/console.js
@@ -1,4 +1,4 @@
-const WorkerFarm = require('../../../src/WorkerFarm').default;
+const WorkerFarm = require('#atlaspack/workers').default;
 
 function run() {
   if (WorkerFarm.isWorker()) {

--- a/packages/core/workers/test/integration/workerfarm/ipc-pid.js
+++ b/packages/core/workers/test/integration/workerfarm/ipc-pid.js
@@ -1,4 +1,4 @@
-const WorkerFarm = require('../../../src/WorkerFarm').default;
+const WorkerFarm = require('#atlaspack/workers').default;
 
 function run(api) {
   let result = [process.pid];

--- a/packages/core/workers/test/integration/workerfarm/ipc-pid.js
+++ b/packages/core/workers/test/integration/workerfarm/ipc-pid.js
@@ -1,4 +1,5 @@
-const WorkerFarm = require('#atlaspack/workers').default;
+// eslint-disable-next-line @atlaspack/no-self-package-imports
+const WorkerFarm = require('@atlaspack/workers').default;
 
 function run(api) {
   let result = [process.pid];

--- a/packages/core/workers/test/integration/workerfarm/ipc.js
+++ b/packages/core/workers/test/integration/workerfarm/ipc.js
@@ -1,4 +1,5 @@
-const WorkerFarm = require('#atlaspack/workers').default;
+// eslint-disable-next-line @atlaspack/no-self-package-imports
+const WorkerFarm = require('@atlaspack/workers').default;
 
 function run(api, a, b) {
   return api.callMaster({

--- a/packages/core/workers/test/integration/workerfarm/ipc.js
+++ b/packages/core/workers/test/integration/workerfarm/ipc.js
@@ -1,4 +1,4 @@
-const WorkerFarm = require('../../../src/WorkerFarm').default;
+const WorkerFarm = require('#atlaspack/workers').default;
 
 function run(api, a, b) {
   return api.callMaster({

--- a/packages/core/workers/test/integration/workerfarm/logging.js
+++ b/packages/core/workers/test/integration/workerfarm/logging.js
@@ -1,4 +1,4 @@
-const WorkerFarm = require('../../../src/WorkerFarm').default;
+const WorkerFarm = require('#atlaspack/workers').default;
 const Logger = require('@atlaspack/logger').default;
 
 function run() {

--- a/packages/core/workers/test/integration/workerfarm/logging.js
+++ b/packages/core/workers/test/integration/workerfarm/logging.js
@@ -1,4 +1,5 @@
-const WorkerFarm = require('#atlaspack/workers').default;
+// eslint-disable-next-line @atlaspack/no-self-package-imports
+const WorkerFarm = require('@atlaspack/workers').default;
 const Logger = require('@atlaspack/logger').default;
 
 function run() {

--- a/packages/core/workers/test/workerfarm.test.cjs
+++ b/packages/core/workers/test/workerfarm.test.cjs
@@ -1,7 +1,8 @@
-// @flow
-import Logger from '@atlaspack/logger';
-import assert from 'assert';
-import WorkerFarm from '../src';
+// NOTE: @atlaspack/logger exports object instances from the module.
+// If there are issues, check all imports are using the same module instance/path
+const Logger = require('@atlaspack/logger').default;
+const assert = require('assert');
+const WorkerFarm = require('#atlaspack/workers').default;
 
 describe('WorkerFarm', function () {
   this.timeout(30000);

--- a/packages/core/workers/test/workerfarm.test.cjs
+++ b/packages/core/workers/test/workerfarm.test.cjs
@@ -2,7 +2,8 @@
 // If there are issues, check all imports are using the same module instance/path
 const Logger = require('@atlaspack/logger').default;
 const assert = require('assert');
-const WorkerFarm = require('#atlaspack/workers').default;
+// eslint-disable-next-line @atlaspack/no-self-package-imports
+const WorkerFarm = require('@atlaspack/workers').default;
 
 describe('WorkerFarm', function () {
   this.timeout(30000);

--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -1,5 +1,6 @@
 const parcelBabelPreset = require('@atlaspack/babel-preset');
 const path = require('path');
+const fs = require('fs');
 
 require('@babel/register')({
   cwd: path.join(__dirname, '../../..'),
@@ -11,11 +12,21 @@ require('@babel/register')({
     (filepath) =>
       filepath.endsWith('.js') &&
       filepath.includes('/core/integration-tests/test/integration'),
+    // Include tests
+    (filepath) =>
+      filepath.endsWith('.js') &&
+      !fs.readFileSync(filepath, 'utf8').trim().startsWith('// @flow'),
   ],
   only: [path.join(__dirname, '../../..')],
   presets: [parcelBabelPreset],
   plugins: [require('./babel-plugin-module-translate')],
-  extensions: ['.js', '.jsx', '.ts', '.tsx'],
+  extensions: ['.js', '.jsx'],
+});
+
+// This only support transpiling TypeScript to CJS
+// eslint-disable-next-line import/no-extraneous-dependencies
+require('esbuild-register/dist/node').register({
+  extensions: ['.ts', '.cts', '.mts'],
 });
 
 // This adds the registration to the Node args, which are passed

--- a/packages/dev/babel-register/package.json
+++ b/packages/dev/babel-register/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@babel/register": "^7.22.5",
     "@atlaspack/babel-preset": "2.12.0",
-    "resolve": "^1.12.0"
+    "resolve": "^1.12.0",
+    "esbuild-register": "^3.5.0"
   },
   "peerDependencies": {
     "@babel/core": "^7.22.11"

--- a/packages/dev/eslint-config/index.js
+++ b/packages/dev/eslint-config/index.js
@@ -53,7 +53,7 @@ module.exports = {
     'require-await': 'error',
     // Use internal rule
     'monorepo/no-relative-import': 'off',
-    '@atlaspack/no-relative-import': 'error',
+    '@atlaspack/no-relative-import': 'error'
   },
   settings: {
     flowtype: {


### PR DESCRIPTION
This PR verifies that tests are using the correct transpiler/type checker for the file type and adds support for tests written in TypeScript

Rules:
|Condition|Engine|
|-|-|
|`.js` `.cjs` `.mjs` | node native |
|`.js` `.jsx` `startsWith('// @flow')` | babel register |
|`.ts` `.mts` `.cts`  | esbuild register |

## Motivation

There were many test files that were being type stripped as Flow files implicitly without being type checked because the files were not annotated with `// @flow`. Some TypeScript files were actually being stripped by Flow and were working because they only used syntax that overlapped.

This allowed tests to be written with invalid JavaScript syntax and invalid Flow types causing subtle drift from core APIs. This resulted in the accumulation of skipped tests that could no longer be run but did not break CI and was also an obstacle to auto-typescript conversion of the codebase. 

This PR aims to to ensure that all tests will have their appropriate type checker run and fail CI if invalid.

### Notes

It would be wise to force explicit file extensions in import & require paths. This is the default in Nodejs with `type: module` which will make the eventual transition easier, is required by Nodejs's built-in TypeScript runner and also makes it a bit easier to deal with the multiple register systems we have.

It might also be a good idea to name Flow files with `*.flow.js` in addition to `// @flow` to help further discriminate the files for the register systems and make it easier to know how many we have