### PR TITLE
Upload debug symbols to sentry

### DIFF
--- a/.github/workflows/canary-release.yml
+++ b/.github/workflows/canary-release.yml
@@ -15,6 +15,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     secrets: inherit
     with:
-      profile: canary
       release-command: yarn canary:release
       type: canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
       - name: Bump max inotify watches (Linux only)
         if: ${{ runner.os == 'Linux' }}
         run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p;
-      - run: yarn --frozen-lockfile
       - run: yarn test:js:unit
 
   integration_tests:

--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,6 +12,5 @@ jobs:
     uses: ./.github/workflows/release.yml
     secrets: inherit
     with:
-      profile: canary
       release-command: yarn dev:release
       type: dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,13 +11,14 @@ on:
         description: 'The type of release, usually corresponds to the dist-tag'
         required: true
         type: string
-      profile:
-        description: 'The profile to use when building the native binaries'
-        required: false
-        default: 'release'
-        type: string
     secrets:
       NPM_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
+      SENTRY_AUTH_TOKEN:
         required: true
 
 permissions:
@@ -67,7 +68,6 @@ jobs:
         with:
           node-version: 22
       - uses: Swatinem/rust-cache@v2
-        if: ${{ inputs.type != 'latest' }}
         with:
           shared-key: '${{ matrix.name }}'
           # Only store new caches on main
@@ -75,10 +75,14 @@ jobs:
       - name: Build native packages
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
-          CARGO_PROFILE: ${{ inputs.profile }}
+          CARGO_PROFILE: release
         run: yarn build-native
-      - name: Extract debug symbols
+      - name: Upload debug symbols to sentry
         run: node "./scripts/debug-symbols.mjs"
+        env:
+          SENTRY_ORG: ${{secrets.SENTRY_ORG}}
+          SENTRY_PROJECT: ${{secrets.SENTRY_PROJECT}}
+          SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -107,15 +111,18 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: ./.github/actions/setup-node
       - uses: Swatinem/rust-cache@v2
-        if: ${{ inputs.type != 'latest' }}
         with: {shared-key: '${{ matrix.name }}'}
       - name: Build native packages
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
           CARGO_PROFILE: ${{ inputs.profile }}
         run: yarn build-native
-      - name: Extract debug symbols
+      - name: Upload debug symbols to sentry
         run: node "./scripts/debug-symbols.mjs"
+        env:
+          SENTRY_ORG: ${{secrets.SENTRY_ORG}}
+          SENTRY_PROJECT: ${{secrets.SENTRY_PROJECT}}
+          SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -137,20 +144,6 @@ jobs:
           pattern: packages-*
           path: packages
           merge-multiple: true
