### PR TITLE
Fix case where lockfiles are added into a repo

### DIFF
--- a/.changeset/honest-wombats-pay.md
+++ b/.changeset/honest-wombats-pay.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Fix VCS watcher handling of new yarn.lock files between revisions

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -256,7 +256,7 @@ fn get_file_contents_at_commit(
   path: &Path,
 ) -> anyhow::Result<Option<String>> {
   let tree = commit.tree()?;
-  if let Some(entry) = tree.get_path(path).ok() {
+  if let Ok(entry) = tree.get_path(path) {
     let blob = entry
       .to_object(repo)?
       .into_blob()

--- a/crates/atlaspack_vcs/src/yarn_integration/mod.rs
+++ b/crates/atlaspack_vcs/src/yarn_integration/mod.rs
@@ -163,6 +163,10 @@ pub fn generate_events(
 
     if let Some(dependency_state) = state.get(&resolution.resolution) {
       for location in &dependency_state.locations {
+        if location == "" {
+          // the workspace is listed as a location, which we can skip
+          continue;
+        }
         changed_paths.push(node_modules_parent_path.join(location));
       }
     }
@@ -194,7 +198,36 @@ mod test {
 
     let events = generate_events(
       &node_modules_parent_path,
-      &old_yarn_lock,
+      &Some(old_yarn_lock),
+      &new_yarn_lock,
+      &yarn_state,
+    );
+    let events = events
+      .iter()
+      .map(|path| path.to_str().unwrap())
+      .collect::<Vec<_>>();
+
+    assert_eq!(events, vec!["node_modules/lodash"]);
+
+    Ok(())
+  }
+
+  #[test]
+  fn test_generate_events_when_old_file_is_missing() -> anyhow::Result<()> {
+    let node_modules_parent_path = PathBuf::from("");
+    let cargo_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let samples_path = cargo_path.join("samples");
+    let new_yarn_lock_path = samples_path.join("new/yarn-lock");
+    let yarn_state_path = samples_path.join("new/yarn-state.yml");
+
+    let new_yarn_lock = parse_yarn_lock(&std::fs::read_to_string(new_yarn_lock_path)?)?;
+    let yarn_state: YarnStateFile =
+      serde_yaml::from_str(&std::fs::read_to_string(yarn_state_path)?)?;
+    yarn_state.validate()?;
+
+    let events = generate_events(
+      &node_modules_parent_path,
+      &None,
       &new_yarn_lock,
       &yarn_state,
     );

--- a/crates/atlaspack_vcs/src/yarn_integration/mod.rs
+++ b/crates/atlaspack_vcs/src/yarn_integration/mod.rs
@@ -163,7 +163,7 @@ pub fn generate_events(
 
     if let Some(dependency_state) = state.get(&resolution.resolution) {
       for location in &dependency_state.locations {
-        if location == "" {
+        if location.is_empty() {
           // the workspace is listed as a location, which we can skip
           continue;
         }

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -42,11 +42,8 @@ export class NodeVCSAwareFS extends NodeFS {
     const vcsEventsSince = instrument(
       'NodeVCSAwareFS::rust.getEventsSince',
       () => getEventsSince(this.#options.gitRepoPath, vcsState.gitHash),
-    );
-    this.#options.logEventDiff(
-      watcherEventsSince,
-      vcsEventsSince.map((e) => ({path: e.path, type: e.changeType})),
-    );
+    ).map((e) => ({path: e.path, type: e.changeType}));
+    this.#options.logEventDiff(watcherEventsSince, vcsEventsSince);
 
     return watcherEventsSince;
   }


### PR DESCRIPTION
If a lock-file is added into the repository then we will consider all
dependency paths changed.

Test Plan: cargo build
