### PR TITLE
Fix development releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,12 +222,12 @@ jobs:
           npm config set registry https://registry.npmjs.org/
       - run: ${{ inputs.release-command }}
       - name: Get canary version
-        if: ${{ inputs.profile == 'canary' }}
+        if: ${{ inputs.type == 'canary' }}
         id: canary-version
         run: echo "VERSION_TAG=$(npm show @atlaspack/cli@canary --json | jq .version -r)" >> "$GITHUB_OUTPUT"
       - name: Create tag
         uses: actions/github-script@v5
-        if: ${{ inputs.profile == 'canary' }}
+        if: ${{ inputs.type == 'canary' }}
         with:
           script: |
             github.rest.git.createRef({


### PR DESCRIPTION
## Motivation

Development releases currently fail on the "Create tag" step since the canary tag has already been created. This step should not run for development releases.

## Changes

Use `inputs.type` instead of `inputs.profile` when checking to see if the release should be tagged