### PR TITLE
Add write permisions to the changesets step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,7 @@ jobs:
 
   build-and-release-changesets:
     name: Build and release Changesets
+    permissions: write-all
     needs:
       - build-linux-gnu-arm
       - build-linux-gnu-x64


### PR DESCRIPTION
## Motivation

The changesets step failed because it seems the action doesn't have permission to create a PR.

## Changes

To check this is the problem, I've added `write-all` permissions to the step. If that works, I'll come back and revise it down to something more granular

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating github action
