### PR TITLE
Avoid duplicated file writes to disk in ConditionalManifestReporter

### DIFF
--- a/.changeset/brown-tomatoes-argue.md
+++ b/.changeset/brown-tomatoes-argue.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/reporter-conditional-manifest': patch
+'@atlaspack/feature-flags': patch
+---
+
+When conditionalBundlingReporterDuplicateFix is enabled, avoid duplicated writes to the descriptor and logging

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -23,6 +23,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   enableRustWorkerThreadDylibHack: true,
   inlineStringReplacementPerf: false,
   conditionalBundlingAsyncRuntime: false,
+  conditionalBundlingReporterDuplicateFix: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -71,6 +71,10 @@ export type FeatureFlags = {|
    * Enable support for the async bundle runtime (unstable_asyncBundleRuntime) in conditional bundling
    */
   conditionalBundlingAsyncRuntime: boolean,
+  /**
+   * Fix a bug where the conditional manifest reporter would report and write the same manifest multiple times
+   */
+  conditionalBundlingReporterDuplicateFix: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =

--- a/packages/reporters/conditional-manifest/package.json
+++ b/packages/reporters/conditional-manifest/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@atlaspack/plugin": "2.14.1",
+    "@atlaspack/feature-flags": "2.14.1",
     "nullthrows": "^1.1.1"
   },
   "type": "commonjs"

--- a/packages/reporters/conditional-manifest/test/ConditionalManifestReporter.test.js
+++ b/packages/reporters/conditional-manifest/test/ConditionalManifestReporter.test.js
@@ -1,0 +1,114 @@
+// @flow strict-local
+import {
+  manifestHashes,
+  updateManifest,
+} from '../src/ConditionalManifestReporter';
+import sinon from 'sinon';
+import assert from 'assert';
+
+let createMockOverlayFS = () => ({
+  // Mock filesystem methods
+  writeFile: sinon.stub(),
+  readFile: sinon.stub(),
+  exists: sinon.stub(),
+  chdir: sinon.stub(),
+  copyFile: sinon.stub(),
+  createReadStream: sinon.stub(),
+  createWriteStream: sinon.stub(),
+  cwd: sinon.stub(),
+  existsSync: sinon.stub(),
+  findAncestorFile: sinon.stub(),
+  findFirstFile: sinon.stub(),
+  findNodeModule: sinon.stub(),
+  getEventsSince: sinon.stub(),
+  mkdirp: sinon.stub(),
+  ncp: sinon.stub(),
+  readFileSync: sinon.stub(),
+  readdir: sinon.stub(),
+  readdirSync: sinon.stub(),
+  realpath: sinon.stub(),
+  realpathSync: sinon.stub(),
+  rimraf: sinon.stub(),
+  stat: sinon.stub(),
+  statSync: sinon.stub(),
+  symlink: sinon.stub(),
+  unlink: sinon.stub(),
+  watch: sinon.stub(),
+  writeSnapshot: sinon.stub(),
+});
+
+let createMockLogger = () => ({
+  // Mock logger methods
+  warn: sinon.stub(),
+  info: sinon.stub(),
+  verbose: sinon.stub(),
+  error: sinon.stub(),
+  log: sinon.stub(),
+});
+
+describe('ConditionalManifestReporter', function () {
+  beforeEach(() => {
+    manifestHashes.clear();
+  });
+
+  it('should write the manifest to file', async function () {
+    let logger = createMockLogger();
+    let overlayFS = createMockOverlayFS();
+
+    const conditionalManifestFilename =
+      '/project-root/dist/conditional-manifest.json';
+    const conditionalManifest = JSON.stringify({test: 'manifest'});
+
+    await updateManifest(
+      overlayFS,
+      logger,
+      conditionalManifestFilename,
+      conditionalManifest,
+    );
+
+    // Verify that writeFile was called with the correct arguments
+    assert(
+      overlayFS.writeFile.calledWith(
+        conditionalManifestFilename,
+        conditionalManifest,
+        {mode: 0o666},
+      ),
+    );
+
+    // Verify that logger.info was called with the correct message
+    assert(
+      logger.info.calledWith({
+        message: `Wrote conditional manifest to ${conditionalManifestFilename}`,
+      }),
+    );
+  });
+
+  it('should not write the manifest if it has not changed', async function () {
+    let logger = createMockLogger();
+    let overlayFS = createMockOverlayFS();
+
+    let conditionalManifestFilename =
+      '/project-root/dist/conditional-manifest.json';
+    let conditionalManifest = JSON.stringify({test: 'manifest'});
+
+    await updateManifest(
+      overlayFS,
+      logger,
+      conditionalManifestFilename,
+      conditionalManifest,
+    );
+
+    await updateManifest(
+      overlayFS,
+      logger,
+      conditionalManifestFilename,
+      conditionalManifest,
+    );
+
+    // Verify that writeFile was called once
+    assert(overlayFS.writeFile.calledOnce);
+
+    // Verify that logger.info was called with the correct message
+    assert(logger.info.calledOnce);
+  });
+});


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

We get spammed logs in the console at the end of builds in jira, which is annoying and a bit confusing for devs.

## Changes

When the feature flag is enabled, we hash the result and only write/log when the hash changes.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
