### PR TITLE
Native: napi_threads utils

### DIFF
--- a/.changeset/few-bikes-switch.md
+++ b/.changeset/few-bikes-switch.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Added utility to make threading in napi a little easier

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ name = "atlaspack_napi_helpers"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "atlaspack_core",
  "napi",
  "napi-build",
  "once_cell",

--- a/crates/atlaspack/src/lib.rs
+++ b/crates/atlaspack/src/lib.rs
@@ -1,13 +1,11 @@
 pub use atlaspack::*;
 pub use atlaspack_filesystem as file_system;
 pub use atlaspack_plugin_rpc as rpc;
-pub use error::*;
 pub use watch::*;
 
 pub mod atlaspack;
 pub(crate) mod request_tracker;
 
-mod error;
 mod plugins;
 mod project_root;
 mod requests;

--- a/crates/atlaspack/src/request_tracker/request_tracker.rs
+++ b/crates/atlaspack/src/request_tracker/request_tracker.rs
@@ -9,6 +9,7 @@ use petgraph::stable_graph::StableDiGraph;
 
 use atlaspack_core::config_loader::ConfigLoaderRef;
 use atlaspack_core::diagnostic_error;
+use atlaspack_core::error::AtlaspackError;
 use atlaspack_core::types::AtlaspackOptions;
 use atlaspack_filesystem::FileSystemRef;
 use petgraph::visit::Dfs;
@@ -16,7 +17,6 @@ use petgraph::visit::Reversed;
 
 use crate::plugins::PluginsRef;
 use crate::requests::RequestResult;
-use crate::AtlaspackError;
 use crate::WatchEvent;
 use crate::WatchEvents;
 

--- a/crates/atlaspack_core/src/error.rs
+++ b/crates/atlaspack_core/src/error.rs
@@ -1,7 +1,8 @@
 use anyhow::anyhow;
-use atlaspack_core::types::Diagnostic;
-use atlaspack_core::types::Diagnostics;
 use serde::Serialize;
