### PR TITLE
Fix domain sharding for ESM output

### DIFF
--- a/packages/core/integration-tests/test/domain-sharding.js
+++ b/packages/core/integration-tests/test/domain-sharding.js
@@ -2,7 +2,8 @@
 import assert from 'assert';
 import path from 'path';
 
-import {fsFixture, overlayFS, bundle} from '@atlaspack/test-utils';
+import {fsFixture, overlayFS, bundle, run} from '@atlaspack/test-utils';
+import {domainShardingKey} from '@atlaspack/domain-sharding';
 
 const maxShards = 8;
 
@@ -119,6 +120,71 @@ describe('domain-sharding', () => {
         ),
         'Expected generated code for shardUrl was not found',
       );
+    });
+
+    it('for ESM loaded bundle manifest', async () => {
+      const maxShards = 8;
+      await fsFixture(overlayFS)`
+        package.json:
+          {
+            "name": "bundle-sharding-test",
+            "@atlaspack/runtime-js": {
+              "domainSharding": {
+                "maxShards": ${maxShards}
+              }
+            }
+          }
+
+        src/index.js:
+          async function fn() {
+            const a = await import('./a.js');
+            const b = await import('./b.js');
+            console.log('a', a, b);
+          }
+          fn();
+
+        src/a.js:
+          export const a = async () => {
+            const b = await import('./b');
+            return b + 'A';
+          }
+        src/b.js:
+          export const b = 'B';
+
+        yarn.lock:
+      `;
+
+      const bundleGraph = await bundle('src/index.js', {
+        inputFS: overlayFS,
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldOptimize: false,
+          outputFormat: 'esmodule',
+        },
+      });
+
+      const mainBundle = bundleGraph
+        .getBundles()
+        .find((b) => b.name === 'index.js');
+
+      if (!mainBundle) {
+        return assert(mainBundle);
+      }
+
+      // $FlowFixMe - Flow doesn't seem to know about doesNotReject
+      await assert.doesNotReject(
+        run(bundleGraph, {[domainShardingKey]: true}),
+        'Expected bundle to be able to execute',
+      );
+
+      const code = await overlayFS.readFile(mainBundle.filePath, 'utf-8');
+
+      const expectedCode = `var$load = (parcelRequire("cfSxn"))(${maxShards});`
+        .replaceAll('$', '\\$')
+        .replaceAll('(', '\\(')
+        .replaceAll(')', '\\)');
+
+      assert.match(code, new RegExp(expectedCode));
     });
   });
 });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1048,7 +1048,11 @@ export async function runESM(
 
   function load(inputSpecifier, referrer, code = null) {
     // ESM can request bundles with an absolute URL. Normalize this to the baseDir.
-    let specifier = inputSpecifier.replace('http://localhost', baseDir);
+    // Any digits after the - can be ignored, for domain sharding tests
+    let specifier = inputSpecifier.replace(
+      /http:\/\/localhost(-\d+)?/,
+      baseDir,
+    );
 
     if (path.isAbsolute(specifier) || specifier.startsWith('.')) {
       let extname = path.extname(specifier);

--- a/packages/runtimes/js/src/JSRuntime.js
+++ b/packages/runtimes/js/src/JSRuntime.js
@@ -625,7 +625,11 @@ function getLoaderRuntime({
   let code = [];
 
   if (needsEsmLoadPrelude) {
-    code.push(`let load = require('./helpers/browser/esm-js-loader');`);
+    let preludeLoad = shardingConfig
+      ? `let load = require('./helpers/browser/esm-js-loader-shards')(${shardingConfig.maxShards});`
+      : `let load = require('./helpers/browser/esm-js-loader');`;
+
+    code.push(preludeLoad);
   }
 
   code.push(`module.exports = ${loaderCode};`);

--- a/packages/runtimes/js/src/helpers/browser/esm-js-loader-shards.js
+++ b/packages/runtimes/js/src/helpers/browser/esm-js-loader-shards.js
@@ -1,0 +1,11 @@
+let load = (maxShards) => (id) => {
+  // eslint-disable-next-line no-undef
+  return __parcel__import__(
+    require('@atlaspack/domain-sharding').shardUrl(
+      require('../bundle-manifest').resolve(id),
+      maxShards,
+    ),
+  );
+};
+
+module.exports = load;


### PR DESCRIPTION
Seems there was another code path I was not aware of that can generate URLs that needs to be sharded.

When outputting to ESM, the runtime imports `esm-js-loader` and calls its load function with the public ID we're after.

To avoid things becoming entirely too messy, I've created a new `esm-js-loader-shards` that will call the sharding helper on the URL generated, before passing it to `import`.

Adding a test for this required updating the `run` integration test helper so that it could handle sharded domains (because it was trying to request assets from `integration/dist-4/a.hash.js`).