### PR TITLE
Rel: TypeScript support in integration tests

### DIFF
--- a/packages/core/integration-tests/.mocharc.json
+++ b/packages/core/integration-tests/.mocharc.json
@@ -1,4 +1,5 @@
 {
+  "extension": ["js", "mjs", "cjs", "ts", "cts", "mts"],
   "require": [
     "@atlaspack/babel-register",
     "@atlaspack/test-utils/src/mochaSetup.js"


### PR DESCRIPTION
Adding config to allow integration tests to see TypeScript files