### PR TITLE
Only run the changesets job on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,7 +243,7 @@ jobs:
 
   build-and-release-changesets:
     name: Build and release Changesets
-    if: github.ref_name === 'main'
+    if: github.ref_name == 'main'
     permissions: write-all
     needs:
       - build-linux-gnu-arm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,7 @@ jobs:
 
   build-and-release-changesets:
     name: Build and release Changesets
+    if: github.ref_name === 'main'
     permissions: write-all
     needs:
       - build-linux-gnu-arm


### PR DESCRIPTION
## Motivation

There are a bunch of version packages PRs being opened on weird branches, which it turns out is triggered by running a dev release with the manual `workflow_dispatch` step. We don't want changesets to step in here, so I'm preventing it from running unless we're on `main`

## Changes

Add a simple conditional check to the job to make sure the branch is main

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating workflow file
