### PR TITLE
Add tracing logs around git dirty hashes listing

### DIFF
--- a/.changeset/mighty-zoos-design.md
+++ b/.changeset/mighty-zoos-design.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': minor
+---
+
+Add tracing logs for dirty files listing

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -139,7 +139,7 @@ pub mod yarn_integration;
 pub struct VCSState {
   pub git_hash: String,
   pub dirty_files: Vec<VCSFile>,
-  pub dirty_files_execution_time: u64,
+  pub dirty_files_execution_time: u32,
   pub yarn_states: Vec<YarnSnapshot>,
 }
 
@@ -166,7 +166,7 @@ impl VCSState {
       .elapsed()
       .as_millis()
       .try_into()
-      .unwrap_or(u64::MAX);
+      .unwrap_or(u32::MAX);
     tracing::info!(
       "vcs_list_dirty_files executed in: {:?}",
       files_listing_duration

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -162,19 +162,18 @@ impl VCSState {
     let git_hash = head.id().to_string();
     tracing::info!("Found head commit");
     let file_listing = vcs_list_dirty_files(path, exclude_patterns)?;
-    tracing::info!("Listed dirty files");
-    let yarn_states = list_yarn_states(path, failure_mode)?;
-    tracing::info!("Listed yarn states");
     let files_listing_duration = start_time
       .elapsed()
       .as_millis()
       .try_into()
       .unwrap_or(u64::MAX);
-    let yarn_states = list_yarn_states(path, failure_mode)?;
     tracing::info!(
       "vcs_list_dirty_files executed in: {:?}",
       files_listing_duration
     );
+    tracing::info!("Listed dirty files");
+    let yarn_states = list_yarn_states(path, failure_mode)?;
+    tracing::info!("Listed yarn states");
 
     Ok(VCSState {
       git_hash,

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -146,15 +146,12 @@ pub struct VCSState {
 impl VCSState {
   /// Read the VCS state from a repository root. Ignore dirty files matching
   /// the exclude patterns.
-  #[tracing::instrument(level = "info", skip_all)]
   pub fn read_from_repository(
     path: &Path,
     exclude_patterns: &[String],
     failure_mode: FailureMode,
   ) -> anyhow::Result<VCSState> {
     tracing::info!("Reading VCS state");
-    let span = tracing::span!(tracing::Level::INFO, "vcs_dirty_files_duration");
-    let _enter = span.enter();
     let start_time = Instant::now();
 
     let repo = Repository::open(path)?;
@@ -375,6 +372,7 @@ pub fn vcs_list_yarn_lock_files(dir: &Path) -> Result<Vec<String>, anyhow::Error
   Ok(results)
 }
 
+#[tracing::instrument(level = "info", skip_all)]
 pub fn vcs_list_dirty_files(
   dir: &Path,
   exclude_patterns: &[String],

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -346,6 +346,7 @@ export interface YarnState {
 
 export interface VCSState {
   gitHash: string;
+  // Files that have been modified since the last commit
   dirtyFiles: VCSFile[];
   yarnStates: YarnState[];
 }


### PR DESCRIPTION
Tested locally by running `cargo run --example vcs_file_diff snapshot --repository-root="../../"`

<img width="1220" alt="Screenshot 2025-02-18 at 11 15 53 AM" src="https://github.com/user-attachments/assets/a1dd27e4-5cf7-4f0a-955b-d80a2a7f7e21" />
