### PR TITLE
Add publish config for new domain sharding package

### DIFF
--- a/packages/utils/domain-sharding/package.json
+++ b/packages/utils/domain-sharding/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@atlaspack/domain-sharding",
   "version": "2.12.0",
+  "license": "(MIT OR Apache-2.0)",
   "source": "src/index.js",
   "main": "lib/index.js",
   "publishConfig": {

--- a/packages/utils/domain-sharding/package.json
+++ b/packages/utils/domain-sharding/package.json
@@ -2,5 +2,16 @@
   "name": "@atlaspack/domain-sharding",
   "version": "2.12.0",
   "source": "src/index.js",
-  "main": "lib/index.js"
+  "main": "lib/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/atlassian-labs/atlaspack.git"
+  },
+  "engines": {
+    "atlaspack": "^2.12.0",
+    "node": ">= 16.0.0"
+  }
 }


### PR DESCRIPTION
My package.json was probably a little bit minimal. Lerna is failing to publish, so taking some config from another package that seems to be required