### PR TITLE
Bring back server option to transform-contextual-imports

### DIFF
--- a/.changeset/good-toes-worry.md
+++ b/.changeset/good-toes-worry.md
@@ -2,4 +2,4 @@
 '@atlaspack/babel-plugin-transform-contextual-imports': patch
 ---
 
-Bring back server config option to @atlaspack/babel-plugin-transform-contextual-imports
+Bring back server config option to babel plugin

--- a/.changeset/good-toes-worry.md
+++ b/.changeset/good-toes-worry.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/babel-plugin-transform-contextual-imports': patch
+---
+
+Bring back server config option to @atlaspack/babel-plugin-transform-contextual-imports

--- a/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
+++ b/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
@@ -2,17 +2,24 @@ import type {PluginObj, NodePath, types as BabelTypes} from '@babel/core';
 import {declare} from '@babel/helper-plugin-utils';
 
 interface Opts {
+  // Deprecated syntax, use "node" instead
+  server?: boolean;
   // Use node safe import cond syntax
   node?: boolean;
 }
 
 interface State {
   opts: Opts;
+  importNodes?: any[]; // Deprecated: Statement types didn't work so using any
   // Set of identifier names that need to be mutated after import was transformed
   conditionalImportIdentifiers?: Set<string>;
   // Set of identifiers that have been visited in the exit pass, to avoid adding the load property multiple times
   visitedIdentifiers?: Set<BabelTypes.Identifier>;
 }
+
+const isServer = (opts: Opts) => {
+  return 'server' in opts && opts.server;
+};
 
 const isNode = (opts: Opts): boolean => !!('node' in opts && opts.node);
 
@@ -148,11 +155,124 @@ export default declare((api): PluginObj<State> => {
     ),
   ];
 
