### PR TITLE
Add base domain to domain sharding possibilities

### DIFF
--- a/packages/utils/domain-sharding/test/index.test.js
+++ b/packages/utils/domain-sharding/test/index.test.js
@@ -1,11 +1,54 @@
 // @flow
 import assert from 'assert';
-import {shardUrlUnchecked, shardUrl, domainShardingKey} from '../src/index.js';
+import {
+  shardUrlUnchecked,
+  shardUrl,
+  domainShardingKey,
+  applyShardToDomain,
+} from '../src/index.js';
 
 describe('domain sharding helpers', () => {
   beforeEach(() => {
     // $FlowFixMe
     delete globalThis[domainShardingKey];
+  });
+
+  describe('applyShardToDomain', () => {
+    it('should use the base domain for shard 0', () => {
+      const testBundle =
+        'https://bundle-shard.assets.example.com/assets/test-bundle.123abc.js';
+
+      const result = applyShardToDomain(testBundle, 0);
+
+      assert.equal(
+        result,
+        'https://bundle-shard.assets.example.com/assets/test-bundle.123abc.js',
+      );
+    });
+
+    it('should use the 0 shard domain for shard 1', () => {
+      const testBundle =
+        'https://bundle-shard.assets.example.com/assets/test-bundle.123abc.js';
+
+      const result = applyShardToDomain(testBundle, 1);
+
+      assert.equal(
+        result,
+        'https://bundle-shard-0.assets.example.com/assets/test-bundle.123abc.js',
+      );
+    });
+
+    it('should use the 2 shard domain for shard 3', () => {
+      const testBundle =
+        'https://bundle-shard.assets.example.com/assets/test-bundle.123abc.js';
+
+      const result = applyShardToDomain(testBundle, 3);
+
+      assert.equal(
+        result,
+        'https://bundle-shard-2.assets.example.com/assets/test-bundle.123abc.js',
+      );
+    });
   });
 
   describe('shardUrlUnchecked', () => {
@@ -17,7 +60,19 @@ describe('domain sharding helpers', () => {
 
       assert.equal(
         result,
-        'https://bundle-shard-0.assets.example.com/assets/test-bundle.123abc.js',
+        'https://bundle-shard-1.assets.example.com/assets/test-bundle.123abc.js',
+      );
+    });
+
+    it('should include the original domain in the shar', () => {
+      const testBundle =
+        'https://bundle-shard.assets.example.com/assets/test-bundle.123abc.js';
+
+      const result = shardUrlUnchecked(testBundle, 5);
+
+      assert.equal(
+        result,
+        'https://bundle-shard-1.assets.example.com/assets/test-bundle.123abc.js',
       );
     });
 
@@ -29,7 +84,7 @@ describe('domain sharding helpers', () => {
 
       assert.equal(
         result,
-        'https://bundle-shard-4.assets.example.com/assets/TestBundle.1a2b3c.js',
+        'https://bundle-shard-2.assets.example.com/assets/TestBundle.1a2b3c.js',
       );
     });
 
@@ -38,7 +93,7 @@ describe('domain sharding helpers', () => {
 
       const result = shardUrlUnchecked(testBundle, 5);
 
-      assert.equal(result, 'http://localhost-3/assets/testBundle.123abc.js');
+      assert.equal(result, 'http://localhost-2/assets/testBundle.123abc.js');
     });
 
     it('should handle domains with ports', () => {
@@ -48,7 +103,7 @@ describe('domain sharding helpers', () => {
 
       assert.equal(
         result,
-        'http://localhost-3:8081/assets/testBundle.123abc.js',
+        'http://localhost-2:8081/assets/testBundle.123abc.js',
       );
     });
   });
@@ -63,7 +118,7 @@ describe('domain sharding helpers', () => {
 
       assert.equal(
         result,
-        'https://bundle-shard-0.assets.example.com/assets/test-bundle.123abc.js',
+        'https://bundle-shard-1.assets.example.com/assets/test-bundle.123abc.js',
       );
     });
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

To improve CHR with domain sharding when switching between HTTP 1 and 2, use the base domain as a possible domain when sharding URLs.

For example, a config with `maxShards: 4` and a public path of `http://atlaspack-assets.com`would result in the following possible domain shards.

```
http://atlaspack-assets.com // <-- Include the base domain on top of the 4 sharded domains
http://atlaspack-assets-0.com
http://atlaspack-assets-1.com
http://atlaspack-assets-2.com
http://atlaspack-assets-3.com
```

## Checklist

- [x] Existing or new tests cover this change
