### PR TITLE
Fixing Windows build

### DIFF
--- a/.changeset/gentle-eggs-play.md
+++ b/.changeset/gentle-eggs-play.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Added win32 target to lmdblite

--- a/crates/lmdb-js-lite/package.json
+++ b/crates/lmdb-js-lite/package.json
@@ -6,7 +6,8 @@
   "repository": "https://github.com/atlassian-labs/atlaspack",
   "os": [
     "darwin",
-    "linux"
+    "linux",
+    "win32"
   ],
   "napi": {
     "name": "lmdb-js-lite",


### PR DESCRIPTION
We don't produce Windows binaries but I sometimes use my Windows desktop to develop Atlaspack. This one line change allows Atlaspack to be built on Windows machines.