### PR TITLE
Fix exiting async function spans

### DIFF
--- a/.changeset/tall-impalas-suffer.md
+++ b/.changeset/tall-impalas-suffer.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/logger': patch
+---
+
+Fix exiting async spans on instrumentAsync

--- a/packages/core/logger/src/tracer.js
+++ b/packages/core/logger/src/tracer.js
@@ -19,10 +19,11 @@ export async function instrumentAsync<T>(
   fn: () => Promise<T>,
 ): Promise<T> {
   const span = tracer.enter(label);
+  let result;
   try {
-    const result = await fn();
-    return result;
+    result = await fn();
   } finally {
     tracer.exit(span);
   }
+  return result;
 }


### PR DESCRIPTION
The tracer wasn't ending these async function spans properly.

This is of limited use at the moment because async functions might overlap, so
the spans won't be quite right as is.

Test Plan: N/A
