### PR TITLE
Apvm: Reset bin permissions on unix

### DIFF
--- a/.changeset/spotty-shrimps-sneeze.md
+++ b/.changeset/spotty-shrimps-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/apvm': patch
+---
+
+Yarn install resets permissions on binaries. This change checks the binary has the correct permissions before running it and if not, sets the correct permissions

--- a/packages/apvm/apvm/apvm.mjs
+++ b/packages/apvm/apvm/apvm.mjs
@@ -37,12 +37,20 @@ if (!fs.existsSync(binPath)) {
   process.exit(1);
 }
 
+if (platform !== 'windows' && !isExec(binPath)) {
+  fs.chmodSync(binPath, '755');
+}
+
 const [, , ...args] = process.argv;
 try {
-  child_process.execFileSync(`${binPath} ${args.join(' ')}`, {
+  child_process.execFileSync(binPath, args, {
     stdio: 'inherit',
     shell: true,
   });
 } catch (err) {
   process.exit(err.status);
+}
+
+function isExec(p) {
+  return !!(fs.statSync(p).mode & fs.constants.S_IXUSR);
 }


### PR DESCRIPTION
## Motivation

`yarn install` resets permissions on binaries. This change checks the binary has the correct permissions before running it and if not, sets the correct permissions

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
