### PR TITLE
expose VCS timing metrics to analytics

### DIFF
--- a/.changeset/spotty-carrots-attend.md
+++ b/.changeset/spotty-carrots-attend.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/fs': minor
+---
+
+Expose vcs metrics

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -91,9 +91,9 @@ export class NodeVCSAwareFS extends NodeFS {
         ) {
           logger.info({
             origin: '@atlaspack/fs',
-            message: 'Expose VCS timing metrics',
+            message: 'Expose VCS timing metrics on getEventsSince',
             meta: {
-              trackableEvent: 'vcs_timing_metrics',
+              trackableEvent: 'vcs_timing_metrics-getEventsSince',
               dirtyFilesExecutionTime:
                 vcsContent.vcsState?.dirtyFilesExecutionTime,
               yarnStatesExecutionTime:
@@ -180,6 +180,18 @@ export class NodeVCSAwareFS extends NodeFS {
         'NodeVCSAwareFS::getVcsStateSnapshot',
         () => getVcsStateSnapshot(gitRepoPath, this.#excludePatterns),
       );
+
+      logger.info({
+        origin: '@atlaspack/fs',
+        message: 'Expose VCS timing metrics on writeSnapshot',
+        meta: {
+          trackableEvent: 'vcs_timing_metrics-writeSnapshot',
+          // $FlowFixMe[prop-missing] Rust type includes these properties
+          dirtyFilesExecutionTime: vcsState?.dirtyFilesExecutionTime,
+          // $FlowFixMe[prop-missing] Rust type includes these properties
+          yarnStatesExecutionTime: vcsState?.yarnStatesExecutionTime,
+        },
+      });
     } catch (err) {
       logger.error({
         origin: '@atlaspack/fs',

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -82,27 +82,7 @@ export class NodeVCSAwareFS extends NodeFS {
         // Note: can't use toString() directly, or it won't resolve the promise
         const snapshotFile = await this.readFile(snapshot);
         const snapshotFileContent = snapshotFile.toString();
-        const vcsContent = JSON.parse(snapshotFileContent);
-
-        // Expose VCS timing metrics to analytics
-        if (
-          vcsContent.vcsState?.dirtyFilesExecutionTime != null ||
-          vcsContent.vcsState?.yarnStatesExecutionTime != null
-        ) {
-          logger.info({
-            origin: '@atlaspack/fs',
-            message: 'Expose VCS timing metrics on getEventsSince',
-            meta: {
-              trackableEvent: 'vcs_timing_metrics-getEventsSince',
-              dirtyFilesExecutionTime:
-                vcsContent.vcsState?.dirtyFilesExecutionTime,
-              yarnStatesExecutionTime:
-                vcsContent.vcsState?.yarnStatesExecutionTime,
-            },
-          });
-        }
-
-        return vcsContent;
+        return JSON.parse(snapshotFileContent);
       },
     );
     let watcherEventsSince = [];
@@ -183,12 +163,10 @@ export class NodeVCSAwareFS extends NodeFS {
 
       logger.info({
         origin: '@atlaspack/fs',
-        message: 'Expose VCS timing metrics on writeSnapshot',
+        message: 'Expose VCS timing metrics',
         meta: {
-          trackableEvent: 'vcs_timing_metrics-writeSnapshot',
-          // $FlowFixMe[prop-missing] Rust type includes these properties
+          trackableEvent: 'vcs_timing_metrics',
           dirtyFilesExecutionTime: vcsState?.dirtyFilesExecutionTime,
-          // $FlowFixMe[prop-missing] Rust type includes these properties
           yarnStatesExecutionTime: vcsState?.yarnStatesExecutionTime,
         },
       });

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -372,6 +372,8 @@ export interface VCSState {
   // Files that have been modified since the last commit
   dirtyFiles: VCSFile[];
   yarnStates: YarnState[];
+  dirtyFilesExecutionTime: number;
+  yarnStatesExecutionTime: number;
 }
 
 declare export function getVcsStateSnapshot(


### PR DESCRIPTION
Previous PRs introduced timings, but didn't expose the data:
- [PR](https://github.com/atlassian-labs/atlaspack/pull/344) with timing for dirty hashes listings: `dirty_files_execution_time`
- [PR](https://github.com/atlassian-labs/atlaspack/pull/346/files) with timing for yarn state scanning: `yarn_states_execution_time`

This PR exposes the timings info so that we can report them in dev metrics.

Tested locally:
![Screenshot 2025-05-23 at 11 46 23 am](https://github.com/user-attachments/assets/0d0ccc05-66d2-4a18-9dda-d981424d7976)
