### PR TITLE
Fix setting-up monitoring multiple times

### DIFF
--- a/.changeset/long-pans-sit.md
+++ b/.changeset/long-pans-sit.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Fix warnings when creating multiple instances on a process


### PR DESCRIPTION
It is not valid to set the global tracing subscriber multiple times in a process, so we should never drop our monitoring because we will fail to initialize it again.
