### PR TITLE
Chore: Replace require.resolve with path.join for workers

### DIFF
--- a/.changeset/fluffy-students-fail.md
+++ b/.changeset/fluffy-students-fail.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/workers': patch
+'@atlaspack/core': patch
+---
+
+Replace require.resolve with path.join

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -68,6 +68,7 @@ registerCoreWithSerializer();
 
 export const INTERNAL_TRANSFORM: symbol = Symbol('internal_transform');
 export const INTERNAL_RESOLVE: symbol = Symbol('internal_resolve');
+export const WORKER_PATH: string = path.join(__dirname, 'worker.js');
 
 export default class Atlaspack {
   #requestTracker /*: RequestTracker*/;
@@ -728,6 +729,6 @@ export function createWorkerFarm(
 ): WorkerFarm {
   return new WorkerFarm({
     ...options,
-    workerPath: require.resolve('./worker'),
+    workerPath: WORKER_PATH,
   });
 }

--- a/packages/core/workers/src/process/ProcessWorker.js
+++ b/packages/core/workers/src/process/ProcessWorker.js
@@ -9,10 +9,11 @@ import type {
 } from '../types';
 
 import childProcess, {type ChildProcess} from 'child_process';
+import path from 'path';
 
 import {serialize, deserialize} from '@atlaspack/build-cache';
 
-const WORKER_PATH = require.resolve('./ProcessChild');
+const WORKER_PATH = path.join(__dirname, './ProcessChild.js');
 
 export default class ProcessWorker implements WorkerImpl {
   execArgv: Object;

--- a/packages/core/workers/src/threads/ThreadsWorker.js
+++ b/packages/core/workers/src/threads/ThreadsWorker.js
@@ -9,13 +9,14 @@ import type {
 } from '../types';
 
 import {Worker} from 'worker_threads';
+import path from 'path';
 
 import {
   prepareForSerialization,
   restoreDeserializedObject,
 } from '@atlaspack/build-cache';
 
-const WORKER_PATH = require.resolve('./ThreadsChild');
+const WORKER_PATH = path.join(__dirname, './ThreadsChild.js');
 
 export default class ThreadsWorker implements WorkerImpl {
   execArgv: Object;


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Changes

Replace `require.resolve` for known static file paths with `path.join` (workers)

## Motivation

This is unsupported in Nodejs `type: module`, increases the difficulty of migrating to modern Nodejs and prevents the use of Atlaspack with alternative runtimes (experimenting with Deno, Bun, etc)

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
