### PR TITLE
V3: Get basic incremental builds working in V3

### DIFF
--- a/crates/atlaspack/src/atlaspack.rs
+++ b/crates/atlaspack/src/atlaspack.rs
@@ -145,10 +145,15 @@ impl Atlaspack {
     })
   }
 
-  pub fn respond_to_fs_events(&self, _events: WatchEvents) -> anyhow::Result<bool> {
+  pub fn respond_to_fs_events(&self, events: WatchEvents) -> anyhow::Result<bool> {
     self.runtime.block_on(async move {
-      // TODO: For now just indicate that build must be triggered
-      Ok(true)
+      Ok(
+        self
+          .request_tracker
+          .write()
+          .await
+          .respond_to_fs_events(events),
+      )
     })
   }
 

--- a/crates/atlaspack/src/request_tracker/request_graph.rs
+++ b/crates/atlaspack/src/request_tracker/request_graph.rs
@@ -1,6 +1,6 @@
 use petgraph::stable_graph::StableDiGraph;
 
-use crate::request_tracker::{ResultAndInvalidations, RunRequestError};
+use crate::{request_tracker::RunRequestError, requests::RequestResult};
 
 pub type RequestGraph = StableDiGraph<RequestNode, RequestEdgeType>;
 
@@ -9,10 +9,13 @@ pub enum RequestNode {
   Error(RunRequestError),
   Root,
   Incomplete,
-  Valid(ResultAndInvalidations),
+  Valid(RequestResult),
+  Invalid,
+  FileInvalidation,
 }
 
 #[derive(Debug)]
 pub enum RequestEdgeType {
   SubRequest,
+  FileChangeInvalidation,
 }

--- a/crates/atlaspack/src/requests.rs
+++ b/crates/atlaspack/src/requests.rs
@@ -11,7 +11,7 @@ mod path_request;
 mod target_request;
 
 /// Union of all request outputs
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum RequestResult {
   AssetGraph(AssetGraphRequestOutput),
   Asset(AssetRequestOutput),
@@ -23,4 +23,22 @@ pub enum RequestResult {
   TestSub(String),
   #[cfg(test)]
   TestMain(Vec<String>),
+}
+
+impl std::fmt::Debug for RequestResult {
+  fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    match self {
+      RequestResult::AssetGraph(_) => write!(f, "AssetGraph"),
+      RequestResult::Asset(asset_request) => {
+        write!(f, "Asset({:?})", asset_request.asset.file_path)
+      }
+      RequestResult::Entry(_) => write!(f, "Entry"),
+      RequestResult::Path(_) => write!(f, "Path"),
+      RequestResult::Target(_) => write!(f, "Target"),
+      #[cfg(test)]
+      RequestResult::TestSub(_) => write!(f, "TestSub"),
+      #[cfg(test)]
+      RequestResult::TestMain(_) => write!(f, "TestMain"),
+    }
+  }
 }

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -129,6 +129,11 @@ impl Request for AssetRequest {
       time: start.elapsed().as_millis().try_into().unwrap_or(u32::MAX),
     };
 
+    // Ensure the asset source file is marked as an invalidation
+    result
+      .invalidate_on_file_change
+      .push(result.asset.file_path.clone());
+
     Ok(ResultAndInvalidations {
       result: RequestResult::Asset(AssetRequestOutput {
         asset: result.asset,

--- a/crates/atlaspack/src/requests/asset_request.rs
+++ b/crates/atlaspack/src/requests/asset_request.rs
@@ -1,6 +1,7 @@
 use anyhow::anyhow;
 use async_trait::async_trait;
 use atlaspack_core::config_loader::ConfigLoader;
+use atlaspack_core::hash::hash_bytes;
 use atlaspack_core::plugin::AssetBuildEvent;
 use atlaspack_core::plugin::BuildProgressEvent;
 use atlaspack_core::plugin::ReporterEvent;
@@ -128,6 +129,10 @@ impl Request for AssetRequest {
       size: result.asset.code.size(),
       time: start.elapsed().as_millis().try_into().unwrap_or(u32::MAX),
     };
+
+    // Assign the output hash for the Asset now that all transforms have been
+    // applied
+    result.asset.output_hash = Some(hash_bytes(result.asset.code.bytes()));
 
     // Ensure the asset source file is marked as an invalidation
     result

--- a/crates/atlaspack_core/src/hash.rs
+++ b/crates/atlaspack_core/src/hash.rs
@@ -12,7 +12,10 @@ pub type IdentifierHasher = Xxh3;
 
 /// Copy of one of the `node-bindings/src/hash.rs` functions.
 pub fn hash_string(s: String) -> String {
-  let s = s.as_bytes();
+  hash_bytes(s.as_bytes())
+}
+
+pub fn hash_bytes(s: &[u8]) -> String {
   let res = xxh3_64(s);
   format!("{:016x}", res)
 }

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -226,6 +226,10 @@ pub struct Asset {
   /// True if the asset has CommonJS exports
   pub has_cjs_exports: bool,
 
+  /// The content hash for the final transformed source code of the Asset
+  /// Used for calculating the hash of any Bundles the Asset is assigned to
+  pub output_hash: Option<String>,
+
   /// This is true unless the module is a CommonJS module that does non-static access of the
   /// `this`, `exports` or `module.exports` objects. For example if the module uses code like
   /// `module.exports[key] = 10`.

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1124,10 +1124,7 @@ export class RequestGraph extends ContentGraph<
       },
     });
 
-    return (
-      getFeatureFlag('atlaspackV3') ||
-      (didInvalidate && this.invalidNodeIds.size > 0)
-    );
+    return didInvalidate && this.invalidNodeIds.size > 0;
   }
 
   hasCachedRequestChunk(index: number): boolean {

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1124,7 +1124,10 @@ export class RequestGraph extends ContentGraph<
       },
     });
 
