### PR TITLE
Add worker thread hack

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -63,6 +63,9 @@ import {AtlaspackV3, FileSystemV3} from './atlaspack-v3';
 import createAssetGraphRequestJS from './requests/AssetGraphRequest';
 import {createAssetGraphRequestRust} from './requests/AssetGraphRequestRust';
 import type {AssetGraphRequestResult} from './requests/AssetGraphRequest';
+import {loadRustWorkerThreadDylibHack} from './rustWorkerThreadDylibHack';
+
+loadRustWorkerThreadDylibHack();
 
 registerCoreWithSerializer();
 

--- a/packages/core/core/src/rustWorkerThreadDylibHack.js
+++ b/packages/core/core/src/rustWorkerThreadDylibHack.js
@@ -1,0 +1,18 @@
+// @flow strict-local
+
+/**
+ * This is a workaround for https://github.com/rust-lang/rust/issues/91979
+ * when running atlaspack with parcel bindings, it is possible that the parcel
+ * dylib will be loaded from a node worker thread, which causes a crash on exit.
+ *
+ * This is a workaround to ensure that the parcel dylib is loaded in the main
+ * thread, which fixes the crash.
+ */
+export function loadRustWorkerThreadDylibHack() {
+  try {
+    // $FlowFixMe
+    require('@parcel/rust'); // eslint-disable-line
+  } catch (err) {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
This adds a work-around to `rust#91979` (https://github.com/rust-lang/rust/issues/91979)

A segmentation fault is currently triggered on worker thread exit if:

* Application runs with `atlaspack` on the main thread
* Plugin on worker-thread imports `parcel/rust`

The work-around is to force parcel native bindings to be loaded eagerly if
available.

Test Plan: test dev release
