### PR TITLE
Fix re-used bundles for async imports with circular dependencies

### DIFF
--- a/.changeset/warm-eagles-tell.md
+++ b/.changeset/warm-eagles-tell.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/bundler-default': patch
+---
+
+Fix re-used bundles for async imports with circular dependencies

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -961,7 +961,7 @@ export function createIdealGraph(
           );
 
           reachableIntersection.forEach((otherCandidateId) => {
-            // In the case of a ciruclar dependency, you may end up with two
+            // In the case of a circular dependency, you may end up with two
             // reusable bundles that each delete the other, leaving no reusable
             // bundles actually reachable. This check is to avoid assigning the
             // asset to a reusable bundle that has already been marked unreachable.

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -961,6 +961,12 @@ export function createIdealGraph(
           );
 
           reachableIntersection.forEach((otherCandidateId) => {
+            // In the case of a ciruclar dependency, you may end up with two
+            // reusable bundles that each delete the other, leaving no reusable
+            // bundles actually reachable. This check is to avoid assigning the
+            // asset to a reusable bundle that has already been marked unreachable.
+            if (!reachable.has(otherCandidateId)) return;
+
             let otherReuseCandidate = assets[otherCandidateId];
             if (candidateSourceBundleRoot === otherReuseCandidate) return;
             let reusableBundleId = nullthrows(


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR resolves an issue with re-used bundles when they have circular dependencies on each other. Previous to this fix, Assets that were required by two async bundles that had a circular dependency on each other would not be placed in either bundle, causing `Cannot find module` errors at runtime.  

## Changes

The change here ensures that Assets are not removed from reused bundles when there isn't anywhere else safe to put them. 

## Checklist

- [x] Existing or new tests cover this change
