### PR TITLE
Fix the prepublish script for bin packages (apvm)

### DIFF
--- a/scripts/prepare-os-arch-package.mjs
+++ b/scripts/prepare-os-arch-package.mjs
@@ -17,7 +17,6 @@ if (!fs.existsSync(packageJsonPath)) {
 
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'))
 
-
 const [,platform, arch] = packageJson.name.split('/')[1].split('-')
 if (!platform || !arch) {
   // eslint-disable-next-line no-console
@@ -46,6 +45,5 @@ if (!nodeArch || !nodePlatform) {
 
 packageJson.os = [nodePlatform]
 packageJson.cpu = [nodeArch]
-packageJson.scripts = undefined
 
 fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2), 'utf8')


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Pipeline is not able to publish with error:
```
Cannot read properties of undefined (reading 'prepack')
```

## Changes

The `prepack` and `prepublish` scripts are both run by lerna. The script originally mutated the `package.json#scripts` to remove the `prepack` and `prepublish` scripts after being run once - however that breaks the script if it's run a second times.

This PR changes the prepublish script so it doesn't remove the package.json scripts allowing it to be called multiple times.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Updating pipeline