-      - run: yarn install --frozen-lockfile
-      - name: Move debug symbols
-        if: ${{ inputs.profile == 'canary' }}
-        run: |
-          mkdir debug-symbols
-          find packages -name "*.debug" -exec cp {} debug-symbols/ \;
-          find packages -name "*.node" -path "**/DWARF/**" -exec cp {} debug-symbols/ \;
-          ls -l debug-symbols
-      - name: Upload combined debug symbols artifact
-        uses: actions/upload-artifact@v4
-        if: ${{ inputs.profile == 'canary' }}
-        with:
-          name: debug-symbols
-          path: debug-symbols/**
       - name: Debug
         run: ls -l packages/*/*/*.node
       - name: Npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,7 @@ jobs:
       - name: Build native packages
         env:
           RUSTUP_TARGET: ${{ matrix.target }}
-          CARGO_PROFILE: ${{ inputs.profile }}
+          CARGO_PROFILE: release
         run: yarn build-native
       - name: Upload debug symbols to sentry
         run: node "./scripts/debug-symbols.mjs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,13 @@ members = [
   "packages/utils/dev-dep-resolver",
 ]
 
-[profile.canary]
-inherits = "release"
+[profile.dev]
+# Even in dev we want the fastest performance to decrease compile times when
+# testing or linking into products
+opt-level = 3
+
+[profile.release]
+# We extra the debug symbols and send them to sentry in CI
 debug = true
 
 [workspace.lints.rust]
@@ -84,7 +89,15 @@ pretty_assertions = "1.4.1"
 rand = "0.8.5"
 rayon = "1.10.0"
 regex = "1.11.1"
-sentry = { version = "0.35.0", default-features = false, features = ["anyhow", "backtrace", "contexts", "debug-images", "panic", "reqwest", "rustls"] }
+sentry = { version = "0.35.0", default-features = false, features = [
+  "anyhow",
+  "backtrace",
+  "contexts",
+  "debug-images",
+  "panic",
+  "reqwest",
+  "rustls",
+] }
 sentry-tracing = { version = "0.35" }
 serde = "1.0.217"
 serde_bytes = "0.11.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
 opt-level = 3
 
 [profile.release]
-# We extra the debug symbols and send them to sentry in CI
+# The debug symbols are built for release and then sent to sentry in CI
 debug = true
 
 [workspace.lints.rust]

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@changesets/cli": "^2.27.9",
     "@khanacademy/flow-to-ts": "^0.5.2",
     "@napi-rs/cli": "^2.18.3",
+    "@sentry/cli": "^2.45.0",
     "@types/node": ">= 18",
     "buffer": "mischnic/buffer#b8a4fa94",
     "cross-env": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "build-ts": "lerna run build-ts && lerna run check-ts",
     "build-native": "node scripts/build-native.js",
     "build-native-release": "cross-env CARGO_PROFILE=release node scripts/build-native.js",
-    "build-native-canary": "cross-env CARGO_PROFILE=canary node scripts/build-native.js",
     "build-native-wasm": "cross-env CARGO_PROFILE=release RUSTUP_TARGET=wasm32-unknown-unknown scripts/build-native.js",
     "build-repl": "yarn build-native-release && yarn build-native-wasm && yarn workspace @atlaspack/repl build",
     "clean-test": "rimraf packages/core/integration-tests/.parcel-cache && rimraf packages/core/integration-tests/dist",

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -21,11 +21,11 @@ const defaultTarget = {
 }[`${process.platform}-${process.arch}`];
 
 const rustTarget = RUSTUP_TARGET || defaultTarget;
-const rustProfile = CARGO_PROFILE || 'debug';
+let rustProfile = CARGO_PROFILE || 'dev';
 
 const cargoCommand = ['cargo', 'build', '--target', rustTarget];
 
-if (rustProfile !== 'debug') {
+if (rustProfile !== 'dev') {
   cargoCommand.push('--profile', rustProfile);
 }
 
@@ -134,7 +134,7 @@ function buildNapiLibrary(pkgDir) {
     rustTarget,
   );
 
-  if (rustProfile !== 'debug') {
+  if (rustProfile !== 'dev') {
     command.push('--profile', rustProfile);
   }
 
@@ -214,7 +214,7 @@ function copyBinaries(pkgDir) {
   const sourceBin = path.join(
     'target',
     rustTarget,
-    rustProfile,
+    rustProfile === 'dev' ? 'debug' : rustProfile,
     pkgJson.copyBin.name,
   );
 

--- a/scripts/debug-symbols.mjs
+++ b/scripts/debug-symbols.mjs
@@ -1,47 +1,48 @@
 /* eslint-disable no-console */
 import * as path from 'node:path';
 import * as process from 'node:process';
-import * as child_process from 'node:child_process';
 import * as url from 'node:url';
+import {$} from 'zx';
 import glob from 'glob';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const __root = path.dirname(__dirname);
 
