### PR TITLE
Skip node_modules in debug symbols script

### DIFF
--- a/scripts/debug-symbols.mjs
+++ b/scripts/debug-symbols.mjs
@@ -8,7 +8,10 @@ import glob from 'glob';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const __root = path.dirname(__dirname);
 
-for (const foundRel of glob.sync('packages/**/*.node', {cwd: __root})) {
+for (const foundRel of glob.sync('packages/**/*.node', {
+  cwd: __root,
+  ignore: '**/node_modules/**',
+})) {
   const found = path.join(__root, foundRel);
   if (process.platform === 'linux') {
     console.log(`Stripping:     ${found}`);


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

In the context of the super build, debug symbols can be stripped from the `node_modules` of inner packages so this updates the debug symbols script to ignore inner `packages/**/*/node_modules`.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: updating build script
