### PR TITLE
Support atlaspack ignore comments for node replacements

### DIFF
--- a/.changeset/chilled-vans-fly.md
+++ b/.changeset/chilled-vans-fly.md
@@ -1,0 +1,12 @@
+---
+'@atlaspack/transformer-js': minor
+'@atlaspack/rust': minor
+---
+
+Support ignore comments for node replacements
+
+Adding `#__ATLASPACK_IGNORE__` before `__filename` and `__dirname` will now disable the default node replacement behaviour of these variables. This is useful when you want your compiled output to be aware of it's runtime directory rather than it's pre-compiled source directory.
+
+```js
+const dirname = /*#__ATLASPACK_IGNORE__*/ __dirname;
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -306,6 +306,7 @@ dependencies = [
  "parking_lot",
  "path-slash",
  "pathdiff",
+ "pretty_assertions",
  "regex",
  "serde",
  "serde_bytes",

--- a/crates/atlaspack_swc_runner/src/runner.rs
+++ b/crates/atlaspack_swc_runner/src/runner.rs
@@ -1,4 +1,5 @@
 use std::string::FromUtf8Error;
+use swc_core::common::comments::SingleThreadedComments;
 use swc_core::common::input::StringInput;
 use swc_core::common::sync::Lrc;
 use swc_core::common::util::take::Take;
@@ -20,6 +21,8 @@ pub struct RunContext {
   pub global_mark: Mark,
   /// Unresolved mark from SWC resolver
   pub unresolved_mark: Mark,
+  /// Parsed comments from the file
+  pub comments: SingleThreadedComments,
 }
 
 pub struct RunVisitResult<V> {
@@ -113,11 +116,12 @@ fn run_with_transformation<R>(
   let source_map = Lrc::new(SourceMap::default());
   let source_file = source_map.new_source_file(Lrc::new(FileName::Anon), code.into());
 
+  let comments = SingleThreadedComments::default();
   let lexer = Lexer::new(
     Default::default(),
     Default::default(),
     StringInput::from(&*source_file),
-    None,
+    Some(&comments),
   );
 
   let mut parser = Parser::new_from(lexer);
@@ -148,6 +152,7 @@ fn run_with_transformation<R>(
         source_map: source_map.clone(),
         global_mark,
         unresolved_mark,
+        comments: comments.clone(),
       };
 
       let result = transform(context, &mut module);

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -26,7 +26,7 @@ swc_core = { workspace = true, features = [
   "ecma_utils",
   "ecma_visit",
   "ecma_quote",
-  "stacker"
+  "stacker",
 ] }
 
 sourcemap = { workspace = true }
@@ -46,6 +46,7 @@ atlaspack_core = { path = "../../../../crates/atlaspack_core" }
 atlaspack_contextual_imports = { path = "../../../../crates/atlaspack_contextual_imports" }
 atlaspack_swc_runner = { path = "../../../../crates/atlaspack_swc_runner" }
 parking_lot = { workspace = true }
+pretty_assertions = { workspace = true }
 regex = { workspace = true }
 anyhow = { workspace = true }
 tracing = { workspace = true }
@@ -53,3 +54,4 @@ tracing-test = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -438,6 +438,7 @@ pub fn transform(
                     filename: Path::new(&config.filename),
                     unresolved_mark,
                     has_node_replacements: &mut result.has_node_replacements,
+                    comments: comments.clone(),
                   },
                   config.node_replacer,
                 ),


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

When working on the super build, I needed to disable the automatic node replacements of `__filename` and `__dirname` in multiple places. To support this I added a new special comment that can be placed before any references to those global globals which will bypass the replacement logic. The solution takse inspiration from [pure notation comments](https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md). 

In future, we could also potentially use this as a way to inline disable other compiler behaviours.

Example usage
```js
const dirname = /*#__ATLASPACK_IGNORE__*/ __dirname;
```

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
