### PR TITLE
Only store yarn cache on main branch

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,39 @@
+name: Setup node
+description: Setup node with caching
+
+inputs:
+  version:
+    description: Explicit node version
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.version }}
+        node-version-file: .nvmrc
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+      shell: bash
+
+    # We only store yarn cache on main to save cache space
+    - name: Setup yarn cache
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: yarn-${{ runner.os }}
+
+    - name: Restore yarn cache
+      if: ${{ github.ref != 'refs/heads/main' }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: yarn-${{ runner.os }}
+
+    - name: Yarn install
+      run: yarn install --frozen-lockfile
+      shell: bash

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -26,8 +26,7 @@ runs:
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-${{ runner.os }}-
+        restore-keys: yarn-${{ runner.os }}
 
     - name: Restore yarn cache
       if: ${{ github.ref != 'refs/heads/main' }}
@@ -35,8 +34,7 @@ runs:
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
-        restore-keys: |
-          yarn-${{ runner.os }}-
+        restore-keys: yarn-${{ runner.os }}
 
     - name: Yarn install
       run: yarn install --frozen-lockfile

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -25,14 +25,18 @@ runs:
       uses: actions/cache@v4
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: yarn-${{ runner.os }}
+        key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          yarn-${{ runner.os }}-
 
     - name: Restore yarn cache
       if: ${{ github.ref != 'refs/heads/main' }}
       uses: actions/cache/restore@v4
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: yarn-${{ runner.os }}
+        key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+        restore-keys: |
+          yarn-${{ runner.os }}-
 
     - name: Yarn install
       run: yarn install --frozen-lockfile

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -21,18 +21,18 @@ runs:
 
     # We only store yarn cache on main to save cache space
     - name: Setup yarn cache
-      # if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: actions/cache@v4
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: yarn-${{ runner.os }}
 
-    # - name: Restore yarn cache
-    #   if: ${{ github.ref != 'refs/heads/main' }}
-    #   uses: actions/cache/restore@v4
-    #   with:
-    #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-    #     key: yarn-${{ runner.os }}
+    - name: Restore yarn cache
+      if: ${{ github.ref != 'refs/heads/main' }}
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: yarn-${{ runner.os }}
 
     - name: Yarn install
       run: yarn install --frozen-lockfile

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -2,7 +2,7 @@ name: Setup node
 description: Setup node with caching
 
 inputs:
-  version:
+  node-version:
     description: Explicit node version
     required: false
 
@@ -11,7 +11,7 @@ runs:
   steps:
     - uses: actions/setup-node@v4
       with:
-        node-version: ${{ inputs.version }}
+        node-version: ${{ inputs.node-version }}
         node-version-file: .nvmrc
 
     - name: Get yarn cache directory path

--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -21,18 +21,18 @@ runs:
 
     # We only store yarn cache on main to save cache space
     - name: Setup yarn cache
-      if: ${{ github.ref == 'refs/heads/main' }}
+      # if: ${{ github.ref == 'refs/heads/main' }}
       uses: actions/cache@v4
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
         key: yarn-${{ runner.os }}
 
-    - name: Restore yarn cache
-      if: ${{ github.ref != 'refs/heads/main' }}
-      uses: actions/cache/restore@v4
-      with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: yarn-${{ runner.os }}
+    # - name: Restore yarn cache
+    #   if: ${{ github.ref != 'refs/heads/main' }}
+    #   uses: actions/cache/restore@v4
+    #   with:
+    #     path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+    #     key: yarn-${{ runner.os }}
 
     - name: Yarn install
       run: yarn install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,7 @@ jobs:
           shared-key: '${{ matrix.target }}'
           # Only store new caches on main
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - uses: actions/setup-node@v4
-        with: {cache: yarn}
-      # Yarn install is required for @napi-rs/cli
-      - run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-node
       # Build native artifacts
       - env:
           RUSTUP_TARGET: ${{ matrix.target }}
@@ -89,9 +86,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with: {cache: yarn}
-      - run: yarn install --frozen-lockfile
+      - uses: ./.github/actions/setup-node
       - run: npx flow check
       - run: npx eslint .
       - run: npx prettier --list-different .
@@ -146,9 +141,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
-          cache: yarn
           node-version: ${{ matrix.node }}
       - uses: actions/download-artifact@v4
         with:
@@ -186,9 +180,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
-          cache: yarn
           node-version: ${{ matrix.node }}
       - uses: actions/download-artifact@v4
         with:
@@ -198,7 +191,6 @@ jobs:
       - name: Bump max inotify watches (Linux only)
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
         if: ${{ runner.os == 'Linux' }}
-      - run: yarn --frozen-lockfile
       - run: yarn test:integration-ci
 
   integration_tests_v3:
@@ -226,9 +218,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
-          cache: yarn
           node-version: ${{ matrix.node }}
       - uses: actions/download-artifact@v4
         with:
@@ -238,7 +229,6 @@ jobs:
       - name: Bump max inotify watches (Linux only)
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
         if: ${{ runner.os == 'Linux' }}
-      - run: yarn --frozen-lockfile
       - run: yarn test:integration-ci
         env:
           ATLASPACK_V3: true
@@ -255,9 +245,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
-          cache: yarn
           node-version: ${{ matrix.node }}
       - uses: actions/download-artifact@v4
         with:
@@ -267,6 +256,5 @@ jobs:
       - name: Bump max inotify watches (Linux only)
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
         if: ${{ runner.os == 'Linux' }}
-      - run: yarn --frozen-lockfile
       - run: yarn playwright install
       - run: yarn test:e2e:ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,9 +63,8 @@ jobs:
         uses: ./.github/actions/rust-toolchain
         with:
           targets: ${{ matrix.target }}
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
-          cache: yarn
           node-version: 22
       - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.type != 'latest' }}
@@ -73,7 +72,6 @@ jobs:
           shared-key: '${{ matrix.name }}'
           # Only store new caches on main
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: yarn install --frozen-lockfile
       - name: Build native packages
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
@@ -107,12 +105,10 @@ jobs:
         uses: ./.github/actions/rust-toolchain
         with:
           targets: ${{ matrix.target }}
-      - uses: actions/setup-node@v4
-        with: {cache: yarn}
+      - uses: ./.github/actions/setup-node
       - uses: Swatinem/rust-cache@v2
         if: ${{ inputs.type != 'latest' }}
         with: {shared-key: '${{ matrix.name }}'}
-      - run: yarn install --frozen-lockfile
       - name: Build native packages
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
@@ -135,8 +131,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with: {fetch-depth: 0}
-      - uses: actions/setup-node@v4
-        with: {cache: yarn}
+      - uses: ./.github/actions/setup-node
       - uses: actions/download-artifact@v4
         with:
           pattern: packages-*
@@ -191,14 +186,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v4
-        with: {cache: yarn}
+      - uses: ./.github/actions/setup-node
       - uses: actions/download-artifact@v4
         with:
           pattern: packages-*
           path: packages
           merge-multiple: true
-      - run: yarn install --frozen-lockfile
       - uses: changesets/action@v1
         with:
           publish: yarn changesets-publish


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Currently, node caches are filling our github action allowance for not much benefit. This PR shared the node install, yarn install and yarn cache workflow into a composite action. I've also disabled the built-in setup-node yarn caching in favour of a simpler solution implemented directly in the action. 

From now on yarn caches will only be stored on the main branch, PRs only using a restore. 

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: On CI changes
