### PR TITLE
Remove the permissions line from the yaml file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,7 +177,6 @@ jobs:
   build-and-release-changesets:
     name: Build and release Changesets
     if: github.ref_name == 'main'
-    permissions: write-all
     needs:
       - build-native-linux
       - build-native-macos


### PR DESCRIPTION
It seems that this is an alternative to setting up the permissions in the App settings, and I'm concerned that this is overriding the ones I've set. I want to try taking them out

[no-changeset]: Update workflows
