### PR TITLE
Chore: Add options to sentry script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,7 +78,7 @@ jobs:
           CARGO_PROFILE: release
         run: yarn build-native
       - name: Upload debug symbols to sentry
-        run: node "./scripts/debug-symbols.mjs"
+        run: node "./scripts/debug-symbols.mjs" --upload-to-sentry --rm
         env:
           SENTRY_ORG: ${{secrets.SENTRY_ORG}}
           SENTRY_PROJECT: ${{secrets.SENTRY_PROJECT}}
@@ -118,7 +118,7 @@ jobs:
           CARGO_PROFILE: release
         run: yarn build-native
       - name: Upload debug symbols to sentry
-        run: node "./scripts/debug-symbols.mjs"
+        run: node "./scripts/debug-symbols.mjs" --upload-to-sentry --rm
         env:
           SENTRY_ORG: ${{secrets.SENTRY_ORG}}
           SENTRY_PROJECT: ${{secrets.SENTRY_PROJECT}}

--- a/scripts/debug-symbols.mjs
+++ b/scripts/debug-symbols.mjs
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import * as path from 'node:path';
+import * as fs from 'node:fs';
 import * as process from 'node:process';
 import * as url from 'node:url';
 import {$} from 'zx';
@@ -8,7 +9,28 @@ import glob from 'glob';
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const __root = path.dirname(__dirname);
 
-async function uploadDebugSymbolsToSentry() {
+const rm = process.argv.includes('--rm');
+const upload = process.argv.includes('--upload-to-sentry');
+
+console.table({
+  'Strip Debug Symbols': true,
+  'Remove After': rm,
+  'Upload to Sentry': upload,
+});
+
+void (async function main() {
+  const debugFiles = await stripDebugSymbols();
+  if (upload) {
+    await uploadDebugSymbolsToSentry();
+  }
+  if (rm) {
+    await removeFiles(debugFiles);
+  }
+})();
+
+/// Find cdylib files and extract their debug symbols into
+/// a separate debug file
+async function stripDebugSymbols() {
   $.stdio = 'inherit';
 
   const debugFiles = [];
@@ -18,10 +40,11 @@ async function uploadDebugSymbolsToSentry() {
     ignore: '**/node_modules/**',
   })) {
     const found = path.join(__root, foundRel);
-    console.log(`Stripping:     ${found}`);
+    console.log('Stripping', found);
 
     if (process.platform === 'linux') {
       const output = `${found}.debug`;
+      console.log('Generating', output);
 
       await $`objcopy --only-keep-debug --compress-debug-sections=zlib ${found} ${output}`;
       await $`objcopy --strip-debug --strip-unneeded ${found}`;
@@ -30,6 +53,7 @@ async function uploadDebugSymbolsToSentry() {
       debugFiles.push(output);
     } else if (process.platform === 'darwin') {
       const dsymOutput = `${found}.dsym`;
+      console.log('Generating', dsymOutput);
 
       await $`dsymutil ${found} -o ${dsymOutput}`;
       await $`strip -x ${found}`;
@@ -38,13 +62,21 @@ async function uploadDebugSymbolsToSentry() {
     }
   }
 
+  return debugFiles;
+}
+
+/// Upload a list of debug files to sentry
+async function uploadDebugSymbolsToSentry() {
+  $.stdio = 'inherit';
   console.log('Uploading debug files to sentry');
   await $`yarn sentry-cli debug-files upload --include-sources --log-level=info packages`;
+}
 
+/// Remove/clean up debug files
+async function removeFiles(debugFiles) {
   for (const debugFile of debugFiles) {
-    await $`rm -rf ${debugFile}`;
+    console.log('Deleting', debugFile);
+    await fs.promises.rm(debugFile, {recursive: true, force: true});
     console.log('Deleted', debugFile);
   }
 }
-
-uploadDebugSymbolsToSentry();


### PR DESCRIPTION
## Motivation

- Sometimes you want to strip debug symbols without uploading to Sentry
- Sometimes you want to remove debug symbols

## Changes

Added options to `debug-symbols.mjs` script
```bash
# Strip debug symbols and move them to a seperate file
node ./scripts/debug-symbols.mjs

# Strip debug symbols and upload them to sentry
node ./scripts/debug-symbols.mjs --upload-to-sentry

# Strip debug symbols and remove them from disk
node ./scripts/debug-symbols.mjs --rm

# Strip debug symbols, upload them to sentry, then remove them from disk
node ./scripts/debug-symbols.mjs --upload-to-sentry --rm
```

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Build script
