### PR TITLE
APVM : Fix "main" in package.json

### DIFF
--- a/.changeset/fuzzy-zoos-sniff.md
+++ b/.changeset/fuzzy-zoos-sniff.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/apvm': patch
+---
+
+Fixing "package.json#main" specifier in npm shims produced by "apvm link"

--- a/crates/apvm/src/cmd/link_npm.rs
+++ b/crates/apvm/src/cmd/link_npm.rs
@@ -98,7 +98,7 @@ pub fn link_npm(
       &PackageJson {
         name: Some(format!("@atlaspack/{file_stem}")),
         version: Some(specifier.to_string()),
-        main: Some("./index.cjs".to_string()),
+        main: Some("./index.js".to_string()),
         types: Some("./index.d.ts".to_string()),
         r#type: Some("commonjs".to_string()),
         private: None,

--- a/crates/apvm/src/cmd/link_release.rs
+++ b/crates/apvm/src/cmd/link_release.rs
@@ -80,7 +80,7 @@ pub fn link_release(
       &PackageJson {
         name: Some(format!("@atlaspack/{entry_basename}")),
         version: Some(specifier.to_string()),
-        main: Some("./index.cjs".to_string()),
+        main: Some("./index.js".to_string()),
         types: Some("./index.d.ts".to_string()),
         r#type: Some("commonjs".to_string()),
         ..PackageJson::read_from_file(entry_path.join("package.json"))?
@@ -89,7 +89,7 @@ pub fn link_release(
     )?;
 
     fs::write(
-      dest.join("index.cjs"),
+      dest.join("index.js"),
       format!("module.exports = require('atlaspack/{}')\n", entry_basename),
     )?;
 


### PR DESCRIPTION
## Changes

Fixing "package.json#main" specifier in npm shims produced by "apvm link"

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
