### PR TITLE
Update the inline requires optimizer to fix ordering bug

### DIFF
--- a/.changeset/metal-games-tell.md
+++ b/.changeset/metal-games-tell.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/optimizer-inline-requires': patch
+---
+
+Fix bug that caused variables preceding their require to be missed (see [pull request] for more information).
+
+[pull request]: https://github.com/atlassian-labs/atlaspack/pull/365

--- a/.changeset/metal-games-tell.md
+++ b/.changeset/metal-games-tell.md
@@ -1,5 +1,6 @@
 ---
 '@atlaspack/optimizer-inline-requires': patch
+'@atlaspack/rust': patch
 ---
 
 Fix bug that caused variables preceding their require to be missed (see [pull request] for more information).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ name = "atlaspack_plugin_optimizer_inline_requires"
 version = "0.1.0"
 dependencies = [
  "atlaspack_swc_runner",
+ "pretty_assertions",
  "swc_core",
 ]
 

--- a/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
@@ -6,23 +6,23 @@ edition = "2021"
 
 [dependencies]
 swc_core = { workspace = true, features = [
-  "common",
-  "common_ahash",
-  "common_sourcemap",
-  "ecma_ast",
-  "ecma_codegen",
-  "ecma_parser",
-  "ecma_preset_env",
-  "ecma_quote",
-  "ecma_transforms",
-  "ecma_transforms_compat",
-  "ecma_transforms_optimization",
-  "ecma_transforms_proposal",
-  "ecma_transforms_react",
-  "ecma_transforms_typescript",
-  "ecma_utils",
-  "ecma_visit",
-  "stacker",
+    "common",
+    "common_ahash",
+    "common_sourcemap",
+    "ecma_ast",
+    "ecma_codegen",
+    "ecma_parser",
+    "ecma_preset_env",
+    "ecma_quote",
+    "ecma_transforms",
+    "ecma_transforms_compat",
+    "ecma_transforms_optimization",
+    "ecma_transforms_proposal",
+    "ecma_transforms_react",
+    "ecma_transforms_typescript",
+    "ecma_utils",
+    "ecma_visit",
+    "stacker"
 ] }
 atlaspack_swc_runner = { path = "../atlaspack_swc_runner" }
 

--- a/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
@@ -6,22 +6,25 @@ edition = "2021"
 
 [dependencies]
 swc_core = { workspace = true, features = [
-    "common",
-    "common_ahash",
-    "common_sourcemap",
-    "ecma_ast",
-    "ecma_codegen",
-    "ecma_parser",
-    "ecma_preset_env",
-    "ecma_quote",
-    "ecma_transforms",
-    "ecma_transforms_compat",
-    "ecma_transforms_optimization",
-    "ecma_transforms_proposal",
-    "ecma_transforms_react",
-    "ecma_transforms_typescript",
-    "ecma_utils",
-    "ecma_visit",
-    "stacker"
+  "common",
+  "common_ahash",
+  "common_sourcemap",
+  "ecma_ast",
+  "ecma_codegen",
+  "ecma_parser",
+  "ecma_preset_env",
+  "ecma_quote",
+  "ecma_transforms",
+  "ecma_transforms_compat",
+  "ecma_transforms_optimization",
+  "ecma_transforms_proposal",
+  "ecma_transforms_react",
+  "ecma_transforms_typescript",
+  "ecma_utils",
+  "ecma_visit",
+  "stacker",
 ] }
 atlaspack_swc_runner = { path = "../atlaspack_swc_runner" }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }


### PR DESCRIPTION
## Motivation

We've recently had a bug reported with the inline requires optimizer, that was causing variables to not be defined.

As an example:
```js
parcelRegister("k4tEj", function(module, exports) {
  Object.defineProperty(module.exports, "InternSet", {
    enumerable: true,
    get: function() {
        return $g34Jm.InternSet;
    }
  });
  // Approx 500 lines of separation...
  var $g34Jm = require("internmap");
});
```

Because the inline requires optimizer replaces as it goes, it can't start inlining requires until it's encountered the first instance of each one in the file. This means that instances of `$g34Jm` below the require of internmap were being inlined, but the ones above were not.

## Changes

To fix this, we've refactored the inline requires optimizer to work as a two-pass system. First, we run a "collector" visitor over the AST, which will located instances of requires that need inlining, store their information, and delete the variable declaration statement. Then, a second pass goes through and performs the inlining.

This ensures that all possible requires have been discovered before any are attempted to be replaced, which avoids the ordering issue.

## Checklist

- [X] There are new tests to cover this change
