### PR TITLE
Fix changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,17 +257,6 @@ jobs:
           path: artifacts
       - name: Move bindings
         run: for d in artifacts/bindings-*/*/*; do cp $d/*.node packages/$(basename $(dirname $d))/$(basename $d); done
-      - name: Move debug symbols
-        run: |
-          mkdir debug-symbols
-          find artifacts -name "*.debug" -exec cp {} debug-symbols/ \;
-          find artifacts -name "*.node" -path "**/DWARF/**" -exec cp {} debug-symbols/ \;
-          ls -l debug-symbols
-      - name: Upload combined debug symbols artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: debug-symbols
-          path: debug-symbols/**
       - uses: changesets/action@v1
         with:
           publish: yarn changeset publish

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 *.min.js
 *.tsbuildinfo
 *.wasm
+
+artifacts/
+debug-symbols/


### PR DESCRIPTION
## Motivation

Turns out that because Changesets needs to make commits, and the debug files are not ignored, it ends up trying to accidentally add some monstrous files to the repo.

It was also breaking canary releases, because they were both attempting to upload an artifact with the same name.

## Changes

To fix this, I've added the artifacts directories to .gitignore, so that Changesets won't try to include them, and taken the debug symbols step out of Changesets for now. We can reintroduce it once canaries are gone.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating github action
