### PR TITLE
Modify "large blobs" to be written to the LMDB cache

### DIFF
--- a/.changeset/strong-carrots-provide.md
+++ b/.changeset/strong-carrots-provide.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': minor
+---
+
+Modify "large blobs" to be written to the LMDB cache

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1484,15 +1484,19 @@ export default class RequestTracker {
         throw new Error('Serialization was aborted');
       }
 
-      await this.options.cache.setLargeBlob(
-        key,
-        serialize(contents),
-        signal
-          ? {
-              signal: signal,
-            }
-          : undefined,
-      );
+      if (getFeatureFlag('cachePerformanceImprovements')) {
+        await this.options.cache.set(key, serialize(contents));
+      } else {
+        await this.options.cache.setLargeBlob(
+          key,
+          serialize(contents),
+          signal
+            ? {
+                signal: signal,
+              }
+            : undefined,
+        );
+      }
 
       total += 1;
 

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -128,6 +128,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
   let assetGraph;
   if (assetGraphBlob) {
     try {
+      // TODO: this should be reviewed when `cachePerformanceImprovements` flag is removed, as we'll be writing files to LMDB cache instead of large blobs
       let file = await cache.getLargeBlob(
         path.basename(assetGraphBlob).slice(0, -'-0'.length),
       );


### PR DESCRIPTION
Eliminating large blob writes so that we can improve the time it takes to write to cache