### PR TITLE
Replace Fold with VisitMut in EsmToCjsReplacer

### DIFF
--- a/.changeset/good-apes-mate.md
+++ b/.changeset/good-apes-mate.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/transformer-js': patch
+---
+
+Replace Fold with VisitMut in EsmToCjsReplacer to improve performance

--- a/packages/transformers/js/core/src/esm_to_cjs_replacer.rs
+++ b/packages/transformers/js/core/src/esm_to_cjs_replacer.rs
@@ -11,11 +11,9 @@ use swc_core::ecma::atoms::js_word;
 use swc_core::ecma::atoms::JsWord;
 use swc_core::ecma::preset_env::Feature;
 use swc_core::ecma::preset_env::Versions;
-use swc_core::ecma::utils::stack_size::maybe_grow_default;
-use swc_core::ecma::visit::Fold;
-use swc_core::ecma::visit::FoldWith;
+use swc_core::ecma::visit::VisitMut;
+use swc_core::ecma::visit::VisitMutWith;
 
-use crate::fold_member_expr_skip_prop;
 use crate::id;
 use crate::utils::get_undefined_ident;
 use crate::utils::match_export_name;
@@ -265,20 +263,19 @@ impl EsmToCjsReplacer {
   }
 }
 
-macro_rules! modules_visit_fn {
+macro_rules! visit_function_scope {
   ($name:ident, $type:ident) => {
-    fn $name(&mut self, node: $type) -> $type {
+    fn $name(&mut self, node: &mut $type) {
       let in_function_scope = self.in_function_scope;
       self.in_function_scope = true;
-      let res = node.fold_children_with(self);
+      node.visit_mut_children_with(self);
       self.in_function_scope = in_function_scope;
-      res
     }
   };
 }
 
-impl Fold for EsmToCjsReplacer {
-  fn fold_module(&mut self, node: Module) -> Module {
+impl VisitMut for EsmToCjsReplacer {
+  fn visit_mut_module(&mut self, node: &mut Module) {
     let mut is_esm = false;
     let mut needs_interop_flag = false;
 
@@ -390,10 +387,10 @@ impl Fold for EsmToCjsReplacer {
 
     // If we didn't see any module declarations, nothing to do.
     if !is_esm {
-      return node;
+      return;
     }
 
-    let node = node.fold_children_with(self);
+    node.visit_mut_children_with(self);
     let mut items = vec![];
 
     // Second pass
@@ -502,9 +499,11 @@ impl Fold for EsmToCjsReplacer {
                     Expr::Ident(class.ident.clone()),
                     export.span,
                   );
-                  items.push(ModuleItem::Stmt(Stmt::Decl(
-                    export.decl.clone().fold_with(self),
-                  )));
+
+                  let mut decl = export.decl.clone();
+                  decl.visit_mut_with(self);
+
+                  items.push(ModuleItem::Stmt(Stmt::Decl(decl)));
                 }
                 Decl::Fn(func) => {
                   self.create_export(
@@ -512,30 +511,35 @@ impl Fold for EsmToCjsReplacer {
                     Expr::Ident(func.ident.clone()),
                     export.span,
                   );
-                  items.push(ModuleItem::Stmt(Stmt::Decl(
-                    export.decl.clone().fold_with(self),
-                  )));
+
+                  let mut decl = export.decl.clone();
+                  decl.visit_mut_with(self);
+
+                  items.push(ModuleItem::Stmt(Stmt::Decl(decl)));
                 }
                 Decl::Var(var) => {
                   let mut var = var.clone();
+
                   var.decls = var
                     .decls
                     .iter()
                     .map(|decl| {
                       let mut decl = decl.clone();
                       self.in_export_decl = true;
-                      decl.name = decl.name.clone().fold_with(self);
+                      decl.name.visit_mut_with(self);
                       self.in_export_decl = false;
-                      decl.init = decl.init.clone().fold_with(self);
+                      decl.init.visit_mut_with(self);
                       decl
                     })
                     .collect();
+
                   items.push(ModuleItem::Stmt(Stmt::Decl(Decl::Var(var))));
                 }
                 _ => {
-                  items.push(ModuleItem::Stmt(Stmt::Decl(
-                    export.decl.clone().fold_with(self),
-                  )));
+                  let mut decl = export.decl.clone();
+                  decl.visit_mut_with(self);
+
+                  items.push(ModuleItem::Stmt(Stmt::Decl(decl)));
                 }
               }
             }
@@ -555,7 +559,6 @@ impl Fold for EsmToCjsReplacer {
       self.exports.insert(0, helper);
     }
 
-    let mut node = node;
     items.splice(0..0, self.requires.clone());
     items.splice(0..0, self.exports.clone());
 
@@ -588,68 +591,70 @@ impl Fold for EsmToCjsReplacer {
     }
 
     node.body = items;
-    node
   }
 
-  fn fold_binding_ident(&mut self, node: BindingIdent) -> BindingIdent {
+  fn visit_mut_binding_ident(&mut self, node: &mut BindingIdent) {
     if self.in_export_decl {
       // export const {foo} = ...;
       self.create_export(node.id.sym.clone(), Expr::Ident(node.id.clone()), DUMMY_SP);
     }
 
-    node.fold_children_with(self)
+    node.visit_mut_children_with(self);
   }
 
-  modules_visit_fn!(fold_function, Function);
-  modules_visit_fn!(fold_class, Class);
-  modules_visit_fn!(fold_getter_prop, GetterProp);
-  modules_visit_fn!(fold_setter_prop, SetterProp);
+  visit_function_scope!(visit_mut_function, Function);
+  visit_function_scope!(visit_mut_class, Class);
+  visit_function_scope!(visit_mut_getter_prop, GetterProp);
+  visit_function_scope!(visit_mut_setter_prop, SetterProp);
 
-  fn fold_expr(&mut self, node: Expr) -> Expr {
+  fn visit_mut_expr(&mut self, node: &mut Expr) {
     match &node {
       Expr::Ident(ident) => {
         if let Some((source, imported)) = self.imports.get(&id!(ident)).cloned() {
-          self.create_import_access(&source, &imported, ident.span)
-        } else {
-          node
+          *node = self.create_import_access(&source, &imported, ident.span);
         }
       }
       Expr::This(_this) => {
         if !self.in_function_scope {
-          Expr::Ident(get_undefined_ident(self.unresolved_mark))
-        } else {
-          node
+          *node = Expr::Ident(get_undefined_ident(self.unresolved_mark));
         }
       }
-      _ => maybe_grow_default(|| node.fold_children_with(self)),
+      _ => {
+        node.visit_mut_children_with(self);
+      }
     }
   }
 
-  fn fold_prop(&mut self, node: Prop) -> Prop {
+  fn visit_mut_prop(&mut self, node: &mut Prop) {
     // let obj = {a, b}; -> let obj = {a: imported.a, b: imported.b};
-    match &node {
-      Prop::Shorthand(ident) => {
-        if let Some((source, imported)) = self.imports.get(&id!(ident)).cloned() {
-          Prop::KeyValue(KeyValueProp {
-            key: PropName::Ident(IdentName::new(ident.sym.clone(), DUMMY_SP)),
-            value: Box::new(self.create_import_access(&source, &imported, ident.span)),
-          })
-        } else {
-          node.fold_children_with(self)
-        }
+    if let Some(ident) = node.as_mut_shorthand() {
+      if let Some((source, imported)) = self.imports.get(&id!(ident)).cloned() {
+        *node = Prop::KeyValue(KeyValueProp {
+          key: PropName::Ident(IdentName::new(ident.sym.clone(), DUMMY_SP)),
+          value: Box::new(self.create_import_access(&source, &imported, ident.span)),
+        });
+
+        return;
       }
-      _ => node.fold_children_with(self),
     }
+
+    node.visit_mut_children_with(self);
   }
 
-  fold_member_expr_skip_prop! {}
+  fn visit_mut_member_expr(&mut self, node: &mut MemberExpr) {
+    node.obj.visit_mut_with(self);
+
+    if let MemberProp::Computed(_) = node.prop {
+      node.prop.visit_mut_with(self);
+    }
+  }
 }
 
 #[cfg(test)]
 mod tests {
   use std::str::FromStr;
 
-  use atlaspack_swc_runner::test_utils::{run_test_fold, RunVisitResult};
+  use atlaspack_swc_runner::test_utils::{run_test_visit, RunVisitResult};
   use indoc::indoc;
   use swc_core::ecma::preset_env::{BrowserData, Version};
 
@@ -661,7 +666,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         import { useEffect } from 'react';
 
@@ -687,7 +692,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         import { a, b } from 'foo';
 
@@ -716,7 +721,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         import { a, b } from 'foo';
 
@@ -745,7 +750,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         import { a, b } from 'foo';
 
@@ -769,12 +774,38 @@ mod tests {
   }
 
   #[test]
+  fn transforms_imports_and_computed_member_expressions_referencing_import_specifiers_to_cjs() {
+    let RunVisitResult {
+      output_code,
+      visitor,
+      ..
+    } = run_test_visit(
+      r#"
+        import { foo } from 'foo';
+
+        const obj = foo[bar]();
+      "#,
+      |context| EsmToCjsReplacer::new(context.unresolved_mark, None),
+    );
+
+    assert_eq!(
+      output_code,
+      indoc! {r#"
+        var _foo = require("foo");
+        const obj = 0, _foo.foo[bar]();
+      "#}
+    );
+
+    assert!(!visitor.needs_helpers);
+  }
+
+  #[test]
   fn transforms_export_all_to_use_helpers() {
     let RunVisitResult {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         export * from './main';
       "#,
@@ -800,7 +831,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         export default function main() {}
       "#,
@@ -826,7 +857,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         export function main() {}
       "#,
@@ -852,7 +883,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         export const { main } = obj;
       "#,
@@ -878,7 +909,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         module.exports = function main1() {}
         module.exports.main = function main2() {}
@@ -907,7 +938,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         import { useEffect } from 'react';
         export function main() {
@@ -939,7 +970,7 @@ mod tests {
       output_code,
       visitor,
       ..
-    } = run_test_fold(
+    } = run_test_visit(
       r#"
         export const main1 = () => {};
         const main2 = () => {};

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -552,7 +552,7 @@ pub fn transform(
                 diagnostics.extend(bailouts.iter().map(|bailout| bailout.to_diagnostic()));
               }
 
-              let module = module.module().expect("Module should be a module at this point");
+              let mut module = module.module().expect("Module should be a module at this point");
               let module = if config.scope_hoist {
                 let res = hoist(module, config.module_id.as_str(), unresolved_mark, &collect);
                 match res {
@@ -573,7 +573,7 @@ pub fn transform(
                 }
 
                 let mut esm2cjs = EsmToCjsReplacer::new(unresolved_mark, versions);
-                let module = module.fold_with(&mut esm2cjs);
+                module.visit_mut_with(&mut esm2cjs);
                 result.needs_esm_helpers = esm2cjs.needs_helpers;
                 module
               };

--- a/packages/transformers/js/core/src/utils.rs
+++ b/packages/transformers/js/core/src/utils.rs
@@ -423,24 +423,6 @@ impl BailoutReason {
 }
 
 #[macro_export]
-macro_rules! fold_member_expr_skip_prop {
-  () => {
-    fn fold_member_expr(
-      &mut self,
-      mut node: swc_core::ecma::ast::MemberExpr,
-    ) -> swc_core::ecma::ast::MemberExpr {
-      node.obj = node.obj.fold_with(self);
-
-      if let swc_core::ecma::ast::MemberProp::Computed(_) = node.prop {
-        node.prop = node.prop.fold_with(self);
-      }
-
-      node
-    }
-  };
-}
-
-#[macro_export]
 macro_rules! id {
   ($ident: expr) => {
     $ident.to_id()


### PR DESCRIPTION
## Motivation

We have seen some segfaults again that may be related to the fold usages within the transformer. These changes replace `Fold` with `VisitMut` in `EsmToCjsReplacer` of the JS transformer.

## Changes

* Replace `impl Fold` with `impl VisitMut` in `EsmToCjsReplacer`
* Update how the replacer is called to work with visit

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
