### PR TITLE
Update transformer tests and rename ESMFold to EsmToCjsReplacer

### DIFF
--- a/.changeset/great-apricots-suffer.md
+++ b/.changeset/great-apricots-suffer.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/transformer-js': patch
+---
+
+Rename ESMFold to EsmToCjsReplacer and lift fold up one level

--- a/packages/transformers/js/core/src/constant_module.rs
+++ b/packages/transformers/js/core/src/constant_module.rs
@@ -205,8 +205,8 @@ mod tests {
   fn string() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = 'Hi';
-    "#,
+        export const SOMETHING = 'Hi';
+      "#,
     );
 
     assert!(result);
@@ -216,8 +216,8 @@ mod tests {
   fn null() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = null;
-    "#,
+        export const SOMETHING = null;
+      "#,
     );
 
     assert!(result);
@@ -227,8 +227,8 @@ mod tests {
   fn bool() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = false;
-    "#,
+        export const SOMETHING = false;
+      "#,
     );
 
     assert!(result);
@@ -238,8 +238,8 @@ mod tests {
   fn num() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = 3;
-    "#,
+        export const SOMETHING = 3;
+      "#,
     );
 
     assert!(result);
@@ -249,8 +249,8 @@ mod tests {
   fn bigint() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = 3n;
-    "#,
+        export const SOMETHING = 3n;
+      "#,
     );
 
     assert!(result);
