### PR TITLE
Fix sinon flow bindings

### DIFF
--- a/flow-typed/npm/sinon_v7.x.x.js
+++ b/flow-typed/npm/sinon_v7.x.x.js
@@ -164,7 +164,7 @@ declare module 'sinon' {
     withArgs(...args: Array<any>): SinonStub;
   }
 
-  declare interface SinonStubStatic {
+  declare interface SinonStubStatic extends SinonStub {
     (): SinonStub;
     (obj: any): SinonStub;
     (obj: any, method: string): SinonStub;


### PR DESCRIPTION
Fixes flow type bindings so that further refinement assertions can be built
with typechecking.

For example, this is currently failing to typecheck:

```
const writeFileSync = sinon.stub(fs, 'writeFileSync');
const count = writeFileSync.withArgs('f', 'contents').callCount;
```

And will typecheck now.

Test Plan: `yarn flow`
