### PR TITLE
Use new server syntax that works in jest env

### DIFF
--- a/.changeset/hip-deers-occur.md
+++ b/.changeset/hip-deers-occur.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/babel-plugin-transform-contextual-imports': minor
+---
+
+Use new transformed syntax in @atlaspack/babel-plugin-transform-contextual-imports to better support jest

--- a/packages/utils/babel-plugin-transform-contextual-imports/package.json
+++ b/packages/utils/babel-plugin-transform-contextual-imports/package.json
@@ -15,11 +15,11 @@
     "node": ">= 16.0.0"
   },
   "dependencies": {
-    "@babel/core": "^7.12.2",
+    "@babel/core": "^7.22.11",
     "@babel/helper-plugin-utils": "^7.12.2"
   },
   "devDependencies": {
-    "@types/babel__core": "^7.10.3",
+    "@types/babel__core": "^7.20.5",
     "@types/babel__helper-plugin-utils": "^7.10.3"
   }
 }

--- a/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
+++ b/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
@@ -178,6 +178,7 @@ export default declare((api): PluginObj<State> => {
               if (call && isImportCondCallExpression(call)) {
                 const [cond, ifTrue, ifFalse] = call.arguments;
 
+                // Replace with object containing imports and lazy getter, which allows us to load the correct import based on the condition at runtime
                 path.replaceWithMultiple(
                   buildNodeObject(importId, cond, ifTrue, ifFalse),
                 );

--- a/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
+++ b/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
@@ -1,19 +1,18 @@
-import {PluginObj} from '@babel/core';
+import type {PluginObj} from '@babel/core';
 import {declare} from '@babel/helper-plugin-utils';
 import type {StringLiteral} from '@babel/types';
 
 interface Opts {
+  // Use node safe import cond syntax
   server?: boolean;
 }
 
 interface State {
   opts: Opts;
-  importNodes?: any[]; // Statement types didn't work so using any
+  importMap?: Map<string, string>;
 }
 
-const isServer = (opts: Opts) => {
-  return 'server' in opts && opts.server;
-};
+const isServer = (opts: Opts): boolean => !!('server' in opts && opts.server);
 
 export default declare((api): PluginObj<State> => {
   const {types: t} = api;
@@ -131,30 +130,12 @@ export default declare((api): PluginObj<State> => {
             path.node.callee.name === 'importCond'
           ) {
             if (
-              path.node.arguments.length == 3 &&
+              path.node.arguments.length === 3 &&
               path.node.arguments.every((arg) => arg.type === 'StringLiteral')
             ) {
               const [cond, ifTrue, ifFalse] = path.node.arguments;
 
-              if (isServer(state.opts)) {
-                // Make module pass lazy in ssr
-                const identUid = path.scope.generateUid(
-                  `${cond.value}$${ifTrue.value}$${ifFalse.value}`,
-                );
-
-                state.importNodes ??= [];
-                state.importNodes.push(
-                  ...buildServerObject(identUid, cond, ifTrue, ifFalse),
-                );
-
-                // Replace call expression with reference to lazy object getter
-                path.replaceWith(
-                  t.memberExpression(
-                    t.identifier(identUid),
-                    t.identifier('load'),
-                  ),
-                );
-              } else {
+              if (!isServer(state.opts)) {
                 path.replaceWith(buildCondFunction(cond, ifTrue, ifFalse));
               }
             } else {
@@ -166,12 +147,66 @@ export default declare((api): PluginObj<State> => {
           }
         },
       },
-      Program: {
-        exit(path, state) {
-          if (state.importNodes) {
-            // If there's an import
-            path.unshiftContainer('body', state.importNodes);
+      VariableDeclaration: {
+        enter(path, state) {
+          if (isServer(state.opts)) {
+            if (
+              path.node.declarations.length === 1 &&
+              path.node.declarations[0].type === 'VariableDeclarator' &&
+              path.node.declarations[0].id.type === 'Identifier'
+            ) {
+              const importId = path.node.declarations[0].id;
+              const call = path.node.declarations[0].init;
+
+              if (call?.type === 'CallExpression') {
+                if (
+                  call.callee.type === 'Identifier' &&
+                  call.callee.name === 'importCond'
+                ) {
+                  if (
+                    call.arguments.length === 3 &&
+                    call.arguments.every((arg) => arg.type === 'StringLiteral')
+                  ) {
+                    const [cond, ifTrue, ifFalse] = call.arguments;
+
+                    // Make module pass lazy in ssr
+                    const identUid = path.scope.generateUid(
+                      `${cond.value}$${ifTrue.value}$${ifFalse.value}`,
+                    );
+
+                    path.replaceWithMultiple(
+                      buildServerObject(identUid, cond, ifTrue, ifFalse),
+                    );
+
+                    state.importMap?.set(importId.name, identUid);
+                  } else {
+                    // Simple error for incorrect syntax (since it's documented with the type)
+                    throw new Error(
+                      'importCond must have three string literal arguments',
+                    );
+                  }
+                }
+              }
+            }
           }
+        },
+      },
+      Identifier: {
+        exit(path, state) {
+          const newImportId = state.importMap?.get(path.node.name);
+          if (newImportId) {
+            path.replaceWith(
+              t.memberExpression(
+                t.identifier(newImportId),
+                t.identifier('load'),
+              ),
+            );
+          }
+        },
+      },
+      Program: {
+        enter(_, state) {
+          state.importMap = new Map();
         },
       },
     },

--- a/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
+++ b/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
@@ -4,7 +4,7 @@ import type {StringLiteral} from '@babel/types';
 
 interface Opts {
   // Use node safe import cond syntax
-  server?: boolean;
+  node?: boolean;
 }
 
 interface State {
@@ -12,7 +12,7 @@ interface State {
   importMap?: Map<string, string>;
 }
 
-const isServer = (opts: Opts): boolean => !!('server' in opts && opts.server);
+const isNode = (opts: Opts): boolean => !!('node' in opts && opts.node);
 
 export default declare((api): PluginObj<State> => {
   const {types: t} = api;
@@ -44,7 +44,7 @@ export default declare((api): PluginObj<State> => {
       ),
     );
 
-  const buildServerObject = (
+  const buildNodeObject = (
     identUid: string,
     cond: StringLiteral,
     ifTrue: StringLiteral,
@@ -135,7 +135,7 @@ export default declare((api): PluginObj<State> => {
             ) {
               const [cond, ifTrue, ifFalse] = path.node.arguments;
 
-              if (!isServer(state.opts)) {
+              if (!isNode(state.opts)) {
                 path.replaceWith(buildCondFunction(cond, ifTrue, ifFalse));
               }
             } else {
@@ -149,7 +149,7 @@ export default declare((api): PluginObj<State> => {
       },
       VariableDeclaration: {
         enter(path, state) {
-          if (isServer(state.opts)) {
+          if (isNode(state.opts)) {
             if (
               path.node.declarations.length === 1 &&
               path.node.declarations[0].type === 'VariableDeclarator' &&
@@ -175,7 +175,7 @@ export default declare((api): PluginObj<State> => {
                     );
 
                     path.replaceWithMultiple(
-                      buildServerObject(identUid, cond, ifTrue, ifFalse),
+                      buildNodeObject(identUid, cond, ifTrue, ifFalse),
                     );
 
                     state.importMap?.set(importId.name, identUid);

--- a/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
+++ b/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
@@ -8,7 +8,9 @@ interface Opts {
 
 interface State {
   opts: Opts;
+  // Set of identifier names that need to be mutated after import was transformed
   conditionalImportIdentifiers?: Set<string>;
+  // Set of identifiers that have been visited in the exit pass, to avoid adding the load property multiple times
   visitedIdentifiers?: Set<BabelTypes.Identifier>;
 }
 

--- a/packages/utils/babel-plugin-transform-contextual-imports/test/babel-plugin-transform-contextual-imports.test.js
+++ b/packages/utils/babel-plugin-transform-contextual-imports/test/babel-plugin-transform-contextual-imports.test.js
@@ -10,7 +10,7 @@ describe('@atlaspack/babel-plugin-transform-contextual-imports', () => {
     const input = `
       const Imported = importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
     `;
-    let {code: transformed} = babel.transformSync(input, {
+    const {code: transformed} = babel.transformSync(input, {
       configFile: false,
       presets: [],
       plugins: [plugin],
@@ -28,10 +28,10 @@ describe('@atlaspack/babel-plugin-transform-contextual-imports', () => {
 
       console.log(Imported);
     `;
-    let {code: transformed} = babel.transformSync(input, {
+    const {code: transformed} = babel.transformSync(input, {
       configFile: false,
       presets: [],
-      plugins: [[plugin, {server: true}]],
+      plugins: [[plugin, {node: true}]],
     });
 
     assert.equal(

--- a/packages/utils/babel-plugin-transform-contextual-imports/test/babel-plugin-transform-contextual-imports.test.js
+++ b/packages/utils/babel-plugin-transform-contextual-imports/test/babel-plugin-transform-contextual-imports.test.js
@@ -26,7 +26,7 @@ describe('@atlaspack/babel-plugin-transform-contextual-imports', () => {
     const input = `
       const Imported = importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
 
-      console.log(Imported);
+      console.log(Imported, Imported.someProperty);
     `;
     const {code: transformed} = babel.transformSync(input, {
       configFile: false,
@@ -36,14 +36,14 @@ describe('@atlaspack/babel-plugin-transform-contextual-imports', () => {
 
     assert.equal(
       transformed,
-      `const _CONDITION$IF_TRUE$IF_FALSE = {
+      `const Imported = {
   ifTrue: require('IF_TRUE').default,
   ifFalse: require('IF_FALSE').default
 };
-Object.defineProperty(_CONDITION$IF_TRUE$IF_FALSE, "load", {
-  get: () => globalThis.__MCOND && globalThis.__MCOND('CONDITION') ? _CONDITION$IF_TRUE$IF_FALSE.ifTrue : _CONDITION$IF_TRUE$IF_FALSE.ifFalse
+Object.defineProperty(Imported, "load", {
+  get: () => globalThis.__MCOND && globalThis.__MCOND('CONDITION') ? Imported.ifTrue : Imported.ifFalse
 });
-console.log(_CONDITION$IF_TRUE$IF_FALSE.load);`,
+console.log(Imported.load, Imported.load.someProperty);`,
     );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3735,7 +3735,7 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/babel__core@*", "@types/babel__core@^7.10.3":
+"@types/babel__core@*", "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==
@@ -15415,7 +15415,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15440,15 +15440,6 @@ string-width@^1.0.1, string-width@^1.0.2:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15537,7 +15528,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15557,13 +15548,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -17106,7 +17090,7 @@ workerpool@6.1.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
   integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17127,15 +17111,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

For supporting importCond with jest APIs, it's much more trivial to lean on the server style proxying of the import object. This means we can set the feature gate at runtime, allowing for feature gate test suites to work seamlessly in the monorepo. It may make more sense to just support loading fresh modules (more like the browser environment), but it's a big rabbit hole to go down for a small benefit.

## Changes

This change moves to update each identifier in the module, referencing importCond assignment, to the lazy getter.

## Checklist

- [x] Existing or new tests cover this change
