### PR TITLE
Use the new GitHub app to auth changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -184,9 +184,6 @@ jobs:
     id: authenticate-changesets
     if: github.ref_name == 'main'
     permissions: write-all
-    needs:
-      - build-native-linux
-      - build-native-macos
     runs-on: ubuntu-22.04
     uses: actions/create-github-app-token@v1
     with:
@@ -197,7 +194,10 @@ jobs:
     name: Build and release Changesets
     if: github.ref_name == 'main'
     permissions: write-all
-    needs: authenticate-changesets
+    needs:
+      - authenticate-changesets
+      - build-native-linux
+      - build-native-macos
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,13 +179,25 @@ jobs:
               sha: context.sha
             })
 
-  build-and-release-changesets:
-    name: Build and release Changesets
+  authenticate-changesets:
+    name: Authenticate Changesets
+    id: authenticate-changesets
     if: github.ref_name == 'main'
     permissions: write-all
     needs:
       - build-native-linux
       - build-native-macos
+    runs-on: ubuntu-22.04
+    uses: actions/create-github-app-token@v1
+    with:
+      app-id: ${{ vars.ATLASPACK_CI_APP_ID }}
+      private-key: ${{ secrets.ATLASPACK_CI_PRIVATE_KEY }}
+
+  build-and-release-changesets:
+    name: Build and release Changesets
+    if: github.ref_name == 'main'
+    permissions: write-all
+    needs: authenticate-changesets
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
@@ -203,5 +215,5 @@ jobs:
         with:
           publish: yarn changesets-publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.authenticate-changesets.outputs.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation

Currently when the Changesets action opens the Version Packages PR, it uses the default `GITHUB_TOKEN` provided by GitHub Actions.

However PRs opened using this token don't have [permission to kick off] CI.

[permission to kick off]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow

## Changes

The [best practices solution] seems to be to make a GitHub app and then use that to authenticate and get a token that is allowed to run CI.

We've gotten the open source admins to make one for us, and now we can use the [official get-a-token action][a] to auth properly.

[best practices solution]: https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#granting-additional-permissions
[a]: https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/making-authenticated-api-requests-with-a-github-app-in-a-github-actions-workflow#authenticating-with-a-github-app

## Checklist

- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating github actions