### PR TITLE
Support async runtime in conditional bundling

### DIFF
--- a/.changeset/rude-dragons-exercise.md
+++ b/.changeset/rude-dragons-exercise.md
@@ -1,0 +1,8 @@
+---
+'@atlaspack/reporter-conditional-manifest': patch
+'@atlaspack/types-internal': patch
+'@atlaspack/core': patch
+'@atlaspack/feature-flags': patch
+---
+
+Support async script runtime in conditional bundling

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,6 +14,7 @@
       "name": "Run Integration Tests (lldb)",
       "args": [
         "--inspect-brk",
+        "--experimental-vm-modules",
         "${workspaceFolder}/node_modules/.bin/_mocha",
         "--timeout=1000000",
         "${input:integration-tests-args}"

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -444,10 +444,11 @@ export default class BundleGraph<TBundle: IBundle>
   // be used by a webserver to understand which conditions are used by which bundles,
   // and which bundles those conditions require depending on what they evaluate to.
   getConditionalBundleMapping(): Map<
-    TBundle,
+    string,
     Map<
       string,
       {|
+        bundle: TBundle,
         ifTrueBundles: Array<TBundle>,
         ifFalseBundles: Array<TBundle>,
       |},
@@ -486,14 +487,15 @@ export default class BundleGraph<TBundle: IBundle>
       }
 
       for (let bundle of bundles) {
-        const conditions = bundleConditions.get(bundle) ?? new Map();
+        const conditions = bundleConditions.get(bundle.id) ?? new Map();
 
         conditions.set(cond.key, {
+          bundle,
           ifTrueBundles,
           ifFalseBundles,
         });
 
-        bundleConditions.set(bundle, conditions);
+        bundleConditions.set(bundle.id, conditions);
       }
     }
 

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -22,6 +22,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   patchProjectPaths: false,
   enableRustWorkerThreadDylibHack: true,
   inlineStringReplacementPerf: false,
+  conditionalBundlingAsyncRuntime: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -67,6 +67,10 @@ export type FeatureFlags = {|
    * Used heavily for inline bundles.
    */
   inlineStringReplacementPerf: boolean,
+  /**
+   * Enable support for the async bundle runtime (unstable_asyncBundleRuntime) in conditional bundling
+   */
+  conditionalBundlingAsyncRuntime: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -921,7 +921,10 @@ describe('conditional bundling', function () {
           shouldOptimize: false,
           outputFormat: 'esmodule',
         },
-        featureFlags: {conditionalBundlingApi: true},
+        featureFlags: {
+          conditionalBundlingApi: true,
+          conditionalBundlingAsyncRuntime: true,
+        },
         inputFS: overlayFS,
       },
     );

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -15,6 +15,7 @@ import {
   distDir,
 } from '@atlaspack/test-utils';
 import sinon from 'sinon';
+import {runBundle} from '../../test-utils/src/utils';
 
 describe('conditional bundling', function () {
   beforeEach(async () => {
@@ -869,5 +870,80 @@ describe('conditional bundling', function () {
       typeof lazyImported === 'object' && lazyImported?.default,
       'module-c',
     );
+  });
+
+  it(`should support async bundle runtime`, async function () {
+    const dir = path.join(__dirname, 'import-cond-async-bundle-runtime');
+    await overlayFS.mkdirp(dir);
+
+    await fsFixture(overlayFS, dir)`
+      cond-a.js:
+        export default 'cond-a';
+
+      cond-b.js:
+        export default 'cond-b';
+
+      cond-a.html:
+        <script type="module" src="./cond-a.js"></script>
+
+      index.html:
+        <script type="module" src="./index.js"></script>
+
+      index.js:
+        globalThis.__MCOND = (key) => ({ 'cond': true })[key];
+        const condResult = importCond('cond', './cond-a', './cond-b');
+
+        result([condResult]);
+
+      package.json:
+        {
+            "@atlaspack/bundler-default": {
+                "minBundleSize": 0
+            },
+            "@atlaspack/packager-js": {
+              "unstable_asyncBundleRuntime": true
+            },
+            "@atlaspack/packager-html": {
+              "evaluateRootConditionalBundles": true
+            }
+        }
+      yarn.lock:`;
+
+    let b = await bundle(
+      [
+        path.join(__dirname, 'import-cond-async-bundle-runtime/cond-a.html'),
+        path.join(__dirname, 'import-cond-async-bundle-runtime/index.html'),
+      ],
+      {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+          shouldOptimize: false,
+          outputFormat: 'esmodule',
+        },
+        featureFlags: {conditionalBundlingApi: true},
+        inputFS: overlayFS,
+      },
+    );
+
+    let indexBundle = b
+      .getBundles()
+      .find((b) => /index.*\.js/.test(b.filePath));
+    if (!indexBundle) return assert.fail();
+
+    let contents = await overlayFS.readFile(indexBundle.filePath, 'utf8');
+    assert(contents.includes('$parcel$global.rwr('));
+
+    let indexHtmlBundle = nullthrows(
+      b.getBundles().find((b) => /index.*\.html/.test(b.filePath)),
+    );
+    let result;
+    await runBundle(b, indexHtmlBundle, {
+      result: (r) => {
+        result = r;
+      },
+    });
+
+    assert.deepEqual(await result, ['cond-a']);
   });
 });

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1644,10 +1644,11 @@ export interface BundleGraph<TBundle: Bundle> {
   /** Returns the common root directory for the entry assets of a target. */
   getEntryRoot(target: Target): FilePath;
   getConditionalBundleMapping(): Map<
-    TBundle,
+    string,
     Map<
       string,
       {|
+        bundle: TBundle,
         ifTrueBundles: Array<TBundle>,
         ifFalseBundles: Array<TBundle>,
       |},

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -24,5 +24,8 @@
     "@types/react-dom": "^17.0.2",
     "express": "*"
   },
-  "type": "commonjs"
+  "type": "commonjs",
+  "@atlaspack/packager-js": {
+    "unstable_asyncBundleRuntime": true
+  }
 }

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -28,20 +28,20 @@ async function report({
       bundles.map((bundle) => relative(bundle.target.distDir, bundle.filePath));
 
     const manifest = {};
-    for (const [bundle, conditions] of bundles.entries()) {
+    for (const conditions of bundles.values()) {
       const bundleInfo = {};
       for (const [key, cond] of conditions) {
+        const bundle = cond.bundle;
         bundleInfo[key] = {
           // Reverse bundles so we load children bundles first
           ifTrueBundles: mapBundles(cond.ifTrueBundles).reverse(),
           ifFalseBundles: mapBundles(cond.ifFalseBundles).reverse(),
         };
+        manifest[bundle.target.name] ??= {};
+        manifest[bundle.target.name][
+          relative(bundle.target.distDir, bundle.filePath)
+        ] = bundleInfo;
       }
-
-      manifest[bundle.target.name] ??= {};
-      manifest[bundle.target.name][
-        relative(bundle.target.distDir, bundle.filePath)
-      ] = bundleInfo;
     }
 
     const targets = new Set(


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

One thing that was missed when implementing conditional bundling, was the unstable async runtime in use in Jira. If we get a race condition, async bundles may load too late.

## Changes

This change adds support for conditional bundles into the async runtime, by making sure the runtime is added for additional bundles.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