+
+use crate::types::Diagnostic;
+use crate::types::Diagnostics;
 
 pub enum AtlaspackError {
   Diagnostic(Diagnostic),

--- a/crates/atlaspack_core/src/lib.rs
+++ b/crates/atlaspack_core/src/lib.rs
@@ -2,6 +2,7 @@ pub mod asset_graph;
 pub mod bundle_graph;
 pub mod cache;
 pub mod config_loader;
+pub mod error;
 pub mod hash;
 pub mod plugin;
 pub mod project_path;

--- a/crates/atlaspack_napi_helpers/Cargo.toml
+++ b/crates/atlaspack_napi_helpers/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 [lib]
 
 [dependencies]
+atlaspack_core = { path = "../atlaspack_core" }
 serde = { workspace = true }
 anyhow = { workspace = true }
 napi = { workspace = true, features = ["serde-json", "napi4", "napi5", "async", "anyhow"] }

--- a/crates/atlaspack_napi_helpers/src/lib.rs
+++ b/crates/atlaspack_napi_helpers/src/lib.rs
@@ -5,10 +5,13 @@ mod anyhow;
 mod call_method;
 mod console_log;
 mod get_function;
+mod napi_result;
+pub mod napi_threads;
 mod transferable;
 
 pub use self::anyhow::*;
 pub use self::call_method::*;
 pub use self::console_log::*;
 pub use self::get_function::*;
+pub use self::napi_result::*;
 pub use self::transferable::*;

--- a/crates/atlaspack_napi_helpers/src/napi_result.rs
+++ b/crates/atlaspack_napi_helpers/src/napi_result.rs
@@ -4,9 +4,9 @@ use napi::{bindgen_prelude::ToNapiValue, Env, JsObject};
 /// ```
 /// [result: any | null, error: any | null]
 /// ```
-pub struct NapiAtlaspackResult;
+pub struct TupleResult;
 
-impl NapiAtlaspackResult {
+impl TupleResult {
   /// This creates the following JavaScript tuple
   /// ```
   /// [JsAny, null]

--- a/crates/atlaspack_napi_helpers/src/napi_threads/map_to_err_tuple.rs
+++ b/crates/atlaspack_napi_helpers/src/napi_threads/map_to_err_tuple.rs
@@ -1,0 +1,14 @@
+use atlaspack_core::error::AtlaspackError;
+use napi::Env;
+use napi::JsObject;
+
+use crate::TupleResult;
+
+/// Converts return type to JavaScript Tuple representing Rust's Result type
+/// ```
+/// [null, JsAny]
+/// ```
+pub fn map_to_err_tuple(env: Env, error: anyhow::Error) -> napi::Result<JsObject> {
+  let js_object = env.to_js_value(&AtlaspackError::from(&error))?;
+  TupleResult::error(&env, js_object)
+}

--- a/crates/atlaspack_napi_helpers/src/napi_threads/map_to_ok_tuple.rs
+++ b/crates/atlaspack_napi_helpers/src/napi_threads/map_to_ok_tuple.rs
@@ -1,0 +1,16 @@
+use napi::bindgen_prelude::ToNapiValue;
+use napi::Env;
+use napi::JsObject;
+
+use crate::TupleResult;
+
+/// Converts return type to JavaScript Tuple representing Rust's Result type
+/// ```
+/// [JsAny, null]
+/// ```
+pub fn map_to_ok_tuple<JsRet: ToNapiValue + 'static>(
+  env: Env,
+  ret: JsRet,
+) -> napi::Result<JsObject> {
+  TupleResult::ok(&env, ret)
+}

--- a/crates/atlaspack_napi_helpers/src/napi_threads/map_to_ok_tuple_serde.rs
+++ b/crates/atlaspack_napi_helpers/src/napi_threads/map_to_ok_tuple_serde.rs
@@ -1,0 +1,14 @@
+use napi::Env;
+use napi::JsObject;
+use serde::Serialize;
+
+use crate::TupleResult;
+
+/// Converts return type to JavaScript Tuple representing Rust's Result type
+/// ```
+/// [JsAny, null]
+/// ```
+pub fn map_to_ok_tuple_serde<JsRet: Serialize>(env: Env, ret: JsRet) -> napi::Result<JsObject> {
+  let result = env.to_js_value(&ret)?;
+  TupleResult::ok(&env, result)
+}

--- a/crates/atlaspack_napi_helpers/src/napi_threads/mod.rs
+++ b/crates/atlaspack_napi_helpers/src/napi_threads/mod.rs
@@ -1,0 +1,9 @@
+mod map_to_err_tuple;
+mod map_to_ok_tuple;
+mod map_to_ok_tuple_serde;
+mod spawn;
+
+pub use self::map_to_err_tuple::*;
+pub use self::map_to_ok_tuple::*;
+pub use self::map_to_ok_tuple_serde::*;
+pub use self::spawn::*;

--- a/crates/atlaspack_napi_helpers/src/napi_threads/spawn.rs
+++ b/crates/atlaspack_napi_helpers/src/napi_threads/spawn.rs
@@ -1,0 +1,37 @@
+use std::thread;
+
+use napi::bindgen_prelude::FromNapiValue;
+use napi::bindgen_prelude::ToNapiValue;
+use napi::Env;
+use napi::JsObject;
+use napi::JsUnknown;
+
+/// Spawns an OS thread and returns a Promise
+pub fn spawn<Ret: 'static, JsRet: ToNapiValue + 'static, JsErr: ToNapiValue + 'static>(
+  env: &Env,
+  callback: impl 'static + Send + FnOnce() -> anyhow::Result<Ret>,
+  map_result: impl 'static + Send + FnOnce(Env, Ret) -> napi::Result<JsRet>,
+  map_error: impl 'static + Send + FnOnce(Env, anyhow::Error) -> napi::Result<JsErr>,
+) -> napi::Result<JsObject> {
+  let (deferred, promise) = env.create_deferred()?;
+
+  thread::spawn(move || {
+    // Run callback on separate thread
+    let result = callback();
+
+    deferred.resolve(move |env| match result {
+      Ok(result) => {
+        let result = map_result(env, result)?;
+        // Safety: Safe because type must be convertible to JsUnknown because of ToNapiValue trait
+        unsafe { JsUnknown::from_napi_value(env.raw(), JsRet::to_napi_value(env.raw(), result)?) }
+      }
+      Err(error) => {
+        let result = map_error(env, error)?;
+        // Safety: Safe because type must be convertible to JsUnknown because of ToNapiValue trait
+        unsafe { JsUnknown::from_napi_value(env.raw(), JsErr::to_napi_value(env.raw(), result)?) }
+      }
+    });
+  });
+
+  Ok(promise)
+}

--- a/crates/node-bindings/src/atlaspack/atlaspack.rs
+++ b/crates/node-bindings/src/atlaspack/atlaspack.rs
@@ -1,15 +1,7 @@
 use core::str;
 use std::sync::Arc;
-use std::thread;
 
 use anyhow::anyhow;
-use atlaspack::rpc::nodejs::NodejsWorker;
-use atlaspack::Atlaspack;
-use atlaspack::AtlaspackError;
-use atlaspack::AtlaspackInitOptions;
-use atlaspack::WatchEvents;
-use atlaspack_napi_helpers::js_callable::JsCallable;
-use atlaspack_napi_helpers::JsTransferable;
 use lmdb_js_lite::writer::DatabaseWriter;
 use lmdb_js_lite::LMDB;
 use napi::bindgen_prelude::External;
@@ -21,11 +13,18 @@ use napi_derive::napi;
 
 use atlaspack::file_system::FileSystemRef;
 use atlaspack::rpc::nodejs::NodejsRpcFactory;
+use atlaspack::rpc::nodejs::NodejsWorker;
+use atlaspack::Atlaspack;
+use atlaspack::AtlaspackInitOptions;
+use atlaspack::WatchEvents;
+use atlaspack_napi_helpers::js_callable::JsCallable;
+use atlaspack_napi_helpers::napi_threads;
+use atlaspack_napi_helpers::JsTransferable;
+use atlaspack_napi_helpers::TupleResult;
 use atlaspack_package_manager::PackageManagerRef;
 use parking_lot::Mutex;
 
 use super::file_system_napi::FileSystemNapi;
-use super::napi_result::NapiAtlaspackResult;
 use super::package_manager_napi::PackageManagerNapi;
 use super::serialize_asset_graph::serialize_asset_graph;
 
@@ -50,8 +49,6 @@ pub fn atlaspack_napi_create(
   let thread_id = std::thread::current().id();
   tracing::trace!(?thread_id, "atlaspack-napi initialize");
 
-  let (deferred, promise) = env.create_deferred()?;
-
   // Wrap the JavaScript-supplied FileSystem
   let fs: Option<FileSystemRef> = if let Some(fs) = napi_options.fs {
     Some(Arc::new(FileSystemNapi::new(&env, &fs)?))
@@ -69,32 +66,32 @@ pub fn atlaspack_napi_create(
   // Get access to LMDB reference
   let db_handle = lmdb.get_database_napi()?.clone();
   let db_writer = db_handle.database();
-  atlaspack_napi_run_db_health_check(db_writer)?;
+  let db = db_writer.clone();
+  run_db_health_check(db_writer)?;
 
   // Get Atlaspack Options
   let options = env.from_js_value(napi_options.options)?;
   let get_workers = JsCallable::new_method_bound("getWorkers", &napi_options.napi_worker_pool)?;
 
-  thread::spawn({
-    let db = db_writer.clone();
+  napi_threads::spawn(
+    &env,
+    // Separate thread
     move || {
-      let workers = get_workers
-        .call_blocking(
-          |_env| Ok(vec![]),
-          |_env, workers| {
-            let workers_arr = workers.coerce_to_object()?;
-            let mut workers = vec![];
-            for i in 0..workers_arr.get_array_length()? {
-              let worker = workers_arr.get_element::<JsUnknown>(i)?;
-              let worker = JsTransferable::<Arc<NodejsWorker>>::from_unknown(worker)?;
-              workers.push(worker.get()?.clone());
-            }
-            Ok(workers)
-          },
-        )
-        .unwrap();
+      let workers = get_workers.call_blocking(
+        |_env| Ok(vec![]),
+        |_env, workers| {
+          let workers_arr = workers.coerce_to_object()?;
+          let mut workers = vec![];
+          for i in 0..workers_arr.get_array_length()? {
+            let worker = workers_arr.get_element::<JsUnknown>(i)?;
+            let worker = JsTransferable::<Arc<NodejsWorker>>::from_unknown(worker)?;
+            workers.push(worker.get()?.clone());
+          }
+          Ok(workers)
+        },
+      )?;
 
-      let rpc = Arc::new(NodejsRpcFactory::new(workers).unwrap());
+      let rpc = Arc::new(NodejsRpcFactory::new(workers)?);
       let atlaspack = Atlaspack::new(AtlaspackInitOptions {
         db,
         fs,
@@ -103,80 +100,47 @@ pub fn atlaspack_napi_create(
         rpc,
       });
 
-      deferred.resolve(move |env| match atlaspack {
-        Ok(atlaspack) => {
-          NapiAtlaspackResult::ok(&env, External::new(Arc::new(Mutex::new(atlaspack))))
-        }
-        Err(error) => {
-          let js_object = env.to_js_value(&AtlaspackError::from(&error))?;
-          NapiAtlaspackResult::error(&env, js_object)
-        }
-      })
-    }
-  });
-
-  Ok(promise)
+      Ok(External::new(Arc::new(Mutex::new(atlaspack))))
+    },
+    // Nodejs Thread
+    napi_threads::map_to_ok_tuple,
+    napi_threads::map_to_err_tuple,
+  )
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 #[napi]
 pub fn atlaspack_napi_build_asset_graph(
   env: Env,
-  atlaspack_napi: AtlaspackNapi,
+  atlaspack: AtlaspackNapi,
 ) -> napi::Result<JsObject> {
-  let (deferred, promise) = env.create_deferred()?;
-
-  thread::spawn({
-    let atlaspack = atlaspack_napi.clone();
-    move || {
-      let atlaspack = atlaspack.lock();
-      let result = atlaspack.build_asset_graph();
-
-      // "deferred.resolve" closure executes on the JavaScript thread.
-      // Errors are returned as a resolved value because they need to be serialized and are
-      // not supplied as JavaScript Error types. The JavaScript layer needs to handle conversions
-      deferred.resolve(move |env| match result {
-        Ok(asset_graph) => {
-          NapiAtlaspackResult::ok(&env, serialize_asset_graph(&env, &asset_graph)?)
-        }
-        Err(error) => {
-          let js_object = env.to_js_value(&AtlaspackError::from(&error))?;
-          NapiAtlaspackResult::error(&env, js_object)
-        }
-      })
-    }
-  });
-
-  Ok(promise)
+  napi_threads::spawn(
+    &env,
+    // Separate thread
+    move || atlaspack.lock().build_asset_graph(),
+    // Nodejs Thread
+    |env, asset_graph| TupleResult::ok(&env, serialize_asset_graph(&env, &asset_graph)?),
+    napi_threads::map_to_err_tuple,
+  )
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 #[napi]
 pub fn atlaspack_napi_respond_to_fs_events(
   env: Env,
-  atlaspack_napi: AtlaspackNapi,
+  atlaspack: AtlaspackNapi,
   options: JsObject,
 ) -> napi::Result<JsObject> {
-  let (deferred, promise) = env.create_deferred()?;
   let options = env.from_js_value::<WatchEvents, _>(options)?;
 
-  thread::spawn({
-    let atlaspack = atlaspack_napi.clone();
-    move || {
-      let atlaspack = atlaspack.lock();
-      let result = atlaspack.respond_to_fs_events(options);
-
-      deferred.resolve(move |env| match result {
-        Ok(should_rebuild) => NapiAtlaspackResult::ok(&env, should_rebuild),
-        Err(error) => {
-          let js_object = env.to_js_value(&AtlaspackError::from(&error))?;
-          NapiAtlaspackResult::error(&env, js_object)
-        }
-      })
-    }
-  });
-
-  Ok(promise)
+  napi_threads::spawn(
+    &env,
+    // Separate thread
+    move || atlaspack.lock().respond_to_fs_events(options),
+    // Nodejs Thread
+    napi_threads::map_to_ok_tuple,
+    napi_threads::map_to_err_tuple,
+  )
 }
 
 /// Check that the LMDB database is healthy
@@ -185,7 +149,7 @@ pub fn atlaspack_napi_respond_to_fs_events(
 /// to sequence writes with the JavaScript writes, we should be using the
 /// [`lmdb_js_lite::writer::DatabaseWriterHandle`] instead.
 #[tracing::instrument(level = "info", skip_all)]
-pub fn atlaspack_napi_run_db_health_check(db: &Arc<DatabaseWriter>) -> napi::Result<()> {
+fn run_db_health_check(db: &Arc<DatabaseWriter>) -> napi::Result<()> {
   let run_healthcheck = || -> anyhow::Result<()> {
     let txn = db.read_txn()?;
     let value = db

--- a/crates/node-bindings/src/atlaspack/mod.rs
+++ b/crates/node-bindings/src/atlaspack/mod.rs
@@ -7,7 +7,6 @@ pub mod environment;
 pub mod file_system_napi;
 pub mod get_available_threads;
 pub mod monitoring;
-pub mod napi_result;
 pub mod package_manager_napi;
 pub mod serialize_asset_graph;
 pub mod worker;


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

We repeat the thread spawn + promise creation + error handling logic every time we create a Napi binding. This is verbose and introduces the potential for errors.

## Changes

Added thread spawning utility that returns a promise to standardize how we create non-blocking Napi functionality


Replaces 

```rust
#[napi]
pub fn build_asset_graph(env: Env, atlaspack_napi: AtlaspackNapi) -> napi::Result<JsObject> {
  let (deferred, promise) = env.create_deferred()?;

  thread::spawn({
    let atlaspack = atlaspack_napi.clone();
    move || {
      let atlaspack = atlaspack.lock();
      let result = atlaspack.build_asset_graph();

      deferred.resolve(move |env| match result {
        Ok(asset_graph) => {
          NapiAtlaspackResult::ok(&env, serialize_asset_graph(&env, &asset_graph)?)
        }
        Err(error) => {
          let js_object = env.to_js_value(&AtlaspackError::from(&error))?;
          NapiAtlaspackResult::error(&env, js_object)
        }
      })
    }
  });

  Ok(promise)
}
```

With 
```rust
#[napi]
pub fn build_asset_graph(env: Env, atlaspack: AtlaspackNapi) -> napi::Result<JsObject> {
  napi_threads::spawn(
    &env,
    // Seperate thread
    move || atlaspack.lock().build_asset_graph(),
    // Nodejs thread
    napi_threads::map_to_ok_tuple
    napi_threads::map_to_err_tuple,
  )
}
```

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