+  const buildServerObject = (
+    identUid: string,
+    cond: BabelTypes.StringLiteral,
+    ifTrue: BabelTypes.StringLiteral,
+    ifFalse: BabelTypes.StringLiteral,
+  ) => [
+    // Create object containing imports
+    t.variableDeclaration('const', [
+      t.variableDeclarator(
+        t.identifier(identUid),
+        t.objectExpression([
+          t.objectProperty(
+            t.identifier('ifTrue'),
+            t.memberExpression(
+              t.callExpression(t.identifier('require'), [ifTrue]),
+              t.identifier('default'),
+            ),
+          ),
+          t.objectProperty(
+            t.identifier('ifFalse'),
+            t.memberExpression(
+              t.callExpression(t.identifier('require'), [ifFalse]),
+              t.identifier('default'),
+            ),
+          ),
+        ]),
+      ),
+    ]),
+
+    // Create lazy getter via the load property on the object
+    t.expressionStatement(
+      t.callExpression(
+        t.memberExpression(
+          t.identifier('Object'),
+          t.identifier('defineProperty'),
+        ),
+        [
+          t.identifier(identUid),
+          t.stringLiteral('load'),
+          t.objectExpression([
+            t.objectProperty(
+              t.identifier('get'),
+              t.arrowFunctionExpression(
+                [],
+                t.conditionalExpression(
+                  t.logicalExpression(
+                    '&&',
+                    t.memberExpression(
+                      t.identifier('globalThis'),
+                      t.identifier('__MCOND'),
+                    ),
+                    t.callExpression(
+                      t.memberExpression(
+                        t.identifier('globalThis'),
+                        t.identifier('__MCOND'),
+                      ),
+                      [cond],
+                    ),
+                  ),
+                  t.memberExpression(
+                    t.identifier(identUid),
+                    t.identifier('ifTrue'),
+                  ),
+                  t.memberExpression(
+                    t.identifier(identUid),
+                    t.identifier('ifFalse'),
+                  ),
+                ),
+              ),
+            ),
+          ]),
+        ],
+      ),
+    ),
+  ];
+
+  const checkIsServer = (
+    path: NodePath<BabelTypes.CallExpression>,
+    state: State,
+  ) => {
+    if (
+      path.node.callee.type === 'Identifier' &&
+      path.node.callee.name === 'importCond'
+    ) {
+      if (
+        path.node.arguments.length == 3 &&
+        path.node.arguments.every((arg) => arg.type === 'StringLiteral')
+      ) {
+        const [cond, ifTrue, ifFalse] = path.node.arguments;
+
+        if (isServer(state.opts)) {
+          // Make module pass lazy in ssr
+          const identUid = path.scope.generateUid(
+            `${cond.value}$${ifTrue.value}$${ifFalse.value}`,
+          );
+
+          state.importNodes ??= [];
+          state.importNodes.push(
+            ...buildServerObject(identUid, cond, ifTrue, ifFalse),
+          );
+
+          // Replace call expression with reference to lazy object getter
+          path.replaceWith(
+            t.memberExpression(t.identifier(identUid), t.identifier('load')),
+          );
+        }
+      }
+    }
+  };
+
   return {
     name: '@atlaspack/babel-plugin-transform-contextual-imports',
     visitor: {
       CallExpression: {
         enter(path, state) {
+          // Preserve server behaviour in deletable code
+          checkIsServer(path, state);
+
           const node = path.node;
           if (isImportCondCallExpression(node)) {
             const [cond, ifTrue, ifFalse] = node.arguments;
@@ -211,6 +331,12 @@ export default declare((api): PluginObj<State> => {
         enter(_, state) {
           state.conditionalImportIdentifiers = new Set();
           state.visitedIdentifiers = new Set();
+        },
+        exit(path, state) {
+          if (state.importNodes) {
+            // If there's an import
+            path.unshiftContainer('body', state.importNodes);
+          }
         },
       },
     },

--- a/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
+++ b/packages/utils/babel-plugin-transform-contextual-imports/src/index.ts
@@ -2,18 +2,20 @@ import type {PluginObj, NodePath, types as BabelTypes} from '@babel/core';
 import {declare} from '@babel/helper-plugin-utils';
 
 interface Opts {
-  // Deprecated syntax, use "node" instead
+  /** @deprecated Use "node" instead */
   server?: boolean;
-  // Use node safe import cond syntax
+  /** Use node safe import cond syntax */
   node?: boolean;
 }
 
 interface State {
+  /** Plugin options */
   opts: Opts;
-  importNodes?: any[]; // Deprecated: Statement types didn't work so using any
-  // Set of identifier names that need to be mutated after import was transformed
+  /** @deprecated Statement types didn't work so using any */
+  importNodes?: any[];
+  /** Set of identifier names that need to be mutated after import was transformed */
   conditionalImportIdentifiers?: Set<string>;
-  // Set of identifiers that have been visited in the exit pass, to avoid adding the load property multiple times
+  /** Set of identifiers that have been visited in the exit pass, to avoid adding the load property multiple times */
   visitedIdentifiers?: Set<BabelTypes.Identifier>;
 }
 
@@ -334,7 +336,7 @@ export default declare((api): PluginObj<State> => {
         },
         exit(path, state) {
           if (state.importNodes) {
-            // If there's an import
+            // If there's an import node, add it to the top of the body
             path.unshiftContainer('body', state.importNodes);
           }
         },

--- a/packages/utils/babel-plugin-transform-contextual-imports/test/babel-plugin-transform-contextual-imports.test.js
+++ b/packages/utils/babel-plugin-transform-contextual-imports/test/babel-plugin-transform-contextual-imports.test.js
@@ -22,7 +22,30 @@ describe('@atlaspack/babel-plugin-transform-contextual-imports', () => {
     );
   });
 
-  it('should transform importCond to ssr safe code', () => {
+  it('should transform importCond to server (deprecated) lazy code', () => {
+    const input = `
+      importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
+    `;
+    let {code: transformed} = babel.transformSync(input, {
+      configFile: false,
+      presets: [],
+      plugins: [[plugin, {server: true}]],
+    });
+
+    assert(
+      transformed ===
+        `const _CONDITION$IF_TRUE$IF_FALSE = {
+  ifTrue: require('IF_TRUE').default,
+  ifFalse: require('IF_FALSE').default
+};
+Object.defineProperty(_CONDITION$IF_TRUE$IF_FALSE, "load", {
+  get: () => globalThis.__MCOND && globalThis.__MCOND('CONDITION') ? _CONDITION$IF_TRUE$IF_FALSE.ifTrue : _CONDITION$IF_TRUE$IF_FALSE.ifFalse
+});
+_CONDITION$IF_TRUE$IF_FALSE.load;`,
+    );
+  });
+
+  it('should transform importCond to node lazy code', () => {
     const input = `
       const Imported = importCond('CONDITION', 'IF_TRUE', 'IF_FALSE');
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

The recent breaking change shipped to the babel plugin was not within our new process, so if we bring back the original config option - we can bump without config changes

## Changes

Bring back the original code but behind a function, so it can be easily deleted in a future PR.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
