### PR TITLE
Replace Fold with VisitMut in the dependency collector

### DIFF
--- a/.changeset/shiny-bikes-compete.md
+++ b/.changeset/shiny-bikes-compete.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/transformer-js': patch
+---
+
+Replace Fold with VisitMut in the dependency collector to improve performance


### PR DESCRIPTION
## Motivation

We have seen some segfaults again that may be related to the fold usages within the transformer. These changes replace `Fold` with `VisitMut` in the dependency collector of the JS transformer.

## Changes

* Replace `impl Fold` with `impl VisitMut` in `dependency_collector`
* Reformat and add new test cases
* Remove unused `rewrite_require_specifier` fn verified via testing, the specifier is always replaced by then so it never does anything in both the old and new code paths
* Make ast imports consistent and remove custom use statements
* Centralise the collector, hygiene, and resolver passes into main block

## Checklist

- [x] Existing or new tests cover this change

These changes were tested in Jira, and confirmed to have the same build assets and descriptors.
