### PR TITLE
Track watcher callback errors

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -502,9 +502,12 @@ export default class Atlaspack {
       resolvedOptions.watchDir,
       async (err, events) => {
         if (err) {
-          logger.verbose({
+          logger.warn({
             message: `File watch event error occured`,
-            meta: {err},
+            meta: {
+              err,
+              trackableEvent: 'watcher_error',
+            },
           });
           this.#watchEvents.emit({error: err});
           return;


### PR DESCRIPTION
Let's forward watcher errors to monitoring

Test Plan: N/A
