### PR TITLE
Reduce resolver allocations

### DIFF
--- a/.changeset/swift-meals-ring.md
+++ b/.changeset/swift-meals-ring.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/rust': patch
+'@atlaspack/node-resolver-core': patch
+---
+
+Reduce allocations in the resolver

--- a/packages/utils/node-resolver-rs/src/lib.rs
+++ b/packages/utils/node-resolver-rs/src/lib.rs
@@ -1005,7 +1005,7 @@ impl<'a> ResolveRequest<'a> {
 
     if let Some(tsconfig) = self.tsconfig_read()? {
       if let Some(module_suffixs) = tsconfig.module_suffixes.as_ref() {
-        module_suffixes = module_suffixs.clone()
+        module_suffixes = module_suffixs.as_ref().clone()
       };
     }
 

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -16,11 +16,11 @@ use serde::Deserialize;
 pub struct TsConfig {
   #[serde(skip)]
   pub path: PathBuf,
-  base_url: Option<PathBuf>,
-  paths: Option<HashMap<Specifier, Vec<String>>>,
+  base_url: Option<Arc<PathBuf>>,
+  paths: Option<Arc<HashMap<Specifier, Vec<String>>>>,
   #[serde(skip)]
-  paths_base: PathBuf,
-  pub module_suffixes: Option<Vec<String>>,
+  paths_base: Arc<PathBuf>,
+  pub module_suffixes: Option<Arc<Vec<String>>>,
   // rootDirs??
 }
 
@@ -88,14 +88,14 @@ impl TsConfig {
   fn validate(&mut self) {
     #[allow(clippy::needless_borrows_for_generic_args)]
     if let Some(base_url) = &mut self.base_url {
-      *base_url = resolve_path(&self.path, &base_url);
+      *base_url = Arc::new(resolve_path(&self.path, &**base_url));
     }
 
     if self.paths.is_some() {
       self.paths_base = if let Some(base_url) = &self.base_url {
-        base_url.to_owned()
+        base_url.clone()
       } else {
-        self.path.parent().unwrap().to_owned()
+        Arc::new(self.path.parent().unwrap().to_owned())
       };
     }
   }

--- a/packages/utils/node-resolver-rs/src/tsconfig.rs
+++ b/packages/utils/node-resolver-rs/src/tsconfig.rs
@@ -217,7 +217,7 @@ mod tests {
   fn test_paths() {
     let mut tsconfig = TsConfig {
       path: "/foo/tsconfig.json".into(),
-      paths: Some(HashMap::from([
+      paths: Some(Arc::new(HashMap::from([
         (
           "jquery".into(),
           vec![String::from("node_modules/jquery/dist/jquery")],
@@ -230,7 +230,7 @@ mod tests {
         ),
         ("@/components/*".into(), vec![String::from("components/*")]),
         ("url".into(), vec![String::from("node_modules/my-url")]),
-      ])),
+      ]))),
       ..Default::default()
     };
     tsconfig.validate();
@@ -263,7 +263,7 @@ mod tests {
   fn test_base_url() {
     let mut tsconfig = TsConfig {
       path: "/foo/tsconfig.json".into(),
-      base_url: Some(Path::new("src").into()),
+      base_url: Some(Arc::new(Path::new("src").into())),
       ..Default::default()
     };
     tsconfig.validate();
@@ -282,8 +282,8 @@ mod tests {
   fn test_paths_and_base_url() {
     let mut tsconfig = TsConfig {
       path: "/foo/tsconfig.json".into(),
-      base_url: Some(Path::new("src").into()),
-      paths: Some(HashMap::from([
+      base_url: Some(Arc::new(Path::new("src").into())),
+      paths: Some(Arc::new(HashMap::from([
         ("*".into(), vec![String::from("generated/*")]),
         ("bar/*".into(), vec![String::from("test/*")]),
         (
@@ -291,7 +291,7 @@ mod tests {
           vec![String::from("baz/*"), String::from("yo/*")],
         ),
         ("@/components/*".into(), vec![String::from("components/*")]),
-      ])),
+      ]))),
       ..Default::default()
     };
     tsconfig.validate();


### PR DESCRIPTION
It seems we are doing a lot of memory allocation on `TsConfig::extends`, which
should be fixed by this diff.

Test Plan: cargo test