-for (const foundRel of glob.sync('packages/**/*.node', {
-  cwd: __root,
-  ignore: '**/node_modules/**',
-})) {
-  const found = path.join(__root, foundRel);
-  if (process.platform === 'linux') {
+async function uploadDebugSymbolsToSentry() {
+  $.stdio = 'inherit';
+
+  const debugFiles = [];
+
+  for (const foundRel of glob.sync('packages/**/*.node', {
+    cwd: __root,
+    ignore: '**/node_modules/**',
+  })) {
+    const found = path.join(__root, foundRel);
     console.log(`Stripping:     ${found}`);
-    cmd(
-      `objcopy --only-keep-debug --compress-debug-sections=zlib ${found} ${found}.debug`,
-    );
-    cmd(`objcopy --strip-debug --strip-unneeded ${found}`);
-    cmd(`objcopy --add-gnu-debuglink=${found}.debug ${found}`);
-    console.log(`  ➜ Generated: ${found}.debug`);
+    const output = `${found}.debug`;
+    if (process.platform === 'linux') {
+      await $`objcopy --only-keep-debug ${found} ${output}`;
+      await $`objcopy --strip-debug --strip-unneeded ${found}`;
+      await $`objcopy --add-gnu-debuglink=${output} ${found}`;
+    } else if (process.platform === 'darwin') {
+      const dsymOutput = `${found}.dsym`;
+      debugFiles.push(dsymOutput);
+
+      await $`dsymutil ${found} -o ${dsymOutput}`;
+      await $`strip -x ${found} -o ${output}`;
+    }
+    debugFiles.push(output);
+
+    console.log(`  ➜ Generated: ${output}`);
   }
-  if (process.platform === 'darwin') {
-    cmd(`dsymutil ${found}`);
-    cmd(`strip -x ${found}`);
+
+  console.log('Uploading debug files to sentry');
+  await $`yarn sentry-cli debug-files upload --include-sources --log-level=info .`;
+
+  for (const debugFile of debugFiles) {
+    await $`rm -rf ${debugFile}`;
+    console.log('Deleted', debugFile);
   }
 }
 
-function cmd(command, options) {
-  try {
-    const [arg0, ...args] = command
-      .split(' ')
-      .filter((v) => v !== '')
-      .map((v) => v.trim());
-    child_process.execFileSync(arg0, args, {
-      stdio: 'inherit',
-      shell: true,
-      ...options,
-    });
-  } catch (error) {
-    console.error(`Failed: ${command}`);
-    console.error(error);
-    process.exit(1);
-  }
-}
+uploadDebugSymbolsToSentry();

--- a/scripts/debug-symbols.mjs
+++ b/scripts/debug-symbols.mjs
@@ -37,7 +37,7 @@ async function uploadDebugSymbolsToSentry() {
   }
 
   console.log('Uploading debug files to sentry');
-  await $`yarn sentry-cli debug-files upload --include-sources --log-level=info .`;
+  await $`yarn sentry-cli debug-files upload --include-sources --log-level=info packages`;
 
   for (const debugFile of debugFiles) {
     await $`rm -rf ${debugFile}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3514,6 +3514,66 @@
   resolved "https://registry.yarnpkg.com/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz#8be36a1f66f3265389e90b5f9c9962146758f728"
   integrity sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg==
 
+"@sentry/cli-darwin@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-darwin/-/cli-darwin-2.45.0.tgz#e3d6feae4fadcfdf91db9c7b9c4689a66d3d8d19"
+  integrity sha512-p4Uxfv/L2fQdP3/wYnKVVz9gzZJf/1Xp9D+6raax/3Bu5y87yHYUqcdt98y/VAXQD4ofp2QgmhGUVPofvQNZmg==
+
+"@sentry/cli-linux-arm64@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm64/-/cli-linux-arm64-2.45.0.tgz#384c8e17f7e7dc007d164033d0e7c75aa83a2e9b"
+  integrity sha512-gUcLoEjzg7AIc4QQGEZwRHri+EHf3Gcms9zAR1VHiNF3/C/jL4WeDPJF2YiWAQt6EtH84tHiyhw1Ab/R8XFClg==
+
+"@sentry/cli-linux-arm@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-arm/-/cli-linux-arm-2.45.0.tgz#b9d6f86f3934b4d9ced5b45a8158ff2ac2bdd25d"
+  integrity sha512-6sEskFLlFKJ+e0MOYgIclBTUX5jYMyYhHIxXahEkI/4vx6JO0uvpyRAkUJRpJkRh/lPog0FM+tbP3so+VxB2qQ==
+
+"@sentry/cli-linux-i686@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-i686/-/cli-linux-i686-2.45.0.tgz#39e22beb84cfa26e11bdc198364315fdfb4da4d5"
+  integrity sha512-VmmOaEAzSW23YdGNdy/+oQjCNAMY+HmOGA77A25/ep/9AV7PQB6FI7xO5Y1PVvlkxZFJ23e373njSsEeg4uDZw==
+
+"@sentry/cli-linux-x64@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-linux-x64/-/cli-linux-x64-2.45.0.tgz#25cd3699297f9433835fb5edd42dad722c11f041"
+  integrity sha512-a0Oj68mrb25a0WjX/ShZ6AAd4PPiuLcgyzQr7bl2+DvYxIOajwkGbR+CZFEhOVZcfhTnixKy/qIXEzApEPHPQg==
+
+"@sentry/cli-win32-arm64@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-arm64/-/cli-win32-arm64-2.45.0.tgz#50c7d29ea2169bdb4d98bbde81c5f7dac0dd3955"
+  integrity sha512-vn+CwS4p+52pQSLNPoi20ZOrQmv01ZgAmuMnjkh1oUZfTyBAwWLrAh6Cy4cztcN8DfL5dOWKQBo8DBKURE4ttg==
+
+"@sentry/cli-win32-i686@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-i686/-/cli-win32-i686-2.45.0.tgz#201075c4aec37a3e797160e0b468641245437f0c"
+  integrity sha512-8mMoDdlwxtcdNIMtteMK7dbi7054jak8wKSHJ5yzMw8UmWxC5thc/gXBc1uPduiaI56VjoJV+phWHBKCD+6I4w==
+
+"@sentry/cli-win32-x64@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli-win32-x64/-/cli-win32-x64-2.45.0.tgz#2075e9e1ea3c3609e0fa1a758ca033e94e1c600f"
+  integrity sha512-ZvK9cIqFaq7vZ0jkHJ/xh5au6902Dr+AUxSk6L6vCL7JCe2p93KGL/4d8VFB5PD/P7Y9b+105G/e0QIFKzpeOw==
+
+"@sentry/cli@^2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@sentry/cli/-/cli-2.45.0.tgz#35feed7a2fee54faf25daed73001a2a2a3143396"
+  integrity sha512-4sWu7zgzgHAjIxIjXUA/66qgeEf5ZOlloO+/JaGD5qXNSW0G7KMTR6iYjReNKMgdBCTH6bUUt9qiuA+Ex9Masw==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    node-fetch "^2.6.7"
+    progress "^2.0.3"
+    proxy-from-env "^1.1.0"
+    which "^2.0.2"
+  optionalDependencies:
+    "@sentry/cli-darwin" "2.45.0"
+    "@sentry/cli-linux-arm" "2.45.0"
+    "@sentry/cli-linux-arm64" "2.45.0"
+    "@sentry/cli-linux-i686" "2.45.0"
+    "@sentry/cli-linux-x64" "2.45.0"
+    "@sentry/cli-win32-arm64" "2.45.0"
+    "@sentry/cli-win32-i686" "2.45.0"
+    "@sentry/cli-win32-x64" "2.45.0"
+
 "@sigstore/bundle@^2.3.2":
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@sigstore/bundle/-/bundle-2.3.2.tgz#ad4dbb95d665405fd4a7a02c8a073dbd01e4e95e"
@@ -13865,6 +13925,11 @@ proggy@^2.0.0:
   resolved "https://registry.yarnpkg.com/proggy/-/proggy-2.0.0.tgz#154bb0e41d3125b518ef6c79782455c2c47d94e1"
   integrity sha512-69agxLtnI8xBs9gUGqEnK26UfiexpHy+KUpBQWabiytQjnn5wFY8rklAi7GRfABIuPNnQ/ik48+LGLkYYJcy4A==
 
+progress@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 promise-all-reject-late@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-all-reject-late/-/promise-all-reject-late-1.0.1.tgz#f8ebf13483e5ca91ad809ccc2fcf25f26f8643c2"
@@ -17270,7 +17335,7 @@ which-typed-array@^1.1.11, which-typed-array@^1.1.13, which-typed-array@^1.1.2, 
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
-which@2.0.2, which@^2.0.1:
+which@2.0.2, which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

On release builds, we currently extract debug-symbols for each target and merge them into a single artifact to be handled later. This PR instead just uploads the debug-symbols straight to Sentry and then deletes them. 

## Changes
- Add sentry CLI and update the `debug-symbols` script to upload to Sentry
- Removed the `canary` rust profile in favour of using the builtin `release` profile with `debug = true`
- Add `opt-level = 3` to the default `dev` profile, allowing us to viably dev against `yarn build-native` locally which harnesses incremental builds


## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Release pipeline change
