### PR TITLE
Issue/vcs toggle vcs modes

### DIFF
--- a/.changeset/little-teachers-look.md
+++ b/.changeset/little-teachers-look.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/feature-flags': minor
+---
+
+Introduced new method to return feature flag value

--- a/.changeset/rude-keys-occur.md
+++ b/.changeset/rude-keys-occur.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/fs': minor
+---
+
+Introduced ability to toggle vcs mode under a flag

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -14,6 +14,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   fixQuadraticCacheInvalidation: 'OLD',
   useLmdbJsLite: false,
   conditionalBundlingApi: false,
+  vcsMode: 'OLD',
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -28,6 +28,12 @@ export function getFeatureFlag(flagName: $Keys<FeatureFlags>): boolean {
   return value === true || value === 'NEW';
 }
 
+export function getFeatureFlagValue(
+  flagName: $Keys<FeatureFlags>,
+): boolean | string | number {
+  return featureFlagValues[flagName];
+}
+
 export type DiffResult<CustomDiagnostic> = {|
   isDifferent: boolean,
   custom: CustomDiagnostic,

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -30,6 +30,13 @@ export type FeatureFlags = {|
    * and requires server-side support.
    */
   conditionalBundlingApi: boolean,
+  /**
+   * Enable VCS mode. Expected values are:
+   * - OLD - default value, return watchman result
+   * - NEW_AND_CHECK - Return VCS result but still call watchman
+   * - NEW: Return VCS result, but don't call watchman
+   */
+  vcsMode: ConsistencyCheckFeatureFlagValue,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -7,6 +7,7 @@ import type {FilePath} from '@atlaspack/types-internal';
 import type {Event, Options as WatcherOptions} from '@parcel/watcher';
 import {registerSerializableClass} from '@atlaspack/build-cache';
 import {instrument, instrumentAsync} from '@atlaspack/logger';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 // $FlowFixMe
 import packageJSON from '../package.json';
@@ -34,16 +35,27 @@ export class NodeVCSAwareFS extends NodeFS {
     const snapshotFile = await this.readFile(snapshot);
     const snapshotFileContent = snapshotFile.toString();
     const {nativeSnapshotPath, vcsState} = JSON.parse(snapshotFileContent);
+    let watcherEventsSince = [];
 
-    const watcherEventsSince = await instrumentAsync(
-      'NodeVCSAwareFS::watchman.getEventsSince',
-      () => this.watcher().getEventsSince(dir, nativeSnapshotPath, opts),
-    );
     const vcsEventsSince = instrument(
       'NodeVCSAwareFS::rust.getEventsSince',
       () => getEventsSince(this.#options.gitRepoPath, vcsState.gitHash),
-    ).map((e) => ({path: e.path, type: e.changeType}));
-    this.#options.logEventDiff(watcherEventsSince, vcsEventsSince);
+    ).map((e) => ({
+      path: e.path,
+      type: e.changeType,
+    }));
+
+    if (getFeatureFlag('vcsMode') !== 'NEW') {
+      watcherEventsSince = await instrumentAsync(
+        'NodeVCSAwareFS::watchman.getEventsSince',
+        () => this.watcher().getEventsSince(dir, nativeSnapshotPath, opts),
+      );
+      this.#options.logEventDiff(watcherEventsSince, vcsEventsSince);
+    }
+
+    if (['NEW_AND_CHECK', 'NEW'].includes(getFeatureFlag('vcsMode'))) {
+      return vcsEventsSince;
+    }
 
     return watcherEventsSince;
   }
@@ -59,9 +71,10 @@ export class NodeVCSAwareFS extends NodeFS {
       snapshotDirectory,
       `${filename}.native-snapshot.txt`,
     );
-    await this.watcher().writeSnapshot(dir, nativeSnapshotPath, opts);
+    if (getFeatureFlag('vcsMode') !== 'NEW') {
+      await this.watcher().writeSnapshot(dir, nativeSnapshotPath, opts);
+    }
 
-    // TODO: we need the git repo path, pass the exclude patterns
     const vcsState = await getVcsStateSnapshot(
       this.#options.gitRepoPath,
       this.#options.excludePatterns,

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -7,7 +7,7 @@ import type {FilePath} from '@atlaspack/types-internal';
 import type {Event, Options as WatcherOptions} from '@parcel/watcher';
 import {registerSerializableClass} from '@atlaspack/build-cache';
 import {instrument, instrumentAsync} from '@atlaspack/logger';
-import {getFeatureFlag} from '@atlaspack/feature-flags';
+import {getFeatureFlagValue} from '@atlaspack/feature-flags';
 
 // $FlowFixMe
 import packageJSON from '../package.json';
@@ -45,7 +45,7 @@ export class NodeVCSAwareFS extends NodeFS {
       type: e.changeType,
     }));
 
-    if (getFeatureFlag('vcsMode') !== 'NEW') {
+    if (getFeatureFlagValue('vcsMode') !== 'NEW') {
       watcherEventsSince = await instrumentAsync(
         'NodeVCSAwareFS::watchman.getEventsSince',
         () => this.watcher().getEventsSince(dir, nativeSnapshotPath, opts),
@@ -53,7 +53,7 @@ export class NodeVCSAwareFS extends NodeFS {
       this.#options.logEventDiff(watcherEventsSince, vcsEventsSince);
     }
 
-    if (['NEW_AND_CHECK', 'NEW'].includes(getFeatureFlag('vcsMode'))) {
+    if (['NEW_AND_CHECK', 'NEW'].includes(getFeatureFlagValue('vcsMode'))) {
       return vcsEventsSince;
     }
 
@@ -71,7 +71,7 @@ export class NodeVCSAwareFS extends NodeFS {
       snapshotDirectory,
       `${filename}.native-snapshot.txt`,
     );
-    if (getFeatureFlag('vcsMode') !== 'NEW') {
+    if (getFeatureFlagValue('vcsMode') !== 'NEW') {
       await this.watcher().writeSnapshot(dir, nativeSnapshotPath, opts);
     }
 


### PR DESCRIPTION
We want to implement a consistency check pattern to enable VCS modes under a feature flag. There are 4 different scenarios that will be controlled by combining a 'killswitch', already implemented in product,  and a flag to toggle the relevant mode, as explains below:

![Screenshot 2025-02-21 at 2 13 32 PM](https://github.com/user-attachments/assets/1d16978a-7776-4601-a442-409d1640e911)



The first 2 modes are already available in the products and are switched on/off by an infra ff. This PR introduces the ability to return different values for the last 2 modes through another infra ff.






