### PR TITLE
Support inline bundles for single file output

### DIFF
--- a/.changeset/weak-mails-dream.md
+++ b/.changeset/weak-mails-dream.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/bundler-default': patch
+---
+
+Switches the isolated behaviour in single file output mode to be for inline bundles instead. Also makes isolated bundles an error.

--- a/packages/bundlers/default/src/MonolithicBundler.js
+++ b/packages/bundlers/default/src/MonolithicBundler.js
@@ -39,12 +39,15 @@ export function addJSMonolithBundle(
       let assets = bundleGraph.getDependencyAssets(dependency);
 
       for (const asset of assets) {
-        // For assets marked as isolated, we create new bundles and let other
+        if (asset.bundleBehavior === 'isolated') {
+          throw new Error(
+            'Isolated assets are not supported for single file output builds',
+          );
+        }
+
+        // For assets marked as inline, we create new bundles and let other
         // plugins like optimizers include them in the primary bundle
-        if (
-          asset.bundleBehavior === 'isolated' ||
-          asset.bundleBehavior === 'inline'
-        ) {
+        if (asset.bundleBehavior === 'inline') {
           // Create a new bundle to hold the isolated asset
           let isolatedBundle = bundleGraph.createBundle({
             entryAsset: asset,

--- a/packages/bundlers/default/src/MonolithicBundler.js
+++ b/packages/bundlers/default/src/MonolithicBundler.js
@@ -41,12 +41,15 @@ export function addJSMonolithBundle(
       for (const asset of assets) {
         // For assets marked as isolated, we create new bundles and let other
         // plugins like optimizers include them in the primary bundle
-        if (asset.bundleBehavior === 'isolated') {
+        if (
+          asset.bundleBehavior === 'isolated' ||
+          asset.bundleBehavior === 'inline'
+        ) {
           // Create a new bundle to hold the isolated asset
           let isolatedBundle = bundleGraph.createBundle({
             entryAsset: asset,
             target,
-            bundleBehavior: 'isolated',
+            bundleBehavior: asset.bundleBehavior,
           });
 
           bundleGraph.addAssetToBundle(asset, isolatedBundle);

--- a/packages/core/integration-tests/test/monolithic-bundler.js
+++ b/packages/core/integration-tests/test/monolithic-bundler.js
@@ -190,6 +190,7 @@ describe('monolithic bundler', function () {
     });
 
     const result = await run(bundleResult);
-    assert(result.output.startsWith('File text: !function(e,n,r,t,o)'));
+    assert(result.output.startsWith('File text: !function('));
+    assert(result.output.includes('Hello world'));
   });
 });


### PR DESCRIPTION
## Motivation

The isolated bundles are more complicated than expected, and will probably require the `tesseract` target to be added to be handled properly.

Instead, we're addressing this issue in the product by making images into data urls on the server, which requires that the single file bundler supports inline bundles.

It also doesn't really make sense for the single file output mode to even have isolated bundles, since they can't exist in the output, so we've banned them for now.

## Changes

This is a very basic one, and just switches the existing behaviour for handling isolated bundles over to inline, and makes isolated bundles an error.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required