### PR TITLE
Add warning when using javascript fs

### DIFF
--- a/.changeset/tasty-maps-serve.md
+++ b/.changeset/tasty-maps-serve.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/node-resolver-core': patch
+---
+
+Warn when using JavaScript file-systems for the resolver

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -82,19 +82,28 @@ export default class NodeResolver {
     let resolver = this.resolversByEnv.get(options.env.id);
     if (!resolver) {
       await init?.();
+      const useJavaScriptFs =
+        this.options.fs instanceof NodeFS &&
+        process.versions.pnp == null &&
+        // For Wasm builds
+        !init;
+
+      if (useJavaScriptFs && process.env.NODE_ENV !== 'test') {
+        this.options.logger?.warn({
+          message:
+            'Using JavaScript file system for resolution. This should not be used in other than internal atlaspack tests.',
+        });
+      }
+
       resolver = new Resolver(this.options.projectRoot, {
-        fs:
-          this.options.fs instanceof NodeFS &&
-          process.versions.pnp == null &&
-          // For Wasm builds
-          !init
-            ? undefined
-            : {
-                canonicalize: (path) => this.options.fs.realpathSync(path),
-                read: (path) => this.options.fs.readFileSync(path),
-                isFile: (path) => this.options.fs.statSync(path).isFile(),
-                isDir: (path) => this.options.fs.statSync(path).isDirectory(),
-              },
+        fs: useJavaScriptFs
+          ? undefined
+          : {
+              canonicalize: (path) => this.options.fs.realpathSync(path),
+              read: (path) => this.options.fs.readFileSync(path),
+              isFile: (path) => this.options.fs.statSync(path).isFile(),
+              isDir: (path) => this.options.fs.statSync(path).isDirectory(),
+            },
         mode: 1,
         includeNodeModules: options.env.includeNodeModules,
         entries: this.options.mainFields


### PR DESCRIPTION
Warn if the resolver falls into the JavaScript fs.

Test Plan: yarn test
