### PR TITLE
fix vcsMode feature flagging

### DIFF
--- a/.changeset/slow-eggs-ring.md
+++ b/.changeset/slow-eggs-ring.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/feature-flags': patch
+'@atlaspack/core': patch
+---
+
+Fix vcsMode feature flagging

--- a/packages/core/core/src/resolveOptions.js
+++ b/packages/core/core/src/resolveOptions.js
@@ -46,7 +46,10 @@ function compileGlobs(globs: string[]): RegExp[] {
 }
 
 function getDefaultFS(): FileSystem {
-  if (getFeatureFlagValue('vcsMode') !== 'OLD') {
+  if (
+    getFeatureFlag('enableVCSEventsShadowReads') &&
+    getFeatureFlagValue('vcsMode') !== 'OLD'
+  ) {
     return new NodeVCSAwareFS({
       gitRepoPath: null,
       excludePatterns: [],

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -20,6 +20,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   inlineBundlesSourceMapFixes: false,
   conditionalBundlingNestedRuntime: false,
   patchProjectPaths: false,
+  enableVCSEventsShadowReads: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -58,6 +58,11 @@ export type FeatureFlags = {|
    * This feature is experimental and should not be used in production. It will used to test downloadble cache artefacts.
    */
   patchProjectPaths: boolean,
+
+  /**
+   * Enable shadow reads of VCS events
+   */
+  enableVCSEventsShadowReads: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =


### PR DESCRIPTION
ensure `vcsMode` are only checked if VCS is enabled
