### PR TITLE
Add tracing logs around yarn state scanning

### DIFF
--- a/.changeset/mighty-turkeys-hang.md
+++ b/.changeset/mighty-turkeys-hang.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': minor
+---
+
+Add tracing logs around yarn state scanning


### PR DESCRIPTION
Tested locally by running `cargo run --example vcs_file_diff snapshot --repository-root="../../"`


<img width="1082" alt="Screenshot 2025-02-19 at 12 58 54 PM" src="https://github.com/user-attachments/assets/38c6d017-d042-41be-a372-dba97f7a8257" />
