### PR TITLE
Update build script to avoid double builds for napi projects

### DIFF
--- a/packages/core/rust/package.json
+++ b/packages/core/rust/package.json
@@ -12,7 +12,8 @@
   "main": "index.js",
   "browser": "browser.js",
   "napi": {
-    "name": "atlaspack-node-bindings"
+    "name": "atlaspack-node-bindings",
+    "permittedTargets": "*"
   },
   "engines": {
     "node": ">= 16.0.0"

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -21,11 +21,12 @@ const defaultTarget = {
 }[`${process.platform}-${process.arch}`];
 
 const rustTarget = RUSTUP_TARGET || defaultTarget;
+const rustProfile = CARGO_PROFILE || 'debug';
 
 const cargoCommand = ['cargo', 'build', '--target', rustTarget];
 
-if (CARGO_PROFILE && CARGO_PROFILE !== 'debug') {
-  cargoCommand.push('--profile', CARGO_PROFILE);
+if (rustProfile !== 'debug') {
+  cargoCommand.push('--profile', rustProfile);
 }
 
 // eslint-disable-next-line no-console
@@ -36,46 +37,150 @@ child_process.execSync(cargoCommand.join(' '), {stdio: 'inherit', cwd: __root});
 const {workspaces} = JSON.parse(
   fs.readFileSync(path.join(__root, 'package.json'), 'utf8'),
 );
+
 for (const workspace of workspaces) {
-  for (const pkg of glob.sync(`${workspace}/package.json`, {cwd: __root})) {
-    let pkgPath = path.join(__root, pkg);
-    let pkgDir = path.dirname(pkgPath);
-    const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+  for (const pkg of glob.sync(workspace, {cwd: __root})) {
+    buildNapiLibrary(path.join(__root, pkg));
+  }
+}
 
-    // NAPI: Generate types and copy binaries for napi packages
-    if (pkgJson.napi && !pkgJson.napi.skip) {
-      const command = [];
+/*
+  This script enables workspace support for @napi-rs/cli.
 
-      if (rustTarget === 'wasm32-unknown-unknown') {
-        // Not supported
-        // "wasm:build": "cargo build -p atlaspack-node-bindings --target wasm32-unknown-unknown && cp ../../../target/wasm32-unknown-unknown/debug/atlaspack_node_bindings.wasm .",
-        // "wasm:build-release": "CARGO_PROFILE_RELEASE_LTO=true cargo build -p atlaspack-node-bindings --target wasm32-unknown-unknown --release && wasm-opt --strip-debug -O ../../../target/wasm32-unknown-unknown/release/atlaspack_node_bindings.wasm -o atlaspack_node_bindings.wasm"
-      } else {
-        command.push(
-          'npx',
-          'napi',
-          'build',
-          '--platform',
-          '--target',
-          rustTarget,
-        );
-      }
+  napi-rs expects there to be one package and no workspace, the "napi build"
+  command will trigger a "cargo build" which generates the
+  respective dynamic libraries in
 
-      if (CARGO_PROFILE && CARGO_PROFILE !== 'debug') {
-        command.push('--profile', CARGO_PROFILE);
-      }
+  `~/target/<target>/<profile>/libname.(so|dylib|dll)
 
-      command.push(
-        '--cargo-cwd',
-        path.relative(pkgDir, path.join(__root, 'crates', 'node-bindings')),
-      );
+  napi-rs then reads the cargo build manifest and copies the dynamic library
 
-      // eslint-disable-next-line no-console
-      console.log(pkgJson.name, command.join(' '));
-      child_process.execSync(command.join(' '), {
-        stdio: 'inherit',
-        cwd: pkgDir,
-      });
+  from ~/target/../libname.(so|dylib|dll)
+  to   ~/packages/package-name/libname.node
+
+  then generate TypeScript types and an index.js file
+
+  If you have already run "cargo build" before running "napi build",
+  "napi build" will reuse the existing artifacts (it will still run
+  a "cargo build" but the output will be cached/instant).
+
+  To make this work in workspaces, this script will search through the workspace
+  packages, where packages that contain a "package.json@napi" key will have
+  "napi build" run for them with the correct cwd specified.
+
+  USAGE:
+
+  To include napi artifacts in a package the package needs to define the following
+  in the package.json
+
+  ```json
+  {
+    "napi": {
+      // "name" in the Cargo.toml
+      "name": "cargo_package_name",
+
+      // This key defines cargo targets that
+      // are permitted to be copied into the package.
+      // This is used for packages dedicated to an os/arch
+      "permittedTargets": [
+        "x86_64-unknown-linux-gnu",
+        "aarch64-unknown-linux-gnu",
+        "*"                           // can specify any
+                                      // target with wildcard
+      ],
+
+      // Optional: if the package only exports one .node file
+      // this will overwrite the index file to simplify it so
+      // it only reexports the one .node file
+      "overwriteIndex": false
+
+      // Optional: skip build for package
+      "skip": false
     }
   }
+  ```
+*/
+function buildNapiLibrary(pkgDir) {
+  let pkgJsonPath = path.join(pkgDir, 'package.json');
+  if (!fs.existsSync(pkgJsonPath)) return;
+
+  const pkgJson = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+
+  // NAPI: Generate types and copy binaries for napi packages
+  if (pkgJson.napi && pkgJson.napi.skip) return;
+  if (!arrayOrStringHas(pkgJson.napi?.permittedTargets, rustTarget)) return;
+
+  if (rustTarget === 'wasm32-unknown-unknown') {
+    // "wasm:build":
+    //   cargo build -p atlaspack-node-bindings --target wasm32-unknown-unknown
+    //   cp ../../../target/wasm32-unknown-unknown/debug/atlaspack_node_bindings.wasm .
+    // "wasm:build-release":
+    //    "CARGO_PROFILE_RELEASE_LTO=true cargo build -p atlaspack-node-bindings --target wasm32-unknown-unknown --release
+    //    wasm-opt --strip-debug -O ../../../target/wasm32-unknown-unknown/release/atlaspack_node_bindings.wasm -o atlaspack_node_bindings.wasm"
+    console.error('Not supported');
+    process.exit(1);
+  }
+
+  const command = [];
+
+  command.push(
+    'npx',
+    'napi',
+    'build',
+    '--platform', // Tell napi to build types and index.js
+    '--target',
+    rustTarget,
+  );
+
+  if (rustProfile !== 'debug') {
+    command.push('--profile', rustProfile);
+  }
+
+  command.push('--cargo-name', pkgJson.napi.name.replaceAll('-', '_'));
+  command.push(path.relative(__root, pkgDir));
+
+  console.log(pkgJson.name, command.join(' '));
+
+  // npx napi build must be run from the workspace root
+  // to avoid cargo doing a complete build
+
+  // Reference
+  // npx napi build --platform --target {} --profile {} --cargo-name {Cargo.toml#name} {./path/to/package}
+  child_process.execSync(command.join(' '), {
+    stdio: 'inherit',
+    cwd: __root,
+  });
+
+  // If the package is exporting a single .node binary then
+  // overwrite the index.js to export only that binary
+  // This is for @atlaspack/pkg-{platform}-{arch} packages
+  if (pkgJson.napi.overwriteIndex) {
+    for (const file of fs.readdirSync(pkgDir)) {
+      if (!file.endsWith('.node')) {
+        continue;
+      }
+      fs.writeFileSync(
+        path.join(pkgDir, 'index.js'),
+        `module.exports = require('./${file}');\n`,
+        'utf8',
+      );
+      break;
+    }
+  }
+}
+
+function arrayOrStringHas(target, contains) {
+  if (!target) {
+    return false;
+  }
+  if (
+    Array.isArray(target) &&
+    (target.includes(contains) || target.includes('*'))
+  ) {
+    return true;
+  }
+  if (typeof target === 'string' && (target === contains || target === '*')) {
+    return true;
+  }
+  return false;
 }


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Build script will do a double build for napi projects because `@napi-rs/ci` does some stuff internally that triggers it

## Changes

- Update native build script to run the `napi build` command from the project root 
- Update native build script so it only runs if the package declares `package.json#napi.targets`
  - Will use this to split napi builds into separate packages

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: updating build script
