### PR TITLE
Modified AtlaspackLazy to avoid concurrent access

### DIFF
--- a/crates/atlaspack/src/atlaspack.rs
+++ b/crates/atlaspack/src/atlaspack.rs
@@ -19,6 +19,7 @@ use crate::request_tracker::RequestTracker;
 use crate::requests::{AssetGraphRequest, RequestResult};
 use crate::WatchEvents;
 
+#[derive(Clone)]
 pub struct AtlaspackInitOptions {
   pub db: Arc<DatabaseWriter>,
   pub fs: Option<FileSystemRef>,

--- a/crates/node-bindings/src/atlaspack/atlaspack_lazy.rs
+++ b/crates/node-bindings/src/atlaspack/atlaspack_lazy.rs
@@ -2,31 +2,56 @@ use std::sync::Arc;
 
 use atlaspack::Atlaspack;
 use atlaspack::AtlaspackInitOptions;
-use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 
-type LazyAtlaspackResult = Result<Arc<Atlaspack>, anyhow::Error>;
-type LazyAtlaspackInner =
-  Arc<Lazy<LazyAtlaspackResult, Box<dyn FnOnce() -> LazyAtlaspackResult + Send + 'static>>>;
+// type LazyAtlaspackResult = Result<Arc<Atlaspack>, anyhow::Error>;
+type LazyAtlaspackInner = Arc<Mutex<Option<anyhow::Result<Arc<Atlaspack>>>>>;
 
 /// Initialize Atlaspack on first invocation.
 /// Warning: cannot be done on main thread
 #[derive(Clone)]
-pub struct AtlaspackLazy(LazyAtlaspackInner);
+pub struct AtlaspackLazy {
+  atlaspack_container: LazyAtlaspackInner,
+  options: AtlaspackInitOptions,
+}
 
 impl AtlaspackLazy {
   pub fn new(options: AtlaspackInitOptions) -> Self {
-    Self(Arc::new(Lazy::new(Box::new(
-      move || match Atlaspack::new(options) {
-        Ok(atlaspack) => Ok(Arc::new(atlaspack)),
-        Err(err) => Err(err),
-      },
-    ))))
+    Self {
+      atlaspack_container: Default::default(),
+      options,
+    }
   }
 
   pub fn get(&self) -> anyhow::Result<Arc<Atlaspack>> {
-    match &**self.0 {
-      Ok(atlaspack) => Ok(Arc::clone(atlaspack)),
-      Err(error) => Err(anyhow::anyhow!("{:?}", error)),
+    let mut atlaspack_container = self.atlaspack_container.lock();
+
+    if atlaspack_container.is_none() {
+      atlaspack_container.replace(match Atlaspack::new(self.options.clone()) {
+        Ok(atlaspack) => Ok(Arc::new(atlaspack)),
+        Err(err) => Err(err),
+      });
+    }
+
+    match atlaspack_container.as_ref() {
+      Some(Ok(atlaspack)) => Ok(Arc::clone(atlaspack)),
+      Some(Err(error)) => Err(anyhow::anyhow!("{:?}", error)),
+      // Should never happen
+      None => Err(anyhow::anyhow!("Atlaspack cannot initialize")),
+    }
+  }
+
+  pub fn take(&self) -> anyhow::Result<Atlaspack> {
+    let mut atlaspack_container = self.atlaspack_container.lock();
+    match atlaspack_container.take() {
+      Some(Ok(atlaspack)) => match Arc::into_inner(atlaspack) {
+        Some(atlaspack) => Ok(atlaspack),
+        None => Err(anyhow::anyhow!(
+          "Cannot take because there is more than one Atlaspack instance currently held"
+        )),
+      },
+      Some(Err(error)) => Err(error),
+      None => Err(anyhow::anyhow!("Atlaspack not initialized")),
     }
   }
 }


### PR DESCRIPTION
The previous implementation of `AtlaspackLazy` would allow methods to be accessed concurrently which would cause issues.

Also added `.take()` method to facilitate manual shutdown of Atlaspack.

```javascript
const atlaspack = new Atlaspack({ /* ... */})

await Promise.all([
  atlaspack.buildAssetGraph(),
  atlaspack.buildAssetGraph(),
  atlaspack.buildAssetGraph(),
])
```
