### PR TITLE
Replicate the `"main": false` patch from Parcel

### DIFF
--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -38,12 +38,17 @@ pub struct PackageJson {
   pub path: PathBuf,
   #[serde(default, deserialize_with = "ok_or_default")]
   pub name: String,
+  #[serde(default, deserialize_with = "ok_or_default")]
   pub version: Option<String>,
   #[serde(rename = "type", default, deserialize_with = "ok_or_default")]
   pub module_type: ModuleType,
+  #[serde(default, deserialize_with = "ok_or_default")]
   main: Option<String>,
+  #[serde(default, deserialize_with = "ok_or_default")]
   module: Option<String>,
+  #[serde(default, deserialize_with = "ok_or_default")]
   tsconfig: Option<String>,
+  #[serde(default, deserialize_with = "ok_or_default")]
   types: Option<String>,
   #[serde(default, deserialize_with = "ok_or_default")]
   pub source: SourceField,

--- a/packages/utils/node-resolver-rs/src/package_json.rs
+++ b/packages/utils/node-resolver-rs/src/package_json.rs
@@ -36,27 +36,35 @@ bitflags! {
 pub struct PackageJson {
   #[serde(skip)]
   pub path: PathBuf,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   pub name: String,
   pub version: Option<String>,
-  #[serde(rename = "type", default)]
+  #[serde(rename = "type", default, deserialize_with = "ok_or_default")]
   pub module_type: ModuleType,
   main: Option<String>,
   module: Option<String>,
   tsconfig: Option<String>,
   types: Option<String>,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   pub source: SourceField,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   browser: BrowserField,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   alias: IndexMap<Specifier, AliasValue>,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   exports: ExportsField,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   imports: IndexMap<ExportsKey, ExportsField>,
-  #[serde(default)]
+  #[serde(default, deserialize_with = "ok_or_default")]
   side_effects: SideEffects,
+}
+
+fn ok_or_default<'de, T, D>(deserializer: D) -> Result<T, D::Error>
+where
+  T: serde::Deserialize<'de> + Default,
+  D: serde::Deserializer<'de>,
+{
+  Ok(T::deserialize(deserializer).unwrap_or_default())
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone, Copy, Default, PartialEq)]
@@ -1595,5 +1603,7 @@ mod tests {
     assert_eq!(pkg.module_type, ModuleType::CommonJs);
     let pkg: PackageJson = serde_json::from_str(r#"{"name":"foo"}"#).unwrap();
     assert_eq!(pkg.module_type, ModuleType::CommonJs);
+    let pkg: PackageJson = serde_json::from_str(r#"{"main":false}"#).unwrap();
+    assert_eq!(pkg.main, None);
   }
 }


### PR DESCRIPTION
Unfortunately, this [ecosystem pollution][pol] has spread to our world as well, and we've inherited Parcel's problem of not parsing the main field as a boolean.

This PR just replicates [Devon's patch][p] into Atlaspack, including his test.

[p]: https://github.com/parcel-bundler/parcel/pull/10053/commits/bb97f0e68e113bf31c7d35f95b385fa33b0c4d20
[pol]: https://github.com/es-shims/dunder-proto/issues/2