### PR TITLE
Add changesets action

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -16,7 +16,5 @@ jobs:
     secrets: inherit
     with:
       profile: canary
-      release-command: |
-        yarn canary:release
-        yarn changeset publish
+      release-command: yarn canary:release
       type: canary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,3 +236,44 @@ jobs:
               ref: 'refs/tags/${{ steps.canary-version.outputs.VERSION_TAG }}'.trim(),
               sha: context.sha
             })
+
+  build-and-release-changesets:
+    name: Build and release Changesets
+    needs:
+      - build-linux-gnu-arm
+      - build-linux-gnu-x64
+      - build-macos
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: bahmutov/npm-install@v1.8.35
+      - name: Build native packages
+        run: yarn build-native-release
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+      - name: Move bindings
+        run: for d in artifacts/bindings-*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
+      - name: Move debug symbols
+        if: ${{ inputs.profile == 'canary' }}
+        run: |
+          mkdir debug-symbols
+          find artifacts -name "*.debug" -exec cp {} debug-symbols/ \;
+          find artifacts -name "*.node" -path "**/DWARF/**" -exec cp {} debug-symbols/ \;
+          ls -l debug-symbols
+      - name: Upload combined debug symbols artifact
+        uses: actions/upload-artifact@v4
+        if: ${{ inputs.profile == 'canary' }}
+        with:
+          name: debug-symbols
+          path: debug-symbols/**
+      - uses: changesets/action@v1
+        with:
+          publish: yarn changeset publish
+          version: yarn changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,7 +258,6 @@ jobs:
       - name: Move bindings
         run: for d in artifacts/bindings-*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
       - name: Move debug symbols
-        if: ${{ inputs.profile == 'canary' }}
         run: |
           mkdir debug-symbols
           find artifacts -name "*.debug" -exec cp {} debug-symbols/ \;
@@ -266,7 +265,6 @@ jobs:
           ls -l debug-symbols
       - name: Upload combined debug symbols artifact
         uses: actions/upload-artifact@v4
-        if: ${{ inputs.profile == 'canary' }}
         with:
           name: debug-symbols
           path: debug-symbols/**


### PR DESCRIPTION
## Motivation

In order to get Changesets to actually do our publishing, we need to add it as our release step. For Changesets, this comes in two parts, versioning and publishing. Luckily for us, the Changesets action takes care of both of these.

## Changes

I've separated the canary and release steps. Once Changesets is all working and confirmed, we'll turn off canaries entirely. For ad hoc branches that need testing, I'll also add Snapshots.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating github actions
