### PR TITLE
Support specific event types from vcs fs

### DIFF
--- a/crates/atlaspack_vcs/examples/vcs_file_diff.rs
+++ b/crates/atlaspack_vcs/examples/vcs_file_diff.rs
@@ -63,8 +63,9 @@ fn main() {
       .unwrap();
 
       for change in changes {
-        let change = change.strip_prefix(&repository_root).unwrap();
-        println!("{}", change.display());
+        let change_type = change.change_type_str();
+        let change = change.path().strip_prefix(&repository_root).unwrap();
+        println!("{} {}", change_type, change.display());
       }
     }
   }

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -266,6 +266,14 @@ impl FileChangeEvent {
   pub fn change_type(&self) -> &FileChangeType {
     &self.change_type
   }
+
+  pub fn change_type_str(&self) -> &str {
+    match self.change_type() {
+      atlaspack_vcs::FileChangeType::Create => "create",
+      atlaspack_vcs::FileChangeType::Update => "update",
+      atlaspack_vcs::FileChangeType::Delete => "delete",
+    }
+  }
 }
 
 pub enum FileChangeType {

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -269,9 +269,9 @@ impl FileChangeEvent {
 
   pub fn change_type_str(&self) -> &str {
     match self.change_type() {
-      atlaspack_vcs::FileChangeType::Create => "create",
-      atlaspack_vcs::FileChangeType::Update => "update",
-      atlaspack_vcs::FileChangeType::Delete => "delete",
+      FileChangeType::Create => "create",
+      FileChangeType::Update => "update",
+      FileChangeType::Delete => "delete",
     }
   }
 }

--- a/crates/node-bindings/src/vcs.rs
+++ b/crates/node-bindings/src/vcs.rs
@@ -47,11 +47,7 @@ pub fn get_events_since(
     .iter()
     .map(|event| NodeChangeEvent {
       path: event.path().to_str().unwrap().to_string(),
-      change_type: match event.change_type() {
-        atlaspack_vcs::FileChangeType::Create => "create".to_string(),
-        atlaspack_vcs::FileChangeType::Update => "update".to_string(),
-        atlaspack_vcs::FileChangeType::Delete => "delete".to_string(),
-      },
+      change_type: event.change_type_str().to_string(),
     })
     .collect();
 

--- a/crates/node-bindings/src/vcs.rs
+++ b/crates/node-bindings/src/vcs.rs
@@ -22,12 +22,18 @@ pub fn get_vcs_state_snapshot(
   Ok(vcs_state)
 }
 
+#[napi(object)]
+pub struct NodeChangeEvent {
+  pub path: String,
+  pub change_type: String,
+}
+
 #[napi]
 pub fn get_events_since(
   repo_path: String,
   old_rev: String,
   new_rev: Option<String>,
-) -> napi::Result<Vec<String>> {
+) -> napi::Result<Vec<NodeChangeEvent>> {
   let repo_path = Path::new(&repo_path);
   let files = atlaspack_vcs::get_changed_files(
     repo_path,
@@ -39,7 +45,14 @@ pub fn get_events_since(
 
   let files = files
     .iter()
-    .map(|file| file.to_str().unwrap().to_string())
+    .map(|event| NodeChangeEvent {
+      path: event.path().to_str().unwrap().to_string(),
+      change_type: match event.change_type() {
+        atlaspack_vcs::FileChangeType::Create => "create".to_string(),
+        atlaspack_vcs::FileChangeType::Update => "update".to_string(),
+        atlaspack_vcs::FileChangeType::Delete => "delete".to_string(),
+      },
+    })
     .collect();
 
   Ok(files)

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -14,7 +14,7 @@ import packageJSON from '../package.json';
 export interface NodeVCSAwareFSOptions {
   gitRepoPath: FilePath;
   excludePatterns: Array<string>;
-  logEventDiff: (watcherEvents: Event[], vcsEvents: string[]) => void;
+  logEventDiff: (watcherEvents: Event[], vcsEvents: Event[]) => void;
 }
 
 export class NodeVCSAwareFS extends NodeFS {
@@ -43,7 +43,10 @@ export class NodeVCSAwareFS extends NodeFS {
       'NodeVCSAwareFS::rust.getEventsSince',
       () => getEventsSince(this.#options.gitRepoPath, vcsState.gitHash),
     );
-    this.#options.logEventDiff(watcherEventsSince, vcsEventsSince);
+    this.#options.logEventDiff(
+      watcherEventsSince,
+      vcsEventsSince.map((e) => ({path: e.path, type: e.changeType})),
+    );
 
     return watcherEventsSince;
   }

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -354,11 +354,16 @@ declare export function getVcsStateSnapshot(
   path: string,
   excludePatterns: Array<string>,
 ): VCSState;
+export interface NodeChangeEvent {
+  path: string;
+  changeType: 'update' | 'create' | 'delete';
+}
+
 declare export function getEventsSince(
   repoPath: string,
   oldRev: string,
   newRev?: string | void | null,
-): Array<string>;
+): Array<NodeChangeEvent>;
 
 declare export function createAssetId(params: mixed): string;
 declare export function createDependencyId(params: mixed): string;


### PR DESCRIPTION
Adds support for VCS change lists to differentiate between create/delete/update
events.

Test Plan: cargo test
