### PR TITLE
Add multi-arch Node.js docker image

### DIFF
--- a/.github/workflows/build-smoke-test-images.yml
+++ b/.github/workflows/build-smoke-test-images.yml
@@ -1,0 +1,52 @@
+name: Build Smoke Test Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      node_version:
+        description: 'Node.js version to build'
+        required: true
+        default: '18'
+        type: choice
+        options:
+          - '18'
+          - '20'
+          - '22'
+  schedule:
+    # Run weekly on Sunday at 00:00 UTC
+    - cron: '0 0 * * 0'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: docker/multiarch-node
+          platforms: linux/arm/v7,linux/arm64
+          push: true
+          build-args: |
+            NODE_VERSION=${{ github.event.inputs.node_version || '18' }}
+          tags: |
+            ghcr.io/${{ github.repository }}/multiarch-node:node${{ github.event.inputs.node_version || '18' }}

--- a/docker/multiarch-node/Dockerfile
+++ b/docker/multiarch-node/Dockerfile
@@ -4,16 +4,16 @@
 #
 ###############################################################################
 #
+FROM --platform=$BUILDPLATFORM ubuntu:22.04
+
+RUN apt-get update && apt-get -y upgrade && apt-get -y autoremove && apt-get -y clean && apt-get -f -y install build-essential wget pkg-config curl sudo
+
 # Specify Node.js version with:
 #
 #    --build-arg NODE_VERSION=22
 #
 # Valid values: 18, 20, 22
 ARG NODE_VERSION=18
-
-FROM --platform=$BUILDPLATFORM ubuntu:22.04
-
-RUN apt-get update && apt-get -y upgrade && apt-get -y autoremove && apt-get -y clean && apt-get -f -y install build-essential wget pkg-config curl sudo
-
-RUN echo "NODE_VERSION=${NODE_VERSION}"
-RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && apt-get -y install nodejs node-gyp git
+RUN curl -sL https://deb.nodesource.com/setup_$NODE_VERSION.x | sudo -E bash -
+RUN apt-get install -y nodejs
+RUN apt-get install -y git

--- a/docker/multiarch-node/Dockerfile
+++ b/docker/multiarch-node/Dockerfile
@@ -1,0 +1,19 @@
+# Build with:
+#
+#     docker buildx build --platform linux/arm/v7,linux/arm64 -t your-image-name ./docker/multiarch-node/
+#
+###############################################################################
+#
+# Specify Node.js version with:
+#
+#    --build-arg NODE_VERSION=22
+#
+# Valid values: 18, 20, 22
+ARG NODE_VERSION=18
+
+FROM --platform=$BUILDPLATFORM ubuntu:22.04
+
+RUN apt-get update && apt-get -y upgrade && apt-get -y autoremove && apt-get -y clean && apt-get -f -y install build-essential wget pkg-config curl sudo
+
+RUN echo "NODE_VERSION=${NODE_VERSION}"
+RUN curl -sL https://deb.nodesource.com/setup_${NODE_VERSION}.x | sudo -E bash - && apt-get -y install nodejs node-gyp git

--- a/docker/multiarch-node/README.md
+++ b/docker/multiarch-node/README.md
@@ -1,0 +1,3 @@
+Multi-arch Node.js Docker image to smoke test native bindings.
+
+Based on https://github.com/multiarch/ubuntu-core


### PR DESCRIPTION
Built on ubuntu 22.04.

We have smoke tests for `armhf` and `arm64` which run on a docker image. This docker image is using an older version of GLIBC, which is incompatible with the version on `22.04`. Ubuntu `20.04` runners aren't working anymore, so the build runners will be upgraded to `22.04`.

This diff will add a build for docker images with Node.js for those architectures, based on ubuntu 22.04. We will then update the smoke test workflow to use these. I need to merge to be able to run the workflow.

Test Plan: N/A

[no-changeset]: Adding docker images for smoke testing
