### PR TITLE
Fix unit-tests on node v22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
     name: Unit tests (${{ matrix.os }}, Node ${{ matrix.node }})
     strategy:
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/packages/runtimes/js/test/esm-js-loader-retry.test.ts
+++ b/packages/runtimes/js/test/esm-js-loader-retry.test.ts
@@ -1,3 +1,5 @@
+// @flow strict-local
+
 import load from '../src/helpers/browser/esm-js-loader-retry.js';
 import bundleManifest from '../src/helpers/bundle-manifest.js';
 import {mock} from 'node:test';
@@ -33,6 +35,13 @@ describe('esm-js-loader-retry', () => {
     globalThis.navigator = {onLine: true};
     globalThis.CustomEvent = globalThis.CustomEvent || class {};
     globalThis.dispatchEvent = mock.fn();
+
+    // Add mock for addEventListener
+    globalThis.addEventListener = mock.fn((event, callback) => {
+      if (event === 'online') {
+        callback();
+      }
+    });
   });
 
   it('should not throw', async () => {


### PR DESCRIPTION
Also update workflow to run them on v22.

This was failing because globalThis.navigator does not seem to be being mocked
correctly on node v22.

Test Plan: yarn test:unit
