### PR TITLE
Be more permissive about yarn.lock files missing

### DIFF
--- a/.changeset/clever-needles-argue.md
+++ b/.changeset/clever-needles-argue.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/fs': patch
+'@atlaspack/rust': patch
+---
+
+Allow missing .yarn-state.yml files without throwing on VCS file change reads


### PR DESCRIPTION
Sometimes files are included in git ls-files' output but can't be read.

Test Plan: yarn test:integration
