### PR TITLE
Use older babel version to avoid requiring babel bump

### DIFF
--- a/packages/utils/babel-plugin-transform-contextual-imports/package.json
+++ b/packages/utils/babel-plugin-transform-contextual-imports/package.json
@@ -15,11 +15,11 @@
     "node": ">= 16.0.0"
   },
   "dependencies": {
-    "@babel/core": "^7.22.11",
+    "@babel/core": "^7.12.2",
     "@babel/helper-plugin-utils": "^7.12.2"
   },
   "devDependencies": {
-    "@types/babel__core": "^7.20.5",
+    "@types/babel__core": "^7.12.2",
     "@types/babel__helper-plugin-utils": "^7.10.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3735,7 +3735,7 @@
   dependencies:
     tslib "^2.4.0"
 
-"@types/babel__core@*", "@types/babel__core@^7.20.5":
+"@types/babel__core@*", "@types/babel__core@^7.12.2":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
   integrity sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Using this babel plugin version in SSR requires us to bump babel. Given that unnecessary risk, downgrading again.

## Changes

`"@babel/core": "^7.22.11",` to `"@babel/core": "^7.12.2",`

## Checklist

- [ ] Existing or new tests cover this change