@@ -260,9 +260,9 @@ mod tests {
   fn unexported_consts() {
     let result = is_constant_module(
       r#"
-    const local = 'local';
-    export const SOMETHING = 'export';
-    "#,
+        const local = 'local';
+        export const SOMETHING = 'export';
+      "#,
     );
 
     assert!(result);
@@ -272,8 +272,8 @@ mod tests {
   fn template_literals() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = `TEST`;
-    "#,
+        export const SOMETHING = `TEST`;
+      "#,
     );
 
     assert!(result);
@@ -283,9 +283,9 @@ mod tests {
   fn template_literals_known_var() {
     let result = is_constant_module(
       r#"
-    const localVar = 'local';
-    export const SOMETHING = `TEST-${localVar}`;
-    "#,
+        const localVar = 'local';
+        export const SOMETHING = `TEST-${localVar}`;
+      "#,
     );
 
     assert!(result);
@@ -295,8 +295,8 @@ mod tests {
   fn template_literals_nested_literal() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = `TEST-${'but-why'}`;
-    "#,
+        export const SOMETHING = `TEST-${'but-why'}`;
+      "#,
     );
 
     assert!(result);
@@ -306,8 +306,8 @@ mod tests {
   fn template_literals_unknown_var() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = `TEST-${someVar}`;
-    "#,
+        export const SOMETHING = `TEST-${someVar}`;
+      "#,
     );
 
     assert!(!result);
@@ -317,9 +317,9 @@ mod tests {
   fn side_effect() {
     let result = is_constant_module(
       r#"
-    sideEffect();
-    export const SOMETHING = '';
-    "#,
+        sideEffect();
+        export const SOMETHING = '';
+      "#,
     );
 
     assert!(!result);
@@ -329,9 +329,9 @@ mod tests {
   fn import() {
     let result = is_constant_module(
       r#"
-    import {something} from './somewhere';
-    export const SOMETHING = '';
-    "#,
+        import {something} from './somewhere';
+        export const SOMETHING = '';
+      "#,
     );
 
     assert!(!result);
@@ -341,8 +341,8 @@ mod tests {
   fn object() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = {};
-    "#,
+        export const SOMETHING = {};
+      "#,
     );
 
     assert!(!result);
@@ -352,8 +352,8 @@ mod tests {
   fn array() {
     let result = is_constant_module(
       r#"
-    export const SOMETHING = [];
-    "#,
+        export const SOMETHING = [];
+      "#,
     );
 
     assert!(!result);
@@ -363,8 +363,8 @@ mod tests {
   fn export_let() {
     let result = is_constant_module(
       r#"
-    export let SOMETHING = 'Hi';
-    "#,
+        export let SOMETHING = 'Hi';
+      "#,
     );
 
     assert!(!result);
@@ -374,8 +374,8 @@ mod tests {
   fn var() {
     let result = is_constant_module(
       r#"
-    export var SOMETHING = 'Hi';
-    "#,
+        export var SOMETHING = 'Hi';
+      "#,
     );
 
     assert!(!result);

--- a/packages/transformers/js/core/src/global_replacer.rs
+++ b/packages/transformers/js/core/src/global_replacer.rs
@@ -211,11 +211,12 @@ impl GlobalReplacer<'_> {
 mod tests {
   use std::path::Path;
 
+  use atlaspack_swc_runner::test_utils::{run_test_visit, RunTestContext, RunVisitResult};
+  use indoc::indoc;
   use swc_core::ecma::atoms::JsWord;
 
   use crate::global_replacer::GlobalReplacer;
   use crate::{DependencyDescriptor, DependencyKind};
-  use atlaspack_swc_runner::test_utils::{run_test_visit, RunTestContext, RunVisitResult};
 
   fn make_global_replacer(
     run_test_context: RunTestContext,
@@ -239,15 +240,17 @@ mod tests {
 
     let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
-console.log(process.test);
-    "#,
+        console.log(process.test);
+      "#,
       |run_test_context: RunTestContext| make_global_replacer(run_test_context, &mut items),
     );
+
     assert_eq!(
       output_code,
-      r#"var process = require("process");
-console.log(process.test);
-"#
+      indoc! {r#"
+        var process = require("process");
+        console.log(process.test);
+      "#}
     );
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].kind, DependencyKind::Require);
@@ -260,18 +263,20 @@ console.log(process.test);
 
     let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
-object[process.test];
-object[__dirname];
-    "#,
+        object[process.test];
+        object[__dirname];
+      "#,
       |run_test_context: RunTestContext| make_global_replacer(run_test_context, &mut items),
     );
+
     assert_eq!(
       output_code,
-      r#"var process = require("process");
-var __dirname = "..";
-object[process.test];
-object[__dirname];
-"#
+      indoc! {r#"
+        var process = require("process");
+        var __dirname = "..";
+        object[process.test];
+        object[__dirname];
+      "#}
     );
   }
 
@@ -281,16 +286,18 @@ object[__dirname];
 
     let RunVisitResult { output_code, .. } = run_test_visit(
       r#"
-object.process.test;
-object.__filename;
-    "#,
+        object.process.test;
+        object.__filename;
+      "#,
       |run_test_context: RunTestContext| make_global_replacer(run_test_context, &mut items),
     );
+
     assert_eq!(
       output_code,
-      r#"object.process.test;
-object.__filename;
-"#
+      indoc! {r#"
+        object.process.test;
+        object.__filename;
+      "#}
     );
   }
 }

--- a/packages/transformers/js/core/src/node_replacer.rs
+++ b/packages/transformers/js/core/src/node_replacer.rs
@@ -224,7 +224,8 @@ impl NodeReplacer<'_> {
 
 #[cfg(test)]
 mod tests {
-  use atlaspack_swc_runner::test_utils::run_test_visit;
+  use atlaspack_swc_runner::test_utils::{run_test_visit, RunVisitResult};
+  use indoc::indoc;
 
   use super::*;
 
@@ -234,10 +235,11 @@ mod tests {
     let mut items = vec![];
 
     let code = r#"
-const filename = __filename;
-console.log(__filename);
+      const filename = __filename;
+      console.log(__filename);
     "#;
-    let output_code = run_test_visit(code, |context| NodeReplacer {
+
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -245,15 +247,14 @@ console.log(__filename);
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
-    })
-    .output_code;
+    });
 
-    let expected_code = r#"
-var $parcel$__filename = require("path").resolve(__dirname, "$parcel$filenameReplace", "random.js");
-const filename = $parcel$__filename;
-console.log($parcel$__filename);
-"#
-    .trim_start();
+    let expected_code = indoc! {r#"
+      var $parcel$__filename = require("path").resolve(__dirname, "$parcel$filenameReplace", "random.js");
+      const filename = $parcel$__filename;
+      console.log($parcel$__filename);
+    "#};
+
     assert_eq!(output_code, expected_code);
     assert!(has_node_replacements);
     assert_eq!(items[0].specifier, JsWord::from("path"));
@@ -268,10 +269,11 @@ console.log($parcel$__filename);
     let mut items = vec![];
 
     let code = r#"
-const dirname = __dirname;
-console.log(__dirname);
+      const dirname = __dirname;
+      console.log(__dirname);
     "#;
-    let output_code = run_test_visit(code, |context| NodeReplacer {
+
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -279,15 +281,14 @@ console.log(__dirname);
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
-    })
-    .output_code;
+    });
 
-    let expected_code = r#"
-var $parcel$__dirname = require("path").resolve(__dirname, "$parcel$dirnameReplace");
-const dirname = $parcel$__dirname;
-console.log($parcel$__dirname);
-"#
-    .trim_start();
+    let expected_code = indoc! { r#"
+      var $parcel$__dirname = require("path").resolve(__dirname, "$parcel$dirnameReplace");
+      const dirname = $parcel$__dirname;
+      console.log($parcel$__dirname);
+    "#};
+
     assert_eq!(output_code, expected_code);
     assert!(has_node_replacements);
     assert_eq!(items[0].specifier, JsWord::from("path"));
@@ -302,13 +303,14 @@ console.log($parcel$__dirname);
     let mut items = vec![];
 
     let code = r#"
-function something(__filename, __dirname) {
-    const filename = __filename;
-    console.log(__filename);
-    console.log(__dirname);
-}
+      function something(__filename, __dirname) {
+        const filename = __filename;
+        console.log(__filename);
+        console.log(__dirname);
+      }
     "#;
-    let output_code = run_test_visit(code, |context| NodeReplacer {
+
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -316,17 +318,16 @@ function something(__filename, __dirname) {
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
-    })
-    .output_code;
+    });
 
-    let expected_code = r#"
-function something(__filename, __dirname) {
-    const filename = __filename;
-    console.log(__filename);
-    console.log(__dirname);
-}
-"#
-    .trim_start();
+    let expected_code = indoc! {r#"
+      function something(__filename, __dirname) {
+          const filename = __filename;
+          console.log(__filename);
+          console.log(__dirname);
+      }
+    "#};
+
     assert_eq!(output_code, expected_code);
     assert!(!has_node_replacements);
     assert_eq!(items.len(), 0);
@@ -338,9 +339,10 @@ function something(__filename, __dirname) {
     let mut items = vec![];
 
     let code = r#"
-const filename = obj.__filename;
+      const filename = obj.__filename;
     "#;
-    let output_code = run_test_visit(code, |context| NodeReplacer {
+
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -348,13 +350,12 @@ const filename = obj.__filename;
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
-    })
-    .output_code;
+    });
 
-    let expected_code = r#"
-const filename = obj.__filename;
-"#
-    .trim_start();
+    let expected_code = indoc! {r#"
+      const filename = obj.__filename;
+    "#};
+
     assert_eq!(output_code, expected_code);
     assert!(!has_node_replacements);
     assert_eq!(items.len(), 0);
@@ -366,9 +367,10 @@ const filename = obj.__filename;
     let mut items = vec![];
 
     let code = r#"
-const filename = obj[__filename];
+      const filename = obj[__filename];
     "#;
-    let output_code = run_test_visit(code, |context| NodeReplacer {
+
+    let RunVisitResult { output_code, .. } = run_test_visit(code, |context| NodeReplacer {
       source_map: context.source_map.clone(),
       global_mark: context.global_mark,
       globals: HashMap::new(),
@@ -376,14 +378,13 @@ const filename = obj[__filename];
       has_node_replacements: &mut has_node_replacements,
       items: &mut items,
       unresolved_mark: context.unresolved_mark,
-    })
-    .output_code;
+    });
 
-    let expected_code = r#"
-var $parcel$__filename = require("path").resolve(__dirname, "$parcel$filenameReplace", "random.js");
-const filename = obj[$parcel$__filename];
-"#
-    .trim_start();
+    let expected_code = indoc! {r#"
+      var $parcel$__filename = require("path").resolve(__dirname, "$parcel$filenameReplace", "random.js");
+      const filename = obj[$parcel$__filename];
+    "#};
+
     assert_eq!(output_code, expected_code);
     assert!(has_node_replacements);
     assert_eq!(items.len(), 1);


### PR DESCRIPTION
## Motivation

Refactor some of the transformer tests to create consistency, and add missing tests to the esm fold

## Changes

* Rename `modules.rs` to `esm_to_cjs_replacer`
* Rename `ESMFold` to `EsmToCjsReplacer`
* Add unit tests to `EsmToCjsReplacer`
* Remove `esm2cjs` fn in favour of `EsmToCjsReplacer` with the fold logic lifted up, both to enable testing and consistency
* Update some transformer tests to be more consistent

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required