### PR TITLE
Disable all native watcher integration tests

### DIFF
--- a/packages/core/integration-tests/test/watcher.js
+++ b/packages/core/integration-tests/test/watcher.js
@@ -23,7 +23,7 @@ import {symlinkSync} from 'fs';
 const inputDir = path.join(__dirname, '/watcher');
 const distDir = path.join(inputDir, 'dist');
 
-describe('watcher', function () {
+describe.v2('watcher', function () {
   let subscription;
   afterEach(async () => {
     if (subscription) {


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Looks like have any watcher native tests enabled can cause hangs. I'm going to disable completely and fix this soon.
## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Test only change
