### PR TITLE
Chore: Use utility to resolve & read package.json dynamically in core 

### DIFF
--- a/.changeset/neat-nails-tap.md
+++ b/.changeset/neat-nails-tap.md
@@ -1,0 +1,17 @@
+---
+'@atlaspack/node-resolver-core': patch
+'@atlaspack/create-react-app': patch
+'@atlaspack/package-manager': patch
+'@atlaspack/bundle-stats': patch
+'@atlaspack/link': patch
+'@atlaspack/transformer-babel': patch
+'@atlaspack/transformer-js': patch
+'@atlaspack/workers': patch
+'@atlaspack/cache': patch
+'@atlaspack/utils': patch
+'@atlaspack/core': patch
+'@atlaspack/cli': patch
+'@atlaspack/fs': patch
+---
+
+Using utility to resolve & read package.json at runtime

--- a/packages/core/cache/src/FSCache.js
+++ b/packages/core/cache/src/FSCache.js
@@ -9,6 +9,7 @@ import stream from 'stream';
 import path from 'path';
 import {promisify} from 'util';
 
+import {readPackageJsonSync} from '@atlaspack/utils';
 import logger from '@atlaspack/logger';
 import {
   deserialize,
@@ -16,10 +17,9 @@ import {
   serialize,
 } from '@atlaspack/build-cache';
 
-// flowlint-next-line untyped-import:off
-import packageJson from '../package.json';
-
 import {WRITE_LIMIT_CHUNK} from './constants';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 const pipeline: (Readable, Writable) => Promise<void> = promisify(
   stream.pipeline,

--- a/packages/core/cache/src/IDBCache.browser.js
+++ b/packages/core/cache/src/IDBCache.browser.js
@@ -8,13 +8,11 @@ import {
   registerSerializableClass,
   serialize,
 } from '@atlaspack/build-cache';
-import {bufferStream} from '@atlaspack/utils';
+import {bufferStream, readPackageJsonSync} from '@atlaspack/utils';
 // $FlowFixMe[untyped-import]
 import {openDB} from 'idb';
 
-// $FlowFixMe[untyped-import]
-import packageJson from '../package.json';
-
+const packageJson = readPackageJsonSync(__dirname);
 const STORE_NAME = 'cache';
 
 export class IDBCache implements Cache {

--- a/packages/core/cache/src/LMDBCache.js
+++ b/packages/core/cache/src/LMDBCache.js
@@ -13,13 +13,13 @@ import {
   serialize,
 } from '@atlaspack/build-cache';
 import {NodeFS} from '@atlaspack/fs';
+import {readPackageJsonSync} from '@atlaspack/utils';
 // flowlint-next-line untyped-import:off
 import lmdb from 'lmdb';
 
-// $FlowFixMe
-import packageJson from '../package.json';
-
 import {FSCache} from './FSCache';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 const pipeline: (Readable, Writable) => Promise<void> = promisify(
   stream.pipeline,

--- a/packages/core/cache/src/LMDBLiteCache.js
+++ b/packages/core/cache/src/LMDBLiteCache.js
@@ -15,11 +15,11 @@ import path from 'path';
 import {promisify} from 'util';
 
 import {NodeFS} from '@atlaspack/fs';
-
-// $FlowFixMe
-import packageJson from '../package.json';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
 import {FSCache} from './FSCache';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 interface DBOpenOptions {
   name: string;

--- a/packages/core/cli/src/cli.js
+++ b/packages/core/cli/src/cli.js
@@ -5,10 +5,10 @@ import {NodeFS} from '@atlaspack/fs';
 import {openInBrowser} from '@atlaspack/utils';
 import {Disposable} from '@atlaspack/events';
 import {INTERNAL_ORIGINAL_CONSOLE} from '@atlaspack/logger';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import chalk from 'chalk';
 import commander from 'commander';
 import path from 'path';
-import {version} from '../package.json';
 import {applyOptions} from './applyOptions';
 import {makeDebugCommand} from './makeDebugCommand';
 import {normalizeOptions} from './normalizeOptions';
@@ -18,6 +18,7 @@ import {
 } from './handleUncaughtException';
 import {commonOptions, hmrOptions} from './options';
 
+const {version} = readPackageJsonSync(__dirname);
 const program = new commander.Command();
 
 // Exit codes in response to signals are traditionally

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -30,7 +30,7 @@ import dumpGraphToGraphViz from './dumpGraphToGraphViz';
 import resolveOptions from './resolveOptions';
 import {ValueEmitter} from '@atlaspack/events';
 import {registerCoreWithSerializer} from './registerCoreWithSerializer';
-import {PromiseQueue} from '@atlaspack/utils';
+import {PromiseQueue, readPackageJsonSync} from '@atlaspack/utils';
 import {AtlaspackConfig} from './AtlaspackConfig';
 import logger from '@atlaspack/logger';
 import RequestTracker, {
@@ -66,6 +66,7 @@ import type {AssetGraphRequestResult} from './requests/AssetGraphRequest';
 
 registerCoreWithSerializer();
 
+const packageJson = readPackageJsonSync(__dirname);
 export const INTERNAL_TRANSFORM: symbol = Symbol('internal_transform');
 export const INTERNAL_RESOLVE: symbol = Symbol('internal_resolve');
 
@@ -158,7 +159,7 @@ export default class Atlaspack {
       const lmdb: Lmdb = resolvedOptions.cache.getNativeRef();
 
       // $FlowFixMe
-      const version = require('../package.json').version;
+      const version = packageJson.version;
       await lmdb.put('current_session_version', Buffer.from(version));
 
       rustAtlaspack = new AtlaspackV3({

--- a/packages/core/core/src/constants.js
+++ b/packages/core/core/src/constants.js
@@ -1,7 +1,10 @@
 // @flow strict-local
 
-// $FlowFixMe
-import {version} from '../package.json';
+import {readPackageJsonSync} from '@atlaspack/utils';
+import {type PackageJSON} from '@atlaspack/types-internal';
+
+const pkg: PackageJSON = readPackageJsonSync(__dirname);
+const version = pkg.version;
 
 export const ATLASPACK_VERSION = version;
 export const HASH_REF_PREFIX = 'HASH_REF_';

--- a/packages/core/core/src/loadAtlaspackPlugin.js
+++ b/packages/core/core/src/loadAtlaspackPlugin.js
@@ -10,10 +10,14 @@ import ThrowableDiagnostic, {
   generateJSONCodeHighlights,
   md,
 } from '@atlaspack/diagnostic';
-import {findAlternativeNodeModules, resolveConfig} from '@atlaspack/utils';
+import {
+  findAlternativeNodeModules,
+  resolveConfig,
+  readPackageJsonSync,
+} from '@atlaspack/utils';
 import {type ProjectPath, toProjectPath} from './projectPath';
-import {version as ATLASPACK_VERSION} from '../package.json';
 
+const {version: ATLASPACK_VERSION} = readPackageJsonSync(__dirname);
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 const CONFIG = Symbol.for('parcel-plugin-config');
 

--- a/packages/core/core/src/registerCoreWithSerializer.js
+++ b/packages/core/core/src/registerCoreWithSerializer.js
@@ -2,14 +2,15 @@
 
 import {registerSerializableClass} from '@atlaspack/build-cache';
 import {Graph} from '@atlaspack/graph';
-
-import packageJson from '../package.json';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
 import {AtlaspackConfig} from './AtlaspackConfig';
 import AssetGraph from './AssetGraph';
 import BundleGraph from './BundleGraph';
 import Config from './public/Config';
 import {RequestGraph} from './RequestTracker';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 let coreRegistered;
 export function registerCoreWithSerializer() {

--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -12,16 +12,18 @@ import type {
   Options as WatcherOptions,
   AsyncSubscription,
 } from '@parcel/watcher';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
 import path from 'path';
 import {Readable, Writable} from 'stream';
 import {registerSerializableClass} from '@atlaspack/build-cache';
 import {SharedBuffer} from '@atlaspack/utils';
-import packageJSON from '../package.json';
 import WorkerFarm, {Handle} from '@atlaspack/workers';
 import nullthrows from 'nullthrows';
 import EventEmitter from 'events';
 import {findAncestorFile, findNodeModule, findFirstFile} from './find';
+
+const packageJSON = readPackageJsonSync(__dirname);
 
 const instances: Map<number, MemoryFS> = new Map();
 let id = 0;

--- a/packages/core/fs/src/NodeFS.js
+++ b/packages/core/fs/src/NodeFS.js
@@ -20,16 +20,18 @@ import path from 'path';
 import {tmpdir} from 'os';
 import {promisify} from 'util';
 import {registerSerializableClass} from '@atlaspack/build-cache';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import {hashFile} from '@atlaspack/utils';
 import {getFeatureFlag} from '@atlaspack/feature-flags';
 import watcher from '@parcel/watcher';
-import packageJSON from '../package.json';
 
 import * as searchNative from '@atlaspack/rust';
 import * as searchJS from './find';
 
 // Most of this can go away once we only support Node 10+, which includes
 // require('fs').promises
+
+const packageJSON = readPackageJsonSync(__dirname);
 
 const realpath = promisify(
   process.platform === 'win32' ? fs.realpath : fs.realpath.native,

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -8,9 +8,9 @@ import type {Event, Options as WatcherOptions} from '@parcel/watcher';
 import {registerSerializableClass} from '@atlaspack/build-cache';
 import {instrument, instrumentAsync} from '@atlaspack/logger';
 import {getFeatureFlagValue} from '@atlaspack/feature-flags';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
-// $FlowFixMe
-import packageJSON from '../package.json';
+const packageJSON = readPackageJsonSync(__dirname);
 
 export interface NodeVCSAwareFSOptions {
   gitRepoPath: null | FilePath;

--- a/packages/core/fs/src/OverlayFS.js
+++ b/packages/core/fs/src/OverlayFS.js
@@ -16,13 +16,15 @@ import type {
 } from '@parcel/watcher';
 
 import {registerSerializableClass} from '@atlaspack/build-cache';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import WorkerFarm from '@atlaspack/workers';
-import packageJSON from '../package.json';
 import {findAncestorFile, findNodeModule, findFirstFile} from './find';
 import {MemoryFS} from './MemoryFS';
 
 import nullthrows from 'nullthrows';
 import path from 'path';
+
+const packageJSON = readPackageJsonSync(__dirname);
 
 export class OverlayFS implements FileSystem {
   deleted: Set<FilePath> = new Set();

--- a/packages/core/package-manager/src/MockPackageInstaller.js
+++ b/packages/core/package-manager/src/MockPackageInstaller.js
@@ -10,9 +10,11 @@ import type {FilePath} from '@atlaspack/types';
 
 import path from 'path';
 import {registerSerializableClass} from '@atlaspack/build-cache';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import {ncp} from '@atlaspack/fs';
-import pkg from '../package.json';
 import {moduleRequestsFromDependencyMap} from './utils';
+
+const pkg = readPackageJsonSync(__dirname);
 
 type Package = {|
   fs: FileSystem,

--- a/packages/core/package-manager/src/NodePackageManager.js
+++ b/packages/core/package-manager/src/NodePackageManager.js
@@ -22,6 +22,7 @@ import ThrowableDiagnostic, {
   md,
 } from '@atlaspack/diagnostic';
 import {NodeFS} from '@atlaspack/fs';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import nativeFS from 'fs';
 import Module from 'module';
 import path from 'path';
@@ -32,11 +33,12 @@ import nullthrows from 'nullthrows';
 import {getModuleParts} from '@atlaspack/utils';
 import {getConflictingLocalDependencies} from './utils';
 import {installPackage} from './installPackage';
-import pkg from '../package.json';
 import {getConditionsFromEnv} from './nodejsConditions';
 import {ResolverBase} from '@atlaspack/node-resolver-core';
 import {pathToFileURL} from 'url';
 import {transformSync} from '@swc/core';
+
+const pkg = readPackageJsonSync(__dirname);
 
 // Package.json fields. Must match package_json.rs.
 const MAIN = 1 << 0;

--- a/packages/core/package-manager/src/Npm.js
+++ b/packages/core/package-manager/src/Npm.js
@@ -8,9 +8,9 @@ import logger from '@atlaspack/logger';
 import {registerSerializableClass} from '@atlaspack/build-cache';
 import promiseFromProcess from './promiseFromProcess';
 import {npmSpecifierFromModuleRequest} from './utils';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
-// $FlowFixMe
-import pkg from '../package.json';
+const pkg = readPackageJsonSync(__dirname);
 
 const NPM_CMD = 'npm';
 

--- a/packages/core/package-manager/src/Pnpm.js
+++ b/packages/core/package-manager/src/Pnpm.js
@@ -7,14 +7,14 @@ import fs from 'fs';
 import commandExists from 'command-exists';
 import spawn from 'cross-spawn';
 import {registerSerializableClass} from '@atlaspack/build-cache';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import logger from '@atlaspack/logger';
 import split from 'split2';
 import JSONParseStream from './JSONParseStream';
 import promiseFromProcess from './promiseFromProcess';
 import {exec, npmSpecifierFromModuleRequest} from './utils';
 
-// $FlowFixMe
-import pkg from '../package.json';
+const pkg = readPackageJsonSync(__dirname);
 
 const PNPM_CMD = 'pnpm';
 

--- a/packages/core/package-manager/src/Yarn.js
+++ b/packages/core/package-manager/src/Yarn.js
@@ -10,9 +10,9 @@ import split from 'split2';
 import JSONParseStream from './JSONParseStream';
 import promiseFromProcess from './promiseFromProcess';
 import {exec, npmSpecifierFromModuleRequest} from './utils';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
-// $FlowFixMe
-import pkg from '../package.json';
+const pkg = readPackageJsonSync(__dirname);
 
 const YARN_CMD = 'yarn';
 

--- a/packages/core/utils/src/find-package-json.js
+++ b/packages/core/utils/src/find-package-json.js
@@ -1,0 +1,33 @@
+// @flow
+
+import * as path from 'path';
+import * as fs from 'fs';
+
+export function findPackageJson(from: string): string | null {
+  let currentDir = path.resolve(from);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const pkgfile = path.join(currentDir, 'package.json');
+    if (fs.existsSync(pkgfile)) {
+      return pkgfile;
+    }
+    const dir = path.dirname(currentDir);
+    if (dir === currentDir) {
+      break;
+    }
+    currentDir = dir;
+  }
+
+  return null;
+}
+
+export function readPackageJsonSync<T>(from: string): T {
+  const packageJson = findPackageJson(from);
+  if (!packageJson) {
+    // Cannot return T | null because there are too many failing null checks
+    // $FlowFixMe
+    return null;
+  }
+  return JSON.parse(fs.readFileSync(packageJson, 'utf8'));
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -29,6 +29,7 @@ export {default as throttle} from './throttle';
 export {default as openInBrowser} from './openInBrowser';
 
 // Explicit re-exports instead of export * for lazy require performance
+export {findPackageJson, readPackageJsonSync} from './find-package-json';
 export {findAlternativeNodeModules, findAlternativeFiles} from './alternatives';
 export {blobToBuffer, blobToString} from './blob';
 export {

--- a/packages/core/workers/src/Handle.js
+++ b/packages/core/workers/src/Handle.js
@@ -1,7 +1,8 @@
 // @flow strict-local
 import {registerSerializableClass} from '@atlaspack/build-cache';
-// $FlowFixMe
-import packageJson from '../package.json';
+import {readPackageJsonSync} from '@atlaspack/utils';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 let HANDLE_ID = 0;
 // $FlowFixMe

--- a/packages/dev/atlaspack-link/src/cli.js
+++ b/packages/dev/atlaspack-link/src/cli.js
@@ -1,15 +1,16 @@
 // @flow strict-local
 /* eslint-disable no-console */
+import {readPackageJsonSync} from '@atlaspack/utils';
 
 import type {LinkCommandOptions} from './link';
 import type {UnlinkCommandOptions} from './unlink';
 
-// $FlowFixMe[untyped-import]
-import {version} from '../package.json';
 import {createLinkCommand} from './link';
 import {createUnlinkCommand} from './unlink';
 
 import commander from 'commander';
+
+const {version} = readPackageJsonSync(__dirname);
 
 export type ProgramOptions = {|...LinkCommandOptions, ...UnlinkCommandOptions|};
 

--- a/packages/dev/bundle-stats-cli/src/cli.js
+++ b/packages/dev/bundle-stats-cli/src/cli.js
@@ -2,15 +2,15 @@
 // @flow strict-local
 import type {PackagedBundle} from '@atlaspack/types';
 import type {ParcelOptions} from '@atlaspack/core/src/types';
+import {readPackageJsonSync} from '@atlaspack/utils';
 import type {commander$Command} from 'commander';
-
-// $FlowFixMe[untyped-import]
-import {version} from '../package.json';
 
 import commander from 'commander';
 import fs from 'fs';
 import path from 'path';
 import {DefaultMap} from '@atlaspack/utils';
+
+const {version} = readPackageJsonSync(__dirname);
 
 const {
   loadGraphs,

--- a/packages/dev/repl/src/atlaspack/BrowserPackageManager.js
+++ b/packages/dev/repl/src/atlaspack/BrowserPackageManager.js
@@ -10,8 +10,7 @@ import type {
   Invalidations,
   ResolveResult,
 } from '@atlaspack/package-manager';
-// $FlowFixMe[untyped-import]
-import packageJson from '../../package.json';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
 import path from 'path';
 import nullthrows from 'nullthrows';
@@ -44,6 +43,8 @@ import transformerPostcss from '@atlaspack/transformer-postcss';
 import transformerPosthtml from '@atlaspack/transformer-posthtml';
 import transformerRaw from '@atlaspack/transformer-raw';
 import transformerReactRefreshWrap from '@atlaspack/transformer-react-refresh-wrap';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 export const BUILTINS = {
   '@atlaspack/bundler-default': bundlerDefault,

--- a/packages/transformers/babel/src/babel7.js
+++ b/packages/transformers/babel/src/babel7.js
@@ -8,6 +8,7 @@ import type {
   PluginLogger,
 } from '@atlaspack/types';
 import typeof * as BabelCore from '@babel/core';
+import {readPackageJsonSync} from '@atlaspack/utils';
 
 import invariant from 'assert';
 import path from 'path';
@@ -15,7 +16,7 @@ import {md} from '@atlaspack/diagnostic';
 import {relativeUrl} from '@atlaspack/utils';
 import {remapAstLocations} from './remapAstLocations';
 
-import packageJson from '../package.json';
+const packageJson = readPackageJsonSync(__dirname);
 
 const transformerVersion: mixed = packageJson.version;
 invariant(typeof transformerVersion === 'string');

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -19,9 +19,15 @@ import ThrowableDiagnostic, {
   encodeJSONKeyComponent,
   convertSourceLocationToHighlight,
 } from '@atlaspack/diagnostic';
-import {validateSchema, remapSourceLocation, globMatch} from '@atlaspack/utils';
-import pkg from '../package.json';
+import {
+  validateSchema,
+  remapSourceLocation,
+  globMatch,
+  readPackageJsonSync,
+} from '@atlaspack/utils';
 import {getFeatureFlag} from '@atlaspack/feature-flags';
+
+const pkg = readPackageJsonSync(__dirname);
 
 const JSX_EXTENSIONS = {
   jsx: true,

--- a/packages/utils/create-react-app/package.json
+++ b/packages/utils/create-react-app/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@atlaspack/utils": "2.13.1",
     "@npmcli/promise-spawn": "^1.3.2",
     "chalk": "^2.4.2",
     "command-exists": "^1.2.6",

--- a/packages/utils/create-react-app/src/cli.js
+++ b/packages/utils/create-react-app/src/cli.js
@@ -1,8 +1,7 @@
 // @flow strict-local
 
+import {readPackageJsonSync} from '@atlaspack/utils';
 import program from 'commander';
-// flowlint-next-line untyped-import:off
-import {version} from '../package.json';
 // flowlint-next-line untyped-import:off
 import simpleGit from 'simple-git';
 import fs from 'fs';
@@ -18,6 +17,7 @@ import chalk from 'chalk';
 import * as emoji from './emoji';
 
 const TEMPLATES_DIR = path.resolve(__dirname, '../templates');
+const {version} = readPackageJsonSync(__dirname);
 
 const ncp = promisify(_ncp);
 // eslint-disable-next-line no-console

--- a/packages/utils/node-resolver-core/src/builtins.js
+++ b/packages/utils/node-resolver-core/src/builtins.js
@@ -1,9 +1,10 @@
 // @flow strict-local
 // $FlowFixMe this is untyped
+import {readPackageJsonSync} from '@atlaspack/utils';
 import {builtinModules} from 'module';
 import nullthrows from 'nullthrows';
-// flowlint-next-line untyped-import:off
-import packageJson from '../package.json';
+
+const packageJson = readPackageJsonSync(__dirname);
 
 export const empty: string = require.resolve('./_empty.js');
 
@@ -16,7 +17,7 @@ for (let key of builtinModules) {
   builtins[key] = {name: empty, range: null};
 }
 
-let polyfills = {
+let polyfills: {[string]: string} = {
   assert: 'assert',
   buffer: 'buffer',
   console: 'console-browserify',
@@ -46,7 +47,7 @@ for (let k in polyfills) {
   let polyfill = polyfills[k];
   builtins[k] = {
     name: polyfill + (builtinModules.includes(polyfill) ? '/' : ''),
-    range: nullthrows(packageJson.devDependencies[polyfill]),
+    range: nullthrows(packageJson?.devDependencies[polyfill]),
   };
 }
 


### PR DESCRIPTION
## Changes

Replace 
```typescript
import packageJson from '../package.json'
```
With
```typescript
import {readPackageJsonSync} from '@atlaspack/utils'

const packageJson = readPackageJsonSync(__dirname) 
```

## Motivation

Static imports of package.json files is not valid for `type: module` preventing the eventual migration to TypeScript and modules. It also messes with bundling atlaspack into a single distributable (an experiment I am working on)

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
