### PR TITLE
Don't include the feature flags package in the included node_modules for utils

### DIFF
--- a/.changeset/good-fishes-reflect.md
+++ b/.changeset/good-fishes-reflect.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/utils': patch
+---
+
+No longer bundles `@atlaspack/feature-flags` into the source, so it will work from the same feature flag state as the rest of the repo.
+
+Previously, this was preventing us from using feature flags inside the utils package, as it was impossible to set them.

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -19,6 +19,7 @@
     "main": {
       "includeNodeModules": {
         "@atlaspack/codeframe": false,
+        "@atlaspack/feature-flags": false,
         "@atlaspack/diagnostic": false,
         "@atlaspack/rust": false,
         "@atlaspack/logger": false,
@@ -31,6 +32,7 @@
   "dependencies": {
     "@atlaspack/codeframe": "2.13.2",
     "@atlaspack/diagnostic": "2.14.0",
+    "@atlaspack/feature-flags": "2.14.0",
     "@atlaspack/logger": "2.14.0",
     "@atlaspack/markdown-ansi": "2.14.0",
     "@atlaspack/rust": "3.0.0",


### PR DESCRIPTION
## Motivation

The inline string replacement perf change didn't end up having the effect we wanted, but it turns out that's because it never got activated.

The build for utils bundles its node_modules into the final output, so feature-flags just needed to be added to the list of dependencies not to bundle.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

