### PR TITLE
Fix conditional bundling reporter when condition is reused

### DIFF
--- a/.changeset/perfect-paws-study.md
+++ b/.changeset/perfect-paws-study.md
@@ -1,0 +1,8 @@
+---
+'@atlaspack/reporter-conditional-manifest': patch
+'@atlaspack/integration-tests': patch
+'@atlaspack/feature-flags': patch
+'@atlaspack/core': patch
+---
+
+Fix conditional bundling reporter when condition is reused

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -31,6 +31,7 @@ import Dependency, {
 import {targetToInternalTarget} from './Target';
 import {fromInternalSourceLocation} from '../utils';
 import BundleGroup, {bundleGroupToInternalBundleGroup} from './BundleGroup';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 // Friendly access for other modules within this package that need access
 // to the internal bundle.
@@ -489,10 +490,20 @@ export default class BundleGraph<TBundle: IBundle>
       for (let bundle of bundles) {
         const conditions = bundleConditions.get(bundle.id) ?? new Map();
 
+        const currentCondition = conditions.get(cond.key);
+
         conditions.set(cond.key, {
           bundle,
-          ifTrueBundles,
-          ifFalseBundles,
+          ifTrueBundles: getFeatureFlag(
+            'conditionalBundlingReporterSameConditionFix',
+          )
+            ? [...(currentCondition?.ifTrueBundles ?? []), ...ifTrueBundles]
+            : ifTrueBundles,
+          ifFalseBundles: getFeatureFlag(
+            'conditionalBundlingReporterSameConditionFix',
+          )
+            ? [...(currentCondition?.ifFalseBundles ?? []), ...ifFalseBundles]
+            : ifFalseBundles,
         });
 
         bundleConditions.set(bundle.id, conditions);

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -492,19 +492,25 @@ export default class BundleGraph<TBundle: IBundle>
 
         const currentCondition = conditions.get(cond.key);
 
-        conditions.set(cond.key, {
-          bundle,
-          ifTrueBundles: getFeatureFlag(
-            'conditionalBundlingReporterSameConditionFix',
-          )
-            ? [...(currentCondition?.ifTrueBundles ?? []), ...ifTrueBundles]
-            : ifTrueBundles,
-          ifFalseBundles: getFeatureFlag(
-            'conditionalBundlingReporterSameConditionFix',
-          )
-            ? [...(currentCondition?.ifFalseBundles ?? []), ...ifFalseBundles]
-            : ifFalseBundles,
-        });
+        if (getFeatureFlag('conditionalBundlingReporterSameConditionFix')) {
+          conditions.set(cond.key, {
+            bundle,
+            ifTrueBundles: [
+              ...(currentCondition?.ifTrueBundles ?? []),
+              ...ifTrueBundles,
+            ],
+            ifFalseBundles: [
+              ...(currentCondition?.ifFalseBundles ?? []),
+              ...ifFalseBundles,
+            ],
+          });
+        } else {
+          conditions.set(cond.key, {
+            bundle,
+            ifTrueBundles,
+            ifFalseBundles,
+          });
+        }
 
         bundleConditions.set(bundle.id, conditions);
       }

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -27,6 +27,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   verboseRequestInvalidationStats: true,
   conditionalBundlingReporterDuplicateFix: false,
   resolveBundlerConfigFromCwd: false,
+  conditionalBundlingReporterSameConditionFix: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -86,6 +86,10 @@ export type FeatureFlags = {|
    * Enable resolution of bundler config starting from the CWD
    */
   resolveBundlerConfigFromCwd: boolean,
+  /**
+   * Fix a bug where the conditional manifest reporter would drop bundles that have the same condition
+   */
+  conditionalBundlingReporterSameConditionFix: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -73,13 +73,12 @@ export async function report({
             manifest[bundle.target.name]?.[relativeBundlePath] ?? {};
 
           bundleInfo[key] = {
-            // Reverse bundles so we load children bundles first
             ifTrueBundles: mapBundles(cond.ifTrueBundles)
-              .reverse()
-              .concat(bundleInfo[key]?.ifTrueBundles ?? []),
+              .concat(bundleInfo[key]?.ifTrueBundles ?? [])
+              .sort(),
             ifFalseBundles: mapBundles(cond.ifFalseBundles)
-              .reverse()
-              .concat(bundleInfo[key]?.ifFalseBundles ?? []),
+              .concat(bundleInfo[key]?.ifFalseBundles ?? [])
+              .sort(),
           };
 
           manifest[bundle.target.name] ??= {};

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -60,18 +60,42 @@ export async function report({
 
     const manifest = {};
     for (const conditions of bundles.values()) {
-      const bundleInfo = {};
+      const oldBundleInfo = {};
       for (const [key, cond] of conditions) {
-        const bundle = cond.bundle;
-        bundleInfo[key] = {
-          // Reverse bundles so we load children bundles first
-          ifTrueBundles: mapBundles(cond.ifTrueBundles).reverse(),
-          ifFalseBundles: mapBundles(cond.ifFalseBundles).reverse(),
-        };
-        manifest[bundle.target.name] ??= {};
-        manifest[bundle.target.name][
-          relative(bundle.target.distDir, bundle.filePath)
-        ] = bundleInfo;
+        if (getFeatureFlag('conditionalBundlingReporterSameConditionFix')) {
+          const bundle = cond.bundle;
+          const relativeBundlePath = relative(
+            bundle.target.distDir,
+            bundle.filePath,
+          );
+
+          const bundleInfo =
+            manifest[bundle.target.name]?.[relativeBundlePath] ?? {};
+
+          bundleInfo[key] = {
+            // Reverse bundles so we load children bundles first
+            ifTrueBundles: mapBundles(cond.ifTrueBundles)
+              .reverse()
+              .concat(bundleInfo[key]?.ifTrueBundles ?? []),
+            ifFalseBundles: mapBundles(cond.ifFalseBundles)
+              .reverse()
+              .concat(bundleInfo[key]?.ifFalseBundles ?? []),
+          };
+
+          manifest[bundle.target.name] ??= {};
+          manifest[bundle.target.name][relativeBundlePath] = bundleInfo;
+        } else {
+          const bundle = cond.bundle;
+          oldBundleInfo[key] = {
+            // Reverse bundles so we load children bundles first
+            ifTrueBundles: mapBundles(cond.ifTrueBundles).reverse(),
+            ifFalseBundles: mapBundles(cond.ifFalseBundles).reverse(),
+          };
+          manifest[bundle.target.name] ??= {};
+          manifest[bundle.target.name][
+            relative(bundle.target.distDir, bundle.filePath)
+          ] = oldBundleInfo;
+        }
       }
     }
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

@flakeparadigm noticed that his code was not getting preloaded in Jira. We isolated this to reusing the same condition for two different imports. 

## Changes

This change fixes the conditional manifest reporter, which was erroneously overriding the previous condition bundles. It is gated behind a feature flag.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
