### PR TITLE
Fix unused symbols for dependencies without symbols

### DIFF
--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1331,7 +1331,7 @@ ${code}
         let unused = incomingDeps.every((d) => {
           let symbols = this.bundleGraph.getUsedSymbols(d);
 
-          // No used symbols avaiable for the asset, make sure we keep all of them
+          // No used symbols available for the asset, make sure we keep all of them
           if (!symbols) return false;
 
           return !symbols.has(symbol) && !symbols.has('*');

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -1329,7 +1329,11 @@ ${code}
         }
 
         let unused = incomingDeps.every((d) => {
-          let symbols = nullthrows(this.bundleGraph.getUsedSymbols(d));
+          let symbols = this.bundleGraph.getUsedSymbols(d);
+
+          // No used symbols avaiable for the asset, make sure we keep all of them
+          if (!symbols) return false;
+
           return !symbols.has(symbol) && !symbols.has('*');
         });
         return !unused;


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

From the issue found by @alshdavid. simple fix to avoid errors and deoptimise if the bundle doesn't support symbols.

## Changes

When a dependency doesn't have symbols, don't error but just deoptimise instead.

## Checklist

- [x] Existing or new tests cover this change
