### PR TITLE
Fix css modules case for single file output

### DIFF
--- a/.changeset/slimy-crews-count.md
+++ b/.changeset/slimy-crews-count.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/bundler-default': patch
+---
+
+In the first attempt to support isolated bundles, there was a check on the number of assets that wasn't really correct.
+That check has been removed, so we can bundle even where there are special cases.

--- a/packages/bundlers/default/src/MonolithicBundler.js
+++ b/packages/bundlers/default/src/MonolithicBundler.js
@@ -1,6 +1,5 @@
 // @flow strict-local
 import type {Asset, Dependency, MutableBundleGraph} from '@atlaspack/types';
-import invariant from 'assert';
 import nullthrows from 'nullthrows';
 
 export function addJSMonolithBundle(

--- a/packages/core/integration-tests/test/monolithic-bundler.js
+++ b/packages/core/integration-tests/test/monolithic-bundler.js
@@ -130,4 +130,38 @@ describe('monolithic bundler', function () {
       {type: 'svg', assets: ['icon.svg']},
     ]);
   });
+
+  it.v2('should handle multiple assets like a CSS module', async function () {
+    await fsFixture(overlayFS, __dirname)`
+      multi-asset-bundles
+        a.js:
+          import styles from './styles.module.css';
+          export const styleContainer = \`<div class="\${styles.container}" />\`;
+        styles.module.css:
+          .container {
+            color: papayawhip;
+          }
+        yarn.lock: {}
+    `;
+
+    let bundleResult = await bundle(
+      path.join(__dirname, 'multi-asset-bundles/a.js'),
+      {
+        defaultTargetOptions: {shouldScopeHoist: false},
+        inputFS: overlayFS,
+        outputFS: overlayFS,
+        mode: 'production',
+        targets: {
+          'multi-asset-bundle': {
+            distDir: 'dist-multi-asset',
+            __unstable_singleFileOutput: true,
+          },
+        },
+      },
+    );
+
+    const result = await run(bundleResult);
+
+    assert.equal(result.styleContainer, '<div class="EcQGha_container" />');
+  });
 });


### PR DESCRIPTION
## Motivation

When making the isolated bundles change (#405), I added a check that a dependency should have one and only one asset.

This is of course completely incorrect, because external dependencies have no assets, and things like CSS Modules will have two assets.

## Changes

The fix here is just to iterate over the assets that are returned and handle each asset individually.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required