### PR TITLE
DRAFT: Using link tag for import retry

### DIFF
--- a/packages/runtimes/js/test/esm-js-loader-retry.test.ts
+++ b/packages/runtimes/js/test/esm-js-loader-retry.test.ts
@@ -9,6 +9,7 @@ declare var globalThis: Window & {[key: string]: any};
 describe('esm-js-loader-retry', () => {
   let mockSetTimeout: Mock<Window['setTimeout']>;
   let mockParcelImport: Mock<() => Promise<void>>;
+  let mockCreateElement: Mock<() => MockLink>;
 
   // eslint-disable-next-line require-await
   const importError = async () => {
@@ -23,7 +24,25 @@ describe('esm-js-loader-retry', () => {
     mockSetTimeout = mock.fn((callback: any, duration: any, ...args: any[]) =>
       callback(),
     );
+
+    mockCreateElement = mock.fn(MockLink.willFail);
+
     globalThis.setTimeout = mockSetTimeout;
+
+    // @ts-expect-error
+    globalThis.document = {
+      createElement: mockCreateElement,
+      head: {
+        appendChild: (el: MockLink) => {
+          if (el.shouldPass) {
+            el.onerror?.();
+          } else {
+            el.onload?.();
+          }
+        },
+        removeChild: () => {},
+      },
+    };
 
     mockParcelImport = mock.fn(() => Promise.resolve());
     globalThis.__parcel__import__ = mockParcelImport;
@@ -40,26 +59,40 @@ describe('esm-js-loader-retry', () => {
   });
 
   it('should throw if all requests fail', async () => {
-    mockParcelImport.mock.mockImplementationOnce(importError, 0);
-    mockParcelImport.mock.mockImplementationOnce(importError, 1);
-    mockParcelImport.mock.mockImplementationOnce(importError, 2);
-    mockParcelImport.mock.mockImplementationOnce(importError, 3);
-    mockParcelImport.mock.mockImplementationOnce(importError, 4);
-    mockParcelImport.mock.mockImplementationOnce(importError, 5);
-    mockParcelImport.mock.mockImplementationOnce(importError, 6);
+    mockCreateElement.mock.mockImplementation(MockLink.willFail);
+    mockParcelImport.mock.mockImplementation(importError);
     await assert.rejects(() => load('1'));
   });
 
   it('should resolve if the first request fails', async () => {
-    mockParcelImport.mock.mockImplementationOnce(importError, 0);
+    mockCreateElement.mock.mockImplementationOnce(MockLink.willFail, 0);
+    mockCreateElement.mock.mockImplementationOnce(MockLink.willPass, 1);
     await assert.doesNotReject(() => load('1'));
   });
 
   it('should resolve if the first few requests fails', async () => {
-    mockParcelImport.mock.mockImplementationOnce(importError, 0);
-    mockParcelImport.mock.mockImplementationOnce(importError, 1);
-    mockParcelImport.mock.mockImplementationOnce(importError, 2);
-    mockParcelImport.mock.mockImplementationOnce(importError, 3);
+    mockCreateElement.mock.mockImplementationOnce(MockLink.willFail, 0);
+    mockCreateElement.mock.mockImplementationOnce(MockLink.willFail, 1);
+    mockCreateElement.mock.mockImplementationOnce(MockLink.willFail, 2);
+    mockCreateElement.mock.mockImplementationOnce(MockLink.willPass, 3);
     await assert.doesNotReject(() => load('1'));
   });
 });
+
+class MockLink {
+  shouldPass: boolean;
+  onload?: () => {};
+  onerror?: () => {};
+
+  constructor(shouldPass: boolean = true) {
+    this.shouldPass = shouldPass;
+  }
+
+  static willFail(): MockLink {
+    return new MockLink(false);
+  }
+
+  static willPass(): MockLink {
+    return new MockLink(true);
+  }
+}


### PR DESCRIPTION
This is an alternative approach to import retries. May be required due to SSR servers having issues with querystring parameters