### PR TITLE
Fix LMDBLiteCache typescript bindings

### DIFF
--- a/packages/core/cache/index.d.ts
+++ b/packages/core/cache/index.d.ts
@@ -2,10 +2,15 @@ import type {FilePath} from '@atlaspack/types';
 import type {Cache} from './lib/types';
 
 export type {Cache} from './lib/types';
+
 export const FSCache: {
   new (cacheDir: FilePath): Cache;
 };
 
 export const LMDBCache: {
+  new (cacheDir: FilePath): Cache;
+};
+
+export const LMDBLiteCache: {
   new (cacheDir: FilePath): Cache;
 };


### PR DESCRIPTION
They weren't exposed previously.

Test Plan: N/A
