### PR TITLE
Remove fold from inlineFs

### DIFF
--- a/.changeset/dirty-mangos-lick.md
+++ b/.changeset/dirty-mangos-lick.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/transformer-js': patch
+---
+
+Replace Fold with VisitMut in InlineFS to improve performance

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -85,7 +85,6 @@ use swc_core::ecma::transforms::optimization::simplify::expr_simplifier;
 use swc_core::ecma::transforms::proposal::decorators;
 use swc_core::ecma::transforms::react;
 use swc_core::ecma::transforms::typescript;
-use swc_core::ecma::visit::fold_pass;
 use swc_core::ecma::visit::visit_mut_pass;
 use swc_core::ecma::visit::FoldWith;
 use swc_core::ecma::visit::VisitMutWith;
@@ -411,7 +410,7 @@ pub fn transform(
                   dead_branch_remover(unresolved_mark),
                   // Inline Node fs.readFileSync calls
                   Optional::new(
-                    fold_pass(inline_fs(
+                    visit_mut_pass(inline_fs(
                       config.filename.as_str(),
                       source_map.clone(),
                       unresolved_mark,


### PR DESCRIPTION
## Motivation

We have seen some segfaults again that may be related to the fold usages within the transformer. These changes replace `Fold` with `VisitMut` in the `inlineFS` feature of the JS transformer.

## Changes

Replace `impl Fold` with `impl VisitMut` in `InlineFS` and add new test cases

## Checklist

- [x] Existing or new tests cover this change
