### PR TITLE
Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Adding the team as codeowners for everything automatically requests reviews when a PR is opened
+
+* @atlassian-labs/atlaspack-core


### PR DESCRIPTION
Now that we're not working in the regular Parcel repo, it's much more appropriate to designate our team as codeowners of the whole repo.

What this should do (once we turn on require review from codeowners in branch protection) is automatically request a review from the team when we open a PR.

[no-changeset]: Only modifying repo setup