### PR TITLE
Only store rust-cache on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,10 @@ jobs:
       - name: Install Rust
         uses: ./.github/actions/rust-toolchain
       - uses: Swatinem/rust-cache@v2
-        with: {shared-key: '${{ matrix.target }}'}
+        with:
+          shared-key: '${{ matrix.target }}'
+          # Only store new caches on main
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v4
         with: {cache: yarn}
       # Yarn install is required for @napi-rs/cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,10 @@ jobs:
           node-version: 22
       - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.type != 'latest' }}
-        with: {shared-key: '${{ matrix.name }}'}
+        with:
+          shared-key: '${{ matrix.name }}'
+          # Only store new caches on main
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: yarn install --frozen-lockfile
       - name: Build native packages
         env:


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

I noticed that most of our native compile steps are not getting a cache hit and therefore running for around 10 minutes when it's closer to [3 mins](https://github.com/atlassian-labs/atlaspack/actions/runs/14828609067/job/41625622751?pr=490) with a cache hit. I believe this is mostly due to the 10GB github action cache limit evicting our caches. 

According to the [rust-cache docs](https://github.com/Swatinem/rust-cache) 
> Caches from base branches are available to PRs, but not across unrelated branches.

Therefore I think it's more efficient to just re-use the cache generated from main on all PRs. 

## Changes

Only save the rust-cache in CI from the main branch, running in restore-only mode for PRs. 

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: CI only change
