### PR TITLE
Disable peer deps causing majors

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,6 +10,9 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  },
   "ignore": [
     "caniuse-database",
     "lmdb-js-lite",


### PR DESCRIPTION
## Motivation

By default, Changesets will apply a major bump to a package if it needs to update the peer dependencies. Especially in a monorepo environment, this means we can end up with major releases very frequently on even patch changes to other packages in the repo.

## Changes

The fix here is to enable the Changesets option to only update a peer dependency if the new version of the dependent package is out of range. When using `^` ranges, this means we only bump a major if the dependent package gets a major bump.

I think this should really be Changesets' default behaviour to be honest, and I've always enabled it on previous projects that have used it.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating changeset config only
