### PR TITLE
Remove the vestigial `parcelDependencies` config check 

### DIFF
--- a/.changeset/mean-feet-look.md
+++ b/.changeset/mean-feet-look.md
@@ -1,0 +1,8 @@
+---
+'@atlaspack/core': patch
+---
+
+Removes the dependency check within the config default `package.json`.
+
+Any dependencies that used to be auto-installed from `parcelDependencies` should
+now be installed in the project root.

--- a/packages/core/core/src/loadAtlaspackPlugin.js
+++ b/packages/core/core/src/loadAtlaspackPlugin.js
@@ -10,11 +10,7 @@ import ThrowableDiagnostic, {
   generateJSONCodeHighlights,
   md,
 } from '@atlaspack/diagnostic';
-import {
-  findAlternativeNodeModules,
-  loadConfig,
-  resolveConfig,
-} from '@atlaspack/utils';
+import {findAlternativeNodeModules, resolveConfig} from '@atlaspack/utils';
 import {type ProjectPath, toProjectPath} from './projectPath';
 import {version as ATLASPACK_VERSION} from '../package.json';
 
@@ -32,73 +28,32 @@ export default async function loadPlugin<T>(
   resolveFrom: ProjectPath,
 |}> {
   let resolveFrom = configPath;
-  if (resolveFrom.includes(NODE_MODULES)) {
-    // Config packages can reference plugins, but cannot contain other plugins within them.
-    // This forces every published plugin to be published separately so they can be mixed and matched if needed.
-    if (pluginName.startsWith('.')) {
-      let configContents = await options.inputFS.readFile(configPath, 'utf8');
-      throw new ThrowableDiagnostic({
-        diagnostic: {
-          message: md`Local plugins are not supported in Atlaspack config packages. Please publish "${pluginName}" as a separate npm package.`,
-          origin: '@atlaspack/core',
-          codeFrames: keyPath
-            ? [
-                {
-                  filePath: configPath,
-                  language: 'json5',
-                  code: configContents,
-                  codeHighlights: generateJSONCodeHighlights(configContents, [
-                    {
-                      key: keyPath,
-                      type: 'value',
-                    },
-                  ]),
-                },
-              ]
-            : undefined,
-        },
-      });
-    }
 
-    let configPkg = await loadConfig(
-      options.inputFS,
-      resolveFrom,
-      ['package.json'],
-      options.projectRoot,
-    );
-    if (
-      configPkg != null &&
-      configPkg.config.dependencies?.[pluginName] == null
-    ) {
-      let contents = await options.inputFS.readFile(
-        configPkg.files[0].filePath,
-        'utf8',
-      );
-      throw new ThrowableDiagnostic({
-        diagnostic: {
-          message: md`Could not determine version of ${pluginName} in ${path.relative(
-            process.cwd(),
-            resolveFrom,
-          )}. Include it in "dependencies".`,
-          origin: '@atlaspack/core',
-          codeFrames: configPkg.config.dependencies
-            ? [
-                {
-                  filePath: configPkg.files[0].filePath,
-                  language: 'json5',
-                  code: contents,
-                  codeHighlights: generateJSONCodeHighlights(contents, [
-                    {
-                      key: '/dependencies',
-                      type: 'key',
-                    },
-                  ]),
-                },
-              ]
-            : undefined,
-        },
-      });
-    }
+  // Config packages can reference plugins, but cannot contain other plugins within them.
+  // This forces every published plugin to be published separately so they can be mixed and matched if needed.
+  if (resolveFrom.includes(NODE_MODULES) && pluginName.startsWith('.')) {
+    let configContents = await options.inputFS.readFile(configPath, 'utf8');
+    throw new ThrowableDiagnostic({
+      diagnostic: {
+        message: md`Local plugins are not supported in Atlaspack config packages. Please publish "${pluginName}" as a separate npm package.`,
+        origin: '@atlaspack/core',
+        codeFrames: keyPath
+          ? [
+              {
+                filePath: configPath,
+                language: 'json5',
+                code: configContents,
+                codeHighlights: generateJSONCodeHighlights(configContents, [
+                  {
+                    key: keyPath,
+                    type: 'value',
+                  },
+                ]),
+              },
+            ]
+          : undefined,
+      },
+    });
   }
 
   let resolved, pkg;


### PR DESCRIPTION
## Motivation

We were receiving reports of some "unable to resolve" errors since merging #383 where the resolver can't find the plugins required. This is being caused by the fact that when a dependency was listed in `parcelDependencies`, we would set the `resolveFrom` to be the project root and then continue on.

## Changes

Since `parcelDependencies` no longer exists, it doesn't make sense to special case whether or not this plugin is in the package.json of the default config plugin anymore. This PR removes that check entirely, so it shouldn't throw errors on plugins that aren't explicitly listed anymore (so long as they're in the project's `package.json`).
