### PR TITLE
Dev: Enable the use of "exports" when resolving bundler plugins

### DIFF
--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -33,6 +33,7 @@ import {getModuleParts} from '@atlaspack/utils';
 import {getConflictingLocalDependencies} from './utils';
 import {installPackage} from './installPackage';
 import pkg from '../package.json';
+import {getConditionsFromEnv} from './nodejsConditions';
 import {ResolverBase} from '@atlaspack/node-resolver-core';
 import {pathToFileURL} from 'url';
 import {transformSync} from '@swc/core';
@@ -587,6 +588,7 @@ export class NodePackageManager implements PackageManager {
       filename: name,
       specifierType: 'commonjs',
       parent: from,
+      packageConditions: getConditionsFromEnv(),
     });
 
     // Invalidate whenever the .pnp.js file changes.

--- a/packages/core/package-manager/src/nodejsConditions.js
+++ b/packages/core/package-manager/src/nodejsConditions.js
@@ -2,10 +2,11 @@
 import process from 'process';
 
 // https://nodejs.org/api/packages.html#conditional-exports
+// TODO We don't support { "type": "module" }
 export const defaultNodejsConditions: Array<string> = Object.freeze([
   'node-addons',
   'node',
-  'import',
+  // 'import',
   'require',
   'module-sync',
   'default',

--- a/packages/core/package-manager/src/nodejsConditions.js
+++ b/packages/core/package-manager/src/nodejsConditions.js
@@ -1,0 +1,34 @@
+// @flow
+import process from 'process';
+
+// https://nodejs.org/api/packages.html#conditional-exports
+export const defaultNodejsConditions: Array<string> = Object.freeze([
+  'node-addons',
+  'node',
+  'import',
+  'require',
+  'module-sync',
+  'default',
+]);
+
+let envConditions: void | Array<string> = undefined;
+
+/** @description Gets the export conditions from NODE_OPTIONS and node arguments */
+export function getConditionsFromEnv(): Array<string> {
+  if (!envConditions) {
+    const conditions = [];
+
+    for (const arg of [
+      ...process.execArgv,
+      ...(process.env.NODE_OPTIONS || '').split(' '),
+    ]) {
+      if (arg.startsWith('--conditions=')) {
+        conditions.push(arg.substring(13));
+      }
+    }
+
+    envConditions = Object.freeze([...conditions, ...defaultNodejsConditions]);
+  }
+
+  return envConditions;
+}


### PR DESCRIPTION
This PR allows the bundler to select plugins and internals using Nodejs's [conditional exports](https://nodejs.org/api/packages.html#conditional-exports)

This will help with the migration path to TypeScript as it allows us to select sources using built-in Nodejs conditional resolution (and builtin nodejs TypeScript support)

```bash
NODE_OPTIONS="--condition=@atlaspack::sources" atlaspack build

node --condition=@atlaspack::sources ./node_modules/.bin/atlaspack build
```

Where Atlaspack packages will be ported to

```json
{
  "name": "@atlaspack/foo",
  "exports": {
    "@atlaspack::sources": "./src/index.ts",
    "types": "./src/index.ts",
    "default": "./lib/index.js",
   }
}
```