### PR TITLE
V3: Fix handling of distDir from target descriptors

### DIFF
--- a/.changeset/lazy-ligers-argue.md
+++ b/.changeset/lazy-ligers-argue.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Fix handling of distDir from target descriptors

--- a/crates/atlaspack/src/requests.rs
+++ b/crates/atlaspack/src/requests.rs
@@ -34,7 +34,7 @@ impl std::fmt::Debug for RequestResult {
       }
       RequestResult::Entry(_) => write!(f, "Entry"),
       RequestResult::Path(_) => write!(f, "Path"),
-      RequestResult::Target(_) => write!(f, "Target"),
+      RequestResult::Target(output) => output.fmt(f),
       #[cfg(test)]
       RequestResult::TestSub(_) => write!(f, "TestSub"),
       #[cfg(test)]

--- a/crates/atlaspack/src/requests/target_request.rs
+++ b/crates/atlaspack/src/requests/target_request.rs
@@ -275,10 +275,7 @@ impl TargetRequest {
 
     let browsers = match config.contents.browserslist.clone() {
       None => {
-        let browserslistrc_path = &request_context
-          .config()
-          .project_root
-          .join(".browserslistrc");
+        let browserslistrc_path = &request_context.project_root.join(".browserslistrc");
 
         // Loading .browserslistrc
         if request_context
@@ -354,7 +351,7 @@ impl TargetRequest {
               &config,
               descriptor.clone(),
               name,
-              &request_context.config().project_root,
+              &request_context.project_root,
             )?);
           }
 
@@ -415,7 +412,7 @@ impl TargetRequest {
         &config,
         custom_target.descriptor.clone(),
         custom_target.name,
-        &request_context.config().project_root,
+        &request_context.project_root,
       )?);
     }
 

--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -114,42 +114,37 @@ describe('watcher', function () {
     assert(distFile.includes('TRANSFORMED CODE'));
   });
 
-  it.v2(
-    'should rebuild properly when a dependency is removed',
-    async function () {
-      await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
+  it('should rebuild properly when a dependency is removed', async function () {
+    await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
 
-      let b = bundler(path.join(inputDir, 'index.js'), {
-        inputFS: overlayFS,
-        targets: {
-          main: {
-            engines: {
-              node: '^8.0.0',
-            },
-            distDir,
+    let b = bundler(path.join(inputDir, 'index.js'), {
+      inputFS: overlayFS,
+      targets: {
+        main: {
+          engines: {
+            node: '^8.0.0',
           },
+          distDir,
         },
-      });
+      },
+    });
 
-      subscription = await b.watch();
-      await getNextBuild(b);
-      let distFile = await outputFS.readFile(
-        path.join(distDir, 'index.js'),
-        'utf8',
-      );
-      assert(distFile.includes('Foo'));
-      await outputFS.writeFile(
-        path.join(inputDir, 'index.js'),
-        'console.log("no more dependencies")',
-      );
-      await getNextBuild(b);
-      distFile = await outputFS.readFile(
-        path.join(distDir, 'index.js'),
-        'utf8',
-      );
-      assert(!distFile.includes('Foo'));
-    },
-  );
+    subscription = await b.watch();
+    let buildEvent = await getNextBuild(b);
+    assert.equal(buildEvent.type, 'buildSuccess');
+    let distFile = await outputFS.readFile(
+      path.join(distDir, 'index.js'),
+      'utf8',
+    );
+    assert(distFile.includes('Foo'));
+    await outputFS.writeFile(
+      path.join(inputDir, 'index.js'),
+      'console.log("no more dependencies")',
+    );
+    await getNextBuild(b);
+    distFile = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
+    assert(!distFile.includes('Foo'));
+  });
 
   it.skip('should re-generate bundle tree when files change', async function () {
     await ncp(path.join(__dirname, '/integration/dynamic-hoist'), inputDir);
@@ -424,7 +419,7 @@ describe('watcher', function () {
     }
   });
 
-  it.v2('should add and remove necessary runtimes to bundles', async () => {
+  it('should add and remove necessary runtimes to bundles', async () => {
     await ncp(path.join(__dirname, 'integration/dynamic'), inputDir);
 
     let indexPath = path.join(inputDir, 'index.js');


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Prior to this change V3 didn't handle custom `distDir` settings in target descriptors passed straight to the node API.

## Checklist

- [x] Existing or new tests cover this change
