### PR TITLE
Added import retries into packager

### DIFF
--- a/packages/runtimes/js/src/helpers/browser/esm-js-loader-retry.js
+++ b/packages/runtimes/js/src/helpers/browser/esm-js-loader-retry.js
@@ -1,25 +1,41 @@
 async function load(id) {
-  if (!parcelRequire.retryState) {
-    parcelRequire.retryState = {};
-  }
+  const url = require('../bundle-manifest').resolve(id);
 
-  if (!globalThis.navigator.onLine) {
-    await new Promise((res) =>
-      globalThis.addEventListener('online', res, {once: true}),
-    );
-  }
+  const maxRetries = 6;
 
-  let url = require('../bundle-manifest').resolve(id);
+  for (let i = 1; i <= maxRetries; i++) {
+    // Wait for the user to go online before making a request
+    if (!globalThis.navigator.onLine) {
+      await new Promise((resolve) =>
+        globalThis.addEventListener('online', resolve, {once: true}),
+      );
+    }
 
-  if (parcelRequire.retryState[id] != undefined) {
-    url = `${url}?retry=${parcelRequire.retryState[id]}`;
-  }
+    let requestUrl = url;
+    if (i !== 0) {
+      // Date ensures the client hasn't previously cached a failed request
+      requestUrl = `${requestUrl}?retry=${i}:${Date.now()}`;
+    }
 
-  try {
-    // eslint-disable-next-line no-undef
-    return await __parcel__import__(url);
-  } catch (error) {
-    parcelRequire.retryState[id] = Date.now();
+    try {
+      // eslint-disable-next-line no-undef
+      return await __parcel__import__(requestUrl);
+    } catch (error) {
+      if (i === maxRetries) throw error;
+      // Dispatch event for reporting
+      window.dispatchEvent(
+        new CustomEvent('atlaspack:import_retry', {
+          detail: {
+            target: url,
+            attempt: i,
+          },
+        }),
+      );
+      const jitter = Math.round(Math.random() * 100);
+      const delay = Math.min(Math.pow(2, i), 8) * 1000;
+
+      await new Promise((resolve) => setTimeout(resolve, delay + jitter));
+    }
   }
 }
 


### PR DESCRIPTION
The previous import retry feature gave the consumer the ability to retry failed requests. This required the consumer to handle the actual retry logic:

```javascript
for (let i = 0; i < 5; i++) {
  try {
    await import('./foo')
  } catch(err) {
    await new Promise(res => setTimeout(res, 1000))
  }
}
```

This PR added the retry logic into the JavaScript runtime, enabled with `--feature-flag importRetry=true`

```javascript
await import('./foo') // will auto retry on failure
```

For reporting purposes, it will also emit a custom event on the window to notify when retries were triggered

```javascript
window.addEventListener('atlaspack:import_retry', ({detail}) => console.log(detail));
```
