### PR TITLE
Add a step for scanning for side effects caused by loadable package

### DIFF
--- a/.changeset/many-pears-tan.md
+++ b/.changeset/many-pears-tan.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/core': minor
+---
+
+Add a step to the BundleGraphRequest that will scan for assets that have a transitive dep on `@confluence/loadable` and marks them as having side effects.
+This allows the inline requires optimizer to be applied to projects that don't necessarily declare side effects correctly.

--- a/.changeset/popular-coins-complain.md
+++ b/.changeset/popular-coins-complain.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/feature-flags': minor
+---
+
+Add a new feature flag to enable the side effect scanning

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -90,6 +90,52 @@ export default function createAssetGraphRequest(
         assetGraphRequest.assetGraph.safeToIncrementallyBundle = false;
       }
 
+      if (input.options.featureFlags?.loadableSideEffects) {
+        // Avoid revisiting nodes
+        let updatedAssetIds = new Set();
+
+        assetGraphRequest.assetGraph.traverse((nodeId) => {
+          let node = nullthrows(assetGraphRequest.assetGraph.getNode(nodeId));
+
+          if (
+            node.type !== 'dependency' ||
+            node.value.specifier.indexOf('@confluence/loadable') === -1
+          ) {
+            return;
+          }
+
+          assetGraphRequest.assetGraph.traverseAncestors(
+            nodeId,
+            (ancestorNodeId, _, actions) => {
+              if (updatedAssetIds.has(ancestorNodeId)) {
+                actions.skipChildren();
+                return;
+              }
+
+              let ancestorNode = nullthrows(
+                assetGraphRequest.assetGraph.getNode(ancestorNodeId),
+              );
+
+              // Async boundaries will catch the side effects
+              if (
+                ancestorNode.type === 'dependency' &&
+                ancestorNode.value.priority !== Priority.sync
+              ) {
+                actions.skipChildren();
+              }
+
+              // inline-requires optimizer is only checking assets
+              if (ancestorNode.type !== 'asset') {
+                return;
+              }
+
+              updatedAssetIds.add(ancestorNodeId);
+              ancestorNode.value.sideEffects = true;
+            },
+          );
+        }, assetGraphRequest.assetGraph.rootNodeId);
+      }
+
       return assetGraphRequest;
     },
     input: requestInput,

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -15,6 +15,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   useLmdbJsLite: false,
   conditionalBundlingApi: false,
   vcsMode: 'OLD',
+  loadableSideEffects: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -37,6 +37,10 @@ export type FeatureFlags = {|
    * - NEW: Return VCS result, but don't call watchman
    */
   vcsMode: ConsistencyCheckFeatureFlagValue,
+  /**
+   * Enable scanning for the presence of loadable to determine side effects
+   */
+  loadableSideEffects: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =

--- a/packages/core/integration-tests/test/loadable.js
+++ b/packages/core/integration-tests/test/loadable.js
@@ -1,0 +1,70 @@
+// @flow
+
+import path from 'path';
+import assert from 'assert';
+import {fsFixture, overlayFS, bundle, findAsset} from '@atlaspack/test-utils';
+
+describe('loadable side effects', () => {
+  it('should mark ancestors of loadable package as having side effects', async () => {
+    await fsFixture(overlayFS, __dirname)`
+      package.json:
+        { "sideEffects": false }
+      index.jsx:
+        import {LoadableComponent} from './loadable-component';
+        import {nonLoadableFn} from './non-loadable-fn';
+        export default () => <LoadableComponent />;
+
+      loadable-component.js:
+        import {loadable} from '@confluence/loadable';
+        export const LoadableComponent = loadable(() => import('./TestingComponent'));
+
+      TestingComponent.jsx:
+        export default () => <div>Testing Component</div>;
+
+      non-loadable-fn.js:
+        export const nonLoadableFn = () => 'non-loadable-fn';
+
+      node_modules/@confluence/loadable/index.js:
+        export const loadable = (inputComponent) => inputComponent;
+    `;
+
+    let result = await bundle(path.join(__dirname, 'index.jsx'), {
+      inputFS: overlayFS,
+      featureFlags: {
+        loadableSideEffects: true,
+      },
+    });
+
+    let asset = findAsset(result, 'index.jsx');
+    assert.equal(
+      asset?.sideEffects,
+      true,
+      'sideEffects should be true for index.js',
+    );
+
+    let loadableComponentAsset = findAsset(result, 'loadable-component.js');
+    assert.equal(
+      loadableComponentAsset?.sideEffects,
+      true,
+      'sideEffects should be true for loadable-component.js',
+    );
+
+    // The non-loadable file is not an ancestor of @confluence/loadable, so
+    // should not be marked as having side effects.
+    let nonLoadableAsset = findAsset(result, 'non-loadable-fn.js');
+    assert.equal(
+      nonLoadableAsset?.sideEffects,
+      false,
+      'sideEffects should be false for non-loadable-fn.js',
+    );
+
+    // The TestingComponent is downstream of the loadable component, so should
+    // not have side effects.
+    let testingComponentAsset = findAsset(result, 'TestingComponent.jsx');
+    assert.equal(
+      testingComponentAsset?.sideEffects,
+      false,
+      'sideEffects should be true for TestingComponent.jsx',
+    );
+  });
+});


### PR DESCRIPTION
Confluence is having an issue adopting the inline requires optimizer because the way Loadable is set up puts a lot of side effects throughout the codebase, and inlining the requires messes that up.

This can be made to work by setting a large number of `package.json`s to have `"sideEffects": true`, but that can easily be ruined by someone incorrectly configuring another package.

A more robust approach is to find any imports of `@confluence/loadable`, and follow the asset graph up to mark all ancestor as having side effects. This ensures that transitive deps will be marked also.

Functionality is locked behind a feature flag.