### PR TITLE
Fix syntax error in inline requires optimizer

### DIFF
--- a/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
@@ -13,6 +13,7 @@ swc_core = { workspace = true, features = [
     "ecma_codegen",
     "ecma_parser",
     "ecma_preset_env",
+    "ecma_quote",
     "ecma_transforms",
     "ecma_transforms_compat",
     "ecma_transforms_optimization",

--- a/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/src/lib.rs
@@ -302,9 +302,11 @@ impl VisitMut for InlineRequiresOptimizer {
         // first let the normal replacement run on this expression so we inline the require
         decl.visit_mut_children_with(self);
         // get the value we've replaced and carry it forward, we'll inline this value now
-        let Some(init) = &decl.init else { continue };
+        let Some(init) = &decl.init else {
+          continue;
+        };
         let init = init.as_expr().clone();
-        decl.init = None;
+        decl.init = Some(Box::new(swc_core::quote!("null" as Expr)));
         self
           .identifier_replacement_visitor
           .add_replacement(default_initializer_id, init);
@@ -326,7 +328,7 @@ impl VisitMut for InlineRequiresOptimizer {
         Expr::Call(initializer.call_expr.clone()),
       );
       self.require_initializers.push(initializer);
-      decl.init = None;
+      decl.init = Some(Box::new(swc_core::quote!("null" as Expr)));
     }
   }
 }
@@ -353,7 +355,7 @@ function doWork() {
     });
 
     let expected_output = r#"
-const fs;
+const fs = null;
 function doWork() {
     return (0, require('fs')).readFileSync('./something');
 }
@@ -383,7 +385,7 @@ parcelRequire.register('moduleId', function(require, module, exports) {
 
     let expected_output = r#"
 parcelRequire.register('moduleId', function(require, module, exports) {
-    const fs;
+    const fs = null;
     function doWork() {
         return (0, require('fs')).readFileSync('./something');
     }
@@ -450,8 +452,8 @@ function run() {
     });
 
     let expected_output = r#"
-const app;
-const appDefault;
+const app = null;
+const appDefault = null;
 function run() {
     return (0, parcelHelpers.interopDefault((0, require("./App")))).test();
 }

--- a/packages/core/rust/test/InlineRequiresNative.test.js
+++ b/packages/core/rust/test/InlineRequiresNative.test.js
@@ -19,7 +19,7 @@ function main() {
     assert.equal(
       result.code,
       `
-const fs;
+const fs = null;
 function main() {
     return (0, require('fs')).readFile('./something');
 }


### PR DESCRIPTION
Fix inline requires optimizer producing `const ...` declaration statements
without an initializer, which triggers syntax errors.

Test Plan: cargo test && yarn test
