### PR TITLE
Add env variable to skip cache invalidation

### DIFF
--- a/.changeset/nervous-singers-tickle.md
+++ b/.changeset/nervous-singers-tickle.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': minor
+---
+
+Add environment variable to skip cache invalidation

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1697,11 +1697,14 @@ async function loadRequestGraph(options): Async<RequestGraph> {
         });
       }, 5000);
       let startTime = Date.now();
-      let events = await options.inputFS.getEventsSince(
-        options.watchDir,
-        snapshotPath,
-        opts,
-      );
+      let events =
+        process.env.ATLASPACK_BYPASS_CACHE_INVALIDATION === 'true'
+          ? []
+          : await options.inputFS.getEventsSince(
+              options.watchDir,
+              snapshotPath,
+              opts,
+            );
       clearTimeout(timeout);
 
       logger.verbose({


### PR DESCRIPTION
On certain scenarios the cache is known to be up-to-date, such as starting-up
an instance from a snapshot which has a working cache.

On such scenarios, querying either `watchman` or vcs is also relatively
expensive, because the machine's data might still be in the process of being
initialized.

This diff adds an environment variable to skip cache invalidation completely.

Test Plan: N/A
