### PR TITLE
Fix inline bundle source maps writting

### DIFF
--- a/.changeset/rude-cats-mate.md
+++ b/.changeset/rude-cats-mate.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/core': patch
+'@atlaspack/feature-flags': patch
+---
+
+Add feature-flag to fix supporting source-maps for inline bundles

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -17,6 +17,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   vcsMode: 'OLD',
   loadableSideEffects: false,
   reduceResolverStringCreation: false,
+  inlineBundlesSourceMapFixes: false,
   conditionalBundlingNestedRuntime: false,
 };
 

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -47,6 +47,10 @@ export type FeatureFlags = {|
    */
   reduceResolverStringCreation: boolean,
   /**
+   * Fixes source maps for inline bundles
+   */
+  inlineBundlesSourceMapFixes: boolean,
+  /**
    * Enable nested loading of bundles in the runtime with conditional bundling
    */
   conditionalBundlingNestedRuntime: boolean,


### PR DESCRIPTION
Change bundles packaged/listed so that inline bundles' source-maps and contents
are written to disk.

Add null check so that inline bundles referencing their parent bundles in the
source-mapping URL still work.

Test Plan: Change is experimental and feature-flagged / subject to change
