### PR TITLE
Add ContentGraph::getContentKeyByNodeId

### DIFF
--- a/packages/core/graph/src/ContentGraph.js
+++ b/packages/core/graph/src/ContentGraph.js
@@ -75,6 +75,13 @@ export default class ContentGraph<TNode, TEdgeType: number = 1> extends Graph<
     }
   }
 
+  getContentKeyByNodeId(nodeId: NodeId): ContentKey {
+    return nullthrows(
+      this._nodeIdToContentKey.get(nodeId),
+      `Expected node id ${nodeId} to exist`,
+    );
+  }
+
   getNodeIdByContentKey(contentKey: ContentKey): NodeId {
     return nullthrows(
       this._contentKeyToNodeId.get(contentKey),

--- a/packages/core/graph/test/ContentGraph.test.js
+++ b/packages/core/graph/test/ContentGraph.test.js
@@ -39,4 +39,22 @@ describe('ContentGraph', () => {
 
     assert(!graph.hasContentKey('contentKey'));
   });
+
+  describe('getContentKeyByNodeId', () => {
+    it('returns the content key for a node', () => {
+      const graph = new ContentGraph();
+
+      const node1 = graph.addNodeByContentKey('node1', {});
+      assert.equal(graph.getContentKeyByNodeId(node1), 'node1');
+      const node2 = graph.addNodeByContentKey('node2', {});
+      assert.equal(graph.getContentKeyByNodeId(node2), 'node2');
+    });
+
+    it('throws if the node does not have a content key', () => {
+      const graph = new ContentGraph();
+
+      const node1 = graph.addNode({});
+      assert.throws(() => graph.getContentKeyByNodeId(node1));
+    });
+  });
 });


### PR DESCRIPTION
Adds a method to retrieve content keys associated with node IDs.

Test Plan: Run unit-tests (yarn test)
