### PR TITLE
Clean-up lmdb js lite feature-flag

### DIFF
--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -12,7 +12,7 @@ import type {AtlaspackOptions} from './types';
 import path from 'path';
 import {hashString} from '@atlaspack/rust';
 import {NodeFS, NodeVCSAwareFS} from '@atlaspack/fs';
-import {LMDBCache, LMDBLiteCache, FSCache} from '@atlaspack/cache';
+import {LMDBLiteCache, FSCache} from '@atlaspack/cache';
 import {getFeatureFlag, getFeatureFlagValue} from '@atlaspack/feature-flags';
 import {NodePackageManager} from '@atlaspack/package-manager';
 import {
@@ -146,14 +146,12 @@ export default async function resolveOptions(
       ? path.resolve(initialOptions.watchDir)
       : projectRoot;
 
-  const needsRustLmdbCache =
-    getFeatureFlag('useLmdbJsLite') || getFeatureFlag('atlaspackV3');
+  const needsRustLmdbCache = getFeatureFlag('atlaspackV3');
 
-  let cache = needsRustLmdbCache
-    ? new LMDBLiteCache(cacheDir)
-    : outputFS instanceof NodeFS
-    ? new LMDBCache(cacheDir)
-    : new FSCache(outputFS, cacheDir);
+  let cache =
+    outputFS instanceof NodeFS || needsRustLmdbCache
+      ? new LMDBLiteCache(cacheDir)
+      : new FSCache(outputFS, cacheDir);
 
   let mode = initialOptions.mode ?? 'development';
   let shouldOptimize =

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -12,7 +12,6 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   useWatchmanWatcher: false,
   importRetry: false,
   fixQuadraticCacheInvalidation: 'OLD',
-  useLmdbJsLite: false,
   conditionalBundlingApi: false,
   vcsMode: 'OLD',
   loadableSideEffects: false,

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -17,10 +17,6 @@ export type FeatureFlags = {|
    */
   importRetry: boolean,
   /**
-   * Enable Rust based LMDB wrapper library
-   */
-  useLmdbJsLite: boolean,
-  /**
    * Fixes quadratic cache invalidation issue
    */
   fixQuadraticCacheInvalidation: ConsistencyCheckFeatureFlagValue,

--- a/packages/core/integration-tests/test/vcs-cache.js
+++ b/packages/core/integration-tests/test/vcs-cache.js
@@ -277,7 +277,6 @@ describe('vcs cache', () => {
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });
@@ -329,7 +328,6 @@ describe('vcs cache', () => {
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });
@@ -385,7 +383,6 @@ describe('vcs cache', () => {
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });
@@ -424,7 +421,6 @@ describe('vcs cache', () => {
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });
@@ -479,7 +475,6 @@ describe('vcs cache', () => {
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });
@@ -539,7 +534,6 @@ describe('vcs cache', () => {
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });
@@ -684,7 +678,6 @@ __metadata:
       outputFS: vcsFS,
       shouldDisableCache: false,
       featureFlags: {
-        useLmdbJsLite: true,
         vcsMode: 'NEW',
       },
     });


### PR DESCRIPTION
Rust backed LMDB cache is now the default.

Test Plan: yarn test:integration
