### PR TITLE
Use rust toolchain version in workflows

### DIFF
--- a/.github/actions/rust-toolchain/action.yml
+++ b/.github/actions/rust-toolchain/action.yml
@@ -1,0 +1,23 @@
+name: Install Rust
+description: Install the Rust toolchain
+
+inputs:
+  components:
+    description: Comma-separated list of components to be additionally installed
+    required: false
+  targets:
+    description: Comma-separated list of target triples to install for this toolchain
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Set toolchain
+      run: echo "RUST_TOOLCHAIN=$(cat rust-toolchain)" >> $GITHUB_ENV
+      shell: bash
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        components: ${{ inputs.components }}
+        targets: ${{ inputs.targets }}
+        toolchain: ${{ env.RUST_TOOLCHAIN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: yarn
-      - uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/rust-toolchain
         with:
-          toolchain: 1.83.0
-          components: rustfmt
+          components: clippy, rustfmt
       - run: yarn --frozen-lockfile
       - run: yarn lint
 
@@ -67,9 +66,7 @@ jobs:
         with:
           cache: yarn
           node-version: ${{ matrix.node }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.83.0
+      - uses: ./.github/actions/rust-toolchain
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.os }}
@@ -98,9 +95,7 @@ jobs:
         with:
           cache: yarn
           node-version: ${{ matrix.node }}
-      - uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: 1.83.0
+      - uses: ./.github/actions/rust-toolchain
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: ./.github/actions/rust-toolchain
         with:
-          toolchain: 1.83.0
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
       - uses: bahmutov/npm-install@v1.8.35
       - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.type != 'latest' }}
@@ -87,11 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: 1.83.0
-          profile: minimal
-          override: true
+        uses: ./.github/actions/rust-toolchain
       - uses: bahmutov/npm-install@v1.8.35
       - name: Build native packages
         run: yarn build-native-${{ inputs.profile }}
@@ -139,10 +134,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@master
+        uses: ./.github/actions/rust-toolchain
         with:
-          toolchain: 1.83.0
-          target: ${{ matrix.target }}
+          targets: ${{ matrix.target }}
       - name: Install cross compile toolchains
         run: |
           sudo apt-get update

--- a/.github/workflows/repl.yml
+++ b/.github/workflows/repl.yml
@@ -34,9 +34,8 @@ jobs:
         with:
           cache: yarn
           node-version: 20
-      - uses: dtolnay/rust-toolchain@master
+      - uses: ./.github/actions/rust-toolchain
         with:
-          toolchain: 1.83.0
           targets: wasm32-unknown-unknown
       - name: Install wasm-opt
         run: |


### PR DESCRIPTION
## Motivation

Bumping the rust version in this repository is tedious, because each job needs to specify the toolchain version. Other rust actions are either archived, do not provide enough features or good defaults.

## Changes

Create a centralised local action that reads from the rust toolchain file, so that we only need to change the version in one place. This has the benefit of not needing to define dependent jobs in multiple workflows.

Note that `actions-rs/toolchain@v1` was replaced as well, and that the default profile in `dtolnay/rust-toolchain@master` is also `minimal` so it should not cause any issues.