### PR TITLE
Disable hanging V3 test

### DIFF
--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -59,28 +59,31 @@ describe('watcher', function () {
     assert.equal(output, 'something else');
   });
 
-  it('should rebuild on a source file change after a failed transformation', async () => {
-    await outputFS.mkdirp(inputDir);
-    await outputFS.writeFile(
-      path.join(inputDir, '/index.js'),
-      'syntax\\error',
-      {encoding: 'utf8'},
-    );
-    let b = bundler(path.join(inputDir, '/index.js'), {inputFS: overlayFS});
-    subscription = await b.watch();
-    let buildEvent = await getNextBuild(b);
-    assert.equal(buildEvent.type, 'buildFailure');
-    await outputFS.writeFile(
-      path.join(inputDir, '/index.js'),
-      'module.exports = "hello"',
-      {encoding: 'utf8'},
-    );
-    buildEvent = await getNextBuild(b);
-    if (!buildEvent.bundleGraph) return assert.fail();
-    let output = await run(buildEvent.bundleGraph);
+  it.v2(
+    'should rebuild on a source file change after a failed transformation',
+    async () => {
+      await outputFS.mkdirp(inputDir);
+      await outputFS.writeFile(
+        path.join(inputDir, '/index.js'),
+        'syntax\\error',
+        {encoding: 'utf8'},
+      );
+      let b = bundler(path.join(inputDir, '/index.js'), {inputFS: overlayFS});
+      subscription = await b.watch();
+      let buildEvent = await getNextBuild(b);
+      assert.equal(buildEvent.type, 'buildFailure');
+      await outputFS.writeFile(
+        path.join(inputDir, '/index.js'),
+        'module.exports = "hello"',
+        {encoding: 'utf8'},
+      );
+      buildEvent = await getNextBuild(b);
+      if (!buildEvent.bundleGraph) return assert.fail();
+      let output = await run(buildEvent.bundleGraph);
 
-    assert.equal(output, 'hello');
-  });
+      assert.equal(output, 'hello');
+    },
+  );
 
   it.v2('should rebuild on a config file change', async function () {
     let inDir = path.join(__dirname, 'integration/parcelrc-custom');
@@ -114,37 +117,43 @@ describe('watcher', function () {
     assert(distFile.includes('TRANSFORMED CODE'));
   });
 
-  it('should rebuild properly when a dependency is removed', async function () {
-    await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
+  it.v2(
+    'should rebuild properly when a dependency is removed',
+    async function () {
+      await ncp(path.join(__dirname, 'integration/babel-default'), inputDir);
 
-    let b = bundler(path.join(inputDir, 'index.js'), {
-      inputFS: overlayFS,
-      targets: {
-        main: {
-          engines: {
-            node: '^8.0.0',
+      let b = bundler(path.join(inputDir, 'index.js'), {
+        inputFS: overlayFS,
+        targets: {
+          main: {
+            engines: {
+              node: '^8.0.0',
+            },
+            distDir,
           },
-          distDir,
         },
-      },
-    });
+      });
 
-    subscription = await b.watch();
-    let buildEvent = await getNextBuild(b);
-    assert.equal(buildEvent.type, 'buildSuccess');
-    let distFile = await outputFS.readFile(
-      path.join(distDir, 'index.js'),
-      'utf8',
-    );
-    assert(distFile.includes('Foo'));
-    await outputFS.writeFile(
-      path.join(inputDir, 'index.js'),
-      'console.log("no more dependencies")',
-    );
-    await getNextBuild(b);
-    distFile = await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8');
-    assert(!distFile.includes('Foo'));
-  });
+      subscription = await b.watch();
+      let buildEvent = await getNextBuild(b);
+      assert.equal(buildEvent.type, 'buildSuccess');
+      let distFile = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(distFile.includes('Foo'));
+      await outputFS.writeFile(
+        path.join(inputDir, 'index.js'),
+        'console.log("no more dependencies")',
+      );
+      await getNextBuild(b);
+      distFile = await outputFS.readFile(
+        path.join(distDir, 'index.js'),
+        'utf8',
+      );
+      assert(!distFile.includes('Foo'));
+    },
+  );
 
   it.skip('should re-generate bundle tree when files change', async function () {
     await ncp(path.join(__dirname, '/integration/dynamic-hoist'), inputDir);


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This test seems to be hanging the Mac V3 test suite and has gotten worse lately. This PR temporarily disables it.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Test change
