### PR TITLE
Apvm: added version to package.json shims

### DIFF
--- a/.changeset/hot-news-ring.md
+++ b/.changeset/hot-news-ring.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/apvm': patch
+---
+
+Added "version" to the package.json of shims

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,6 @@ dependencies = [
  "env_logger",
  "flate2",
  "homedir",
- "json",
  "jwalk",
  "log",
  "rand",

--- a/crates/apvm/Cargo.toml
+++ b/crates/apvm/Cargo.toml
@@ -13,7 +13,6 @@ base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 flate2 = { workspace = true }
 homedir = { workspace = true }
-json = { workspace = true }
 jwalk = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["blocking", "rustls-tls"] }

--- a/crates/apvm/src/main.rs
+++ b/crates/apvm/src/main.rs
@@ -1,4 +1,4 @@
-// #![deny(unused_crate_dependencies)]
+#![deny(unused_crate_dependencies)]
 
 mod cmd;
 mod context;


### PR DESCRIPTION
## Changes

- Added `version` to the shim package.json for version reporting
- Updated link to use `fs_ext` utils (they have logging built in)

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
