### PR TITLE
Change debug build-asset-graph to do no-lazy build

### DIFF
--- a/.changeset/heavy-apricots-study.md
+++ b/.changeset/heavy-apricots-study.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/cli': patch
+---
+
+Make sure atlaspack debug build-asset-graph stores a no-lazy cache

--- a/packages/core/cli/src/makeDebugCommand.js
+++ b/packages/core/cli/src/makeDebugCommand.js
@@ -34,8 +34,8 @@ export function makeDebugCommand(): commander$Command {
         paths: [fs.cwd(), __dirname],
       }),
       shouldPatchConsole: false,
+      shouldBuildLazily: false,
       ...options,
-      shouldBuildLazily: true,
       watchBackend: 'watchman',
     });
     logger.info({


### PR DESCRIPTION
This will only make sure the cache key in use is for a no-lazy build.
