### PR TITLE
Remove dead constant and fix respondToFsEvents types

### DIFF
--- a/.changeset/calm-laws-study.md
+++ b/.changeset/calm-laws-study.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/core': patch
+'@atlaspack/rust': patch
+---
+
+Fix respondToFsEvents return type

--- a/crates/node-bindings/src/atlaspack/atlaspack.rs
+++ b/crates/node-bindings/src/atlaspack/atlaspack.rs
@@ -38,9 +38,6 @@ pub struct AtlaspackNapi {
   atlaspack: AtlaspackLazy,
 }
 
-// Refer to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/length
-const MAX_STRING_LENGTH: usize = 268435440;
-
 #[napi]
 impl AtlaspackNapi {
   #[tracing::instrument(level = "info", skip_all)]

--- a/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
+++ b/packages/core/core/src/atlaspack-v3/AtlaspackV3.js
@@ -65,7 +65,7 @@ export class AtlaspackV3 {
     return graph;
   }
 
-  respondToFsEvents(events: Array<Event>): boolean {
+  respondToFsEvents(events: Array<Event>): Promise<boolean> {
     return this._internal.respondToFsEvents(events);
   }
 }

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -7,13 +7,14 @@ import type {
   PackageManager,
 } from '@atlaspack/types';
 
+// This is defined in browser.js for wasm builds
 declare export var init: void | (() => void);
 
 export type WatchEventType = 'create' | 'update' | 'delete';
 
 export interface WatchEvent {
-  path: string,
-  type: WatchEventType,
+  path: string;
+  type: WatchEventType;
 }
 
 export type WatchEvents = Array<WatchEvent>;
@@ -51,7 +52,7 @@ export type AtlaspackNapiOptions = {|
   nodeWorkers?: number,
   napiWorkerPool: any,
   options: {|
-    featureFlags?: { [string]: string | boolean },
+    featureFlags?: {[string]: string | boolean},
     corePath?: string,
     // TODO Use Omit when available in flow >0.210.0
     ...$Diff<
@@ -71,7 +72,7 @@ declare export class AtlaspackNapi {
   static create(options: AtlaspackNapiOptions, lmdb: mixed): AtlaspackNapi;
   nodeWorkerCount: number;
   buildAssetGraph(): Promise<any>;
-  respondToFsEvents(events: WatchEvents): boolean;
+  respondToFsEvents(events: WatchEvents): Promise<boolean>;
   static defaultThreadCount(): number;
   testingTempFsReadToString(path: string): string;
   testingTempFsIsDir(path: string): boolean;
@@ -86,9 +87,7 @@ declare export function registerWorker(
   worker: any,
 ): void;
 
-declare export function newNodejsWorker(
-  delegate: any,
-): Transferable;
+declare export function newNodejsWorker(delegate: any): Transferable;
 
 declare export function initializeMonitoring(): void;
 declare export function closeMonitoring(): void;


### PR DESCRIPTION
## Motivation

I noticed some code was incorrect when investigating build hangs, so these changes fix that

## Changes

* Fix `respondToFsEvents` return type
* Remove dead `MAX_STRING_LENGTH` constant

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
