### PR TITLE
Fix bugs in the large blob cache changes

### DIFF
--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@atlaspack/build-cache": "2.13.3",
+    "@atlaspack/feature-flags": "2.14.2",
     "@atlaspack/fs": "2.14.3",
     "@atlaspack/logger": "2.14.3",
     "@atlaspack/rust": "3.1.1",


### PR DESCRIPTION
- fix issue where `Buffer` objects were double serialized (use `set(x)` instead of `set(serialize(x))`)
- fix issue where request graph wasn't loaded when the flag was on
- make all large blobs always go through LMDB now regardless of other changes