-    return didInvalidate && this.invalidNodeIds.size > 0;
+    return (
+      getFeatureFlag('atlaspackV3') ||
+      (didInvalidate && this.invalidNodeIds.size > 0)
+    );
   }
 
   hasCachedRequestChunk(index: number): boolean {

--- a/packages/core/core/src/requests/AtlaspackBuildRequest.js
+++ b/packages/core/core/src/requests/AtlaspackBuildRequest.js
@@ -61,7 +61,7 @@ export default function createAtlaspackBuildRequest(
   };
 }
 
-async function run({input, api, options}) {
+async function run({input, api, options, rustAtlaspack}) {
   let {optionsRef, requestedAssetIds, signal} = input;
 
   let bundleGraphRequest = createBundleGraphRequest({
@@ -72,7 +72,9 @@ async function run({input, api, options}) {
 
   let {bundleGraph, changedAssets, assetRequests}: BundleGraphResult =
     await api.runRequest(bundleGraphRequest, {
-      force: options.shouldBuildLazily && requestedAssetIds.size > 0,
+      force:
+        Boolean(rustAtlaspack) ||
+        (options.shouldBuildLazily && requestedAssetIds.size > 0),
     });
 
   // $FlowFixMe Added in Flow 0.121.0 upgrade in #4381 (Windows only)

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -197,10 +197,7 @@ export default function createBundleGraphRequest(
       //       force: true,
       //     },
       //   );
-      //   require('../../lib/requests/asset-graph-diff.js')(
-      //     jsAssetGraph,
-      //     assetGraph,
-      //   );
+      //   require('./asset-graph-diff.js')(jsAssetGraph, assetGraph);
       // }
 
       measurement && measurement.end();

--- a/packages/core/core/src/requests/BundleGraphRequest.js
+++ b/packages/core/core/src/requests/BundleGraphRequest.js
@@ -163,7 +163,9 @@ export default function createBundleGraphRequest(
       let {assetGraph, changedAssets, assetRequests} = await api.runRequest(
         request,
         {
-          force: options.shouldBuildLazily && requestedAssetIds.size > 0,
+          force:
+            Boolean(input.rustAtlaspack) ||
+            (options.shouldBuildLazily && requestedAssetIds.size > 0),
         },
       );
 
@@ -195,7 +197,10 @@ export default function createBundleGraphRequest(
       //       force: true,
       //     },
       //   );
-      //   require('./asset-graph-diff.js')(jsAssetGraph, assetGraph);
+      //   require('../../lib/requests/asset-graph-diff.js')(
+      //     jsAssetGraph,
+      //     assetGraph,
+      //   );
       // }
 
       measurement && measurement.end();

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -23,7 +23,7 @@ import {symlinkSync} from 'fs';
 const inputDir = path.join(__dirname, '/watcher');
 const distDir = path.join(inputDir, 'dist');
 
-describe.v2('watcher', function () {
+describe('watcher', function () {
   let subscription;
   afterEach(async () => {
     if (subscription) {
@@ -59,30 +59,33 @@ describe.v2('watcher', function () {
     assert.equal(output, 'something else');
   });
 
-  it('should rebuild on a source file change after a failed transformation', async () => {
-    await outputFS.mkdirp(inputDir);
-    await outputFS.writeFile(
-      path.join(inputDir, '/index.js'),
-      'syntax\\error',
-      {encoding: 'utf8'},
-    );
-    let b = bundler(path.join(inputDir, '/index.js'), {inputFS: overlayFS});
-    subscription = await b.watch();
-    let buildEvent = await getNextBuild(b);
-    assert.equal(buildEvent.type, 'buildFailure');
-    await outputFS.writeFile(
-      path.join(inputDir, '/index.js'),
-      'module.exports = "hello"',
-      {encoding: 'utf8'},
-    );
-    buildEvent = await getNextBuild(b);
-    if (!buildEvent.bundleGraph) return assert.fail();
-    let output = await run(buildEvent.bundleGraph);
+  it.v2(
+    'should rebuild on a source file change after a failed transformation',
+    async () => {
+      await outputFS.mkdirp(inputDir);
+      await outputFS.writeFile(
+        path.join(inputDir, '/index.js'),
+        'syntax\\error',
+        {encoding: 'utf8'},
+      );
+      let b = bundler(path.join(inputDir, '/index.js'), {inputFS: overlayFS});
+      subscription = await b.watch();
+      let buildEvent = await getNextBuild(b);
+      assert.equal(buildEvent.type, 'buildFailure');
+      await outputFS.writeFile(
+        path.join(inputDir, '/index.js'),
+        'module.exports = "hello"',
+        {encoding: 'utf8'},
+      );
+      buildEvent = await getNextBuild(b);
+      if (!buildEvent.bundleGraph) return assert.fail();
+      let output = await run(buildEvent.bundleGraph);
 
-    assert.equal(output, 'hello');
-  });
+      assert.equal(output, 'hello');
+    },
+  );
 
-  it('should rebuild on a config file change', async function () {
+  it.v2('should rebuild on a config file change', async function () {
     let inDir = path.join(__dirname, 'integration/parcelrc-custom');
     let outDir = path.join(inDir, 'dist');
 
@@ -114,36 +117,42 @@ describe.v2('watcher', function () {
     assert(distFile.includes('TRANSFORMED CODE'));
   });
 
-  it('should rebuild properly when a dependency is removed', async function () {
-    await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
+  it.v2(
+    'should rebuild properly when a dependency is removed',
+    async function () {
+      await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
 
-    let b = bundler(path.join(inputDir, 'index.js'), {
-      inputFS: overlayFS,
-      targets: {
-        main: {
-          engines: {
-            node: '^8.0.0',
+      let b = bundler(path.join(inputDir, 'index.js'), {
+        inputFS: overlayFS,
+        targets: {
+          main: {
+            engines: {
+              node: '^8.0.0',
+            },
+            distDir,
           },
-          distDir,
         },
-      },
-    });
+      });
 
-    subscription = await b.watch();
-    await getNextBuild(b);
-    let distFile = await outputFS.readFile(
-      path.join(distDir, 'index.js'),
-      'utf8',
-    );
-    assert(distFile.includes('Foo'));
-    await outputFS.writeFile(
-      path.join(inputDir, 'index.js'),
-      'console.log("no more dependencies")',
-    );
-    await getNextBuild(b);
-    distFile = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(!distFile.includes('Foo'));
-  });
+      subscription = await b.watch();
+      await getNextBuild(b);
+      let distFile = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(distFile.includes('Foo'));
+      await outputFS.writeFile(
+        path.join(inputDir, 'index.js'),
+        'console.log("no more dependencies")',
+      );
+      await getNextBuild(b);
+      distFile = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(!distFile.includes('Foo'));
+    },
+  );
 
   it.skip('should re-generate bundle tree when files change', async function () {
     await ncp(path.join(__dirname, '/integration/dynamic-hoist'), inputDir);
@@ -418,7 +427,7 @@ describe.v2('watcher', function () {
     }
   });
 
-  it('should add and remove necessary runtimes to bundles', async () => {
+  it.v2('should add and remove necessary runtimes to bundles', async () => {
     await ncp(path.join(__dirname, 'integration/dynamic'), inputDir);
 
     let indexPath = path.join(inputDir, 'index.js');
@@ -473,7 +482,7 @@ describe.v2('watcher', function () {
     ]);
   });
 
-  it('should rebuild if a missing file is added', async function () {
+  it.v2('should rebuild if a missing file is added', async function () {
     await outputFS.mkdirp(inputDir);
     await outputFS.writeFile(
       path.join(inputDir, '/index.js'),

--- a/packages/utils/node-resolver-rs/src/cache.rs
+++ b/packages/utils/node-resolver-rs/src/cache.rs
@@ -178,7 +178,7 @@ impl Cache {
 
   pub fn read_package(&self, path: Cow<Path>) -> Arc<Result<Arc<PackageJson>, ResolverError>> {
     if let Some(pkg) = self.package_duplicates.get(path.as_ref()) {
-      tracing::info!("Deduplicating package import: {:?} -> {:?}", path, pkg.path);
+      tracing::debug!("Deduplicating package import: {:?} -> {:?}", path, pkg.path);
       return Arc::new(Ok(pkg.clone()));
     }
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR adds the remaining features to get the first watcher test running against V3. 

## Changes

- Add `Invalid` and `FileInvalidation` request graph node types
- Assign request invalidations to the graph during `store_request`
- Add new `respond_to_fs_events` API to the native request tracker which invalidates relevant request results from prior builds
- Add  `asset.file_path` as an invalidation to all asset requests
- Add `asset.output_hash` and set it after finishing the transformation pipeline
  - This fixes false positive cache responses in the packaging phase
- Force parcel build request and bundle graph requests when native is set 

## Checklist

- [x] Existing or new tests cover this change
