### PR TITLE
Strip comments on SWC optimizer

### DIFF
--- a/.changeset/breezy-nails-sip.md
+++ b/.changeset/breezy-nails-sip.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/rust': patch
+'@atlaspack/optimizer-inline-requires': patch
+---
+
+Strip comments on optimizer

--- a/crates/atlaspack_swc_runner/src/runner.rs
+++ b/crates/atlaspack_swc_runner/src/runner.rs
@@ -1,5 +1,4 @@
 use std::string::FromUtf8Error;
-use swc_core::common::comments::SingleThreadedComments;
 use swc_core::common::input::StringInput;
 use swc_core::common::sync::Lrc;
 use swc_core::common::util::take::Take;
@@ -113,13 +112,12 @@ fn run_with_transformation<R>(
 ) -> Result<RunWithTransformationOutput<R>, RunWithTransformationError> {
   let source_map = Lrc::new(SourceMap::default());
   let source_file = source_map.new_source_file(Lrc::new(FileName::Anon), code.into());
-  let comments = SingleThreadedComments::default();
 
   let lexer = Lexer::new(
     Default::default(),
     Default::default(),
     StringInput::from(&*source_file),
-    Some(&comments),
+    None,
   );
 
   let mut parser = Parser::new_from(lexer);
@@ -166,7 +164,7 @@ fn run_with_transformation<R>(
       let mut emitter = swc_core::ecma::codegen::Emitter {
         cfg: Config::default(),
         cm: source_map.clone(),
-        comments: Some(&comments),
+        comments: None,
         wr: writer,
       };
 


### PR DESCRIPTION
This code is used in the inline requires optimizer.

Keeping comments seems to trigger some bug in SWC which produces invalid code.

In particular code such as:
```
255 / /* PURE */ e(...)
```

Ends up being outputted as:
```
255 //* PURE */ e(...)
```

This ends-up producing invalid bundles due to syntax errors.

A change made in #407, added comment support to the inline requires optimizer,
which triggered this bug.

Test Plan: integration tests reproducing the error will be added to this diff
