### PR TITLE
Add shared bundle merging feature 

### DIFF
--- a/.changeset/cold-moles-return.md
+++ b/.changeset/cold-moles-return.md
@@ -1,0 +1,21 @@
+---
+'@atlaspack/bundler-default': minor
+---
+
+Add `sharedBundleMergeThreshold` config option
+
+In apps with lots of dynamic imports, many shared bundles are often removed
+from the output to prevent an overload in network requests according to the
+`maxParallelRequests` config. In these cases, setting `sharedBundleMergeThreshold` can
+merge shared bundles with a high overlap in their source bundles (bundles that share the bundle).
+This config trades-off potential overfetching to reduce asset duplication.
+
+The following config would merge shared bundles that have a 75% or higher overlap in source bundles.
+
+```json
+{
+  "@atlaspack/bundler-default": {
+    "sharedBundleMergeThreshold": 0.75
+  }
+}
+```

--- a/packages/bundlers/default/src/bundleMerge.js
+++ b/packages/bundlers/default/src/bundleMerge.js
@@ -1,0 +1,96 @@
+// @flow strict-local
+
+import invariant from 'assert';
+import type {NodeId} from '@atlaspack/graph';
+import type {Bundle, IdealBundleGraph} from './idealGraph';
+import {ContentGraph} from '@atlaspack/graph';
+
+// Returns a decimal showing the proportion source bundles are common to
+// both bundles versus the total number of source bundles.
+function scoreBundleMerge(bundleA: Bundle, bundleB: Bundle): number {
+  let sharedSourceBundles = 0;
+  let allSourceBundles = new Set([
+    ...bundleA.sourceBundles,
+    ...bundleB.sourceBundles,
+  ]);
+
+  for (let bundle of bundleB.sourceBundles) {
+    if (bundleA.sourceBundles.has(bundle)) {
+      sharedSourceBundles++;
+    }
+  }
+
+  return sharedSourceBundles / allSourceBundles.size;
+}
+
+export function findMergeCandidates(
+  bundleGraph: IdealBundleGraph,
+  bundles: Array<NodeId>,
+  threshold: number,
+) {
+  console.time('findMergeCandidates');
+  let graph = new ContentGraph<NodeId>();
+  let seen = new Set<string>();
+  let candidates = new Set<NodeId>();
+
+  // Build graph of clustered merge candidates
+  for (let bundleId of bundles) {
+    let bundle = bundleGraph.getNode(bundleId);
+    invariant(bundle && bundle !== 'root');
+
+    for (let otherBundleId of bundles) {
+      if (bundleId === otherBundleId) {
+        continue;
+      }
+
+      let key = [bundleId, otherBundleId].sort().join(':');
+
+      if (seen.has(key)) {
+        continue;
+      }
+      seen.add(key);
+
+      let otherBundle = bundleGraph.getNode(otherBundleId);
+      invariant(otherBundle && otherBundle !== 'root');
+
+      let score = scoreBundleMerge(bundle, otherBundle);
+
+      if (score >= threshold) {
+        let bundleNode = graph.addNodeByContentKeyIfNeeded(
+          bundleId.toString(),
+          bundleId,
+        );
+        let otherBundleNode = graph.addNodeByContentKeyIfNeeded(
+          otherBundleId.toString(),
+          otherBundleId,
+        );
+
+        // Add edge in both directions
+        graph.addEdge(bundleNode, otherBundleNode);
+        graph.addEdge(otherBundleNode, bundleNode);
+
+        candidates.add(bundleNode);
+        candidates.add(otherBundleNode);
+      }
+    }
+  }
+
+  const clusters = [];
+
+  for (let candidate of candidates) {
+    let cluster = [];
+
+    graph.traverse((nodeId) => {
+      cluster.push(graph.getNode(nodeId));
+      // Remove node from candidates as it has already been processed
+      candidates.delete(nodeId);
+    }, candidate);
+
+    clusters.push(cluster);
+  }
+
+  clusters.sort((a, b) => b.length - a.length);
+
+  console.timeEnd('findMergeCandidates');
+  console.log('Clusters', clusters);
+}

--- a/packages/bundlers/default/src/bundlerConfig.js
+++ b/packages/bundlers/default/src/bundlerConfig.js
@@ -28,6 +28,7 @@ type BaseBundlerConfig = {|
   disableSharedBundles?: boolean,
   manualSharedBundles?: ManualSharedBundles,
   loadConditionalBundlesInParallel?: boolean,
+  sharedBundleMergeThreshold?: number,
 |};
 
 type BundlerConfig = {|
@@ -42,6 +43,7 @@ export type ResolvedBundlerConfig = {|
   disableSharedBundles: boolean,
   manualSharedBundles: ManualSharedBundles,
   loadConditionalBundlesInParallel?: boolean,
+  sharedBundleMergeThreshold: number,
 |};
 
 function resolveModeConfig(
@@ -76,6 +78,7 @@ const HTTP_OPTIONS = {
     minBundleSize: 30000,
     maxParallelRequests: 6,
     disableSharedBundles: false,
+    sharedBundleMergeThreshold: 1,
   },
   '2': {
     minBundles: 1,
@@ -83,6 +86,7 @@ const HTTP_OPTIONS = {
     minBundleSize: 20000,
     maxParallelRequests: 25,
     disableSharedBundles: false,
+    sharedBundleMergeThreshold: 1,
   },
 };
 
@@ -138,6 +142,9 @@ const CONFIG_SCHEMA: SchemaEntity = {
     },
     loadConditionalBundlesInParallel: {
       type: 'boolean',
+    },
+    sharedBundleMergeThreshold: {
+      type: 'number',
     },
   },
   additionalProperties: false,
@@ -224,6 +231,9 @@ export async function loadBundlerConfig(
   return {
     minBundles: modeConfig.minBundles ?? defaults.minBundles,
     minBundleSize: modeConfig.minBundleSize ?? defaults.minBundleSize,
+    sharedBundleMergeThreshold:
+      modeConfig.sharedBundleMergeThreshold ??
+      defaults.sharedBundleMergeThreshold,
     maxParallelRequests:
       modeConfig.maxParallelRequests ?? defaults.maxParallelRequests,
     projectRoot: options.projectRoot,

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -68,7 +68,7 @@ export const idealBundleGraphEdges = Object.freeze({
   conditional: 2,
 });
 
-type IdealBundleGraph = Graph<
+export type IdealBundleGraph = Graph<
   Bundle | 'root',
   $Values<typeof idealBundleGraphEdges>,
 >;
@@ -1129,6 +1129,12 @@ export function createIdealGraph(
     }
   }
 
+  // Step merge shared bundles that meet the overlap threshold
+  // This step is skipped by default as the threshold defaults to 1
+  if (config.sharedBundleMergeThreshold < 1) {
+    mergeOverlapBundles();
+  }
+
   // Step Merge Share Bundles: Merge any shared bundles under the minimum bundle size back into
   // their source bundles, and remove the bundle.
   // We should include "bundle reuse" as shared bundles that may be removed but the bundle itself would have to be retained
@@ -1142,12 +1148,6 @@ export function createIdealGraph(
     ) {
       removeBundle(bundleGraph, bundleNodeId, assetReference);
     }
-  }
-
-  // Step merge shared bundles that meet the overlap threshold
-  // This step is skipped by default as the threshold defaults to 1
-  if (config.sharedBundleMergeThreshold < 1) {
-    mergeOverlapBundles();
   }
 
   // Step Remove Shared Bundles: Remove shared bundles from bundle groups that hit the parallel request limit.

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -24,6 +24,7 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 
 import type {ResolvedBundlerConfig} from './bundlerConfig';
+import {findMergeCandidates} from './bundleMerge';
 
 /* BundleRoot - An asset that is the main entry of a Bundle. */
 type BundleRoot = Asset;
@@ -67,7 +68,7 @@ export const idealBundleGraphEdges = Object.freeze({
   conditional: 2,
 });
 
-type IdealBundleGraph = Graph<
+export type IdealBundleGraph = Graph<
   Bundle | 'root',
   $Values<typeof idealBundleGraphEdges>,
 >;
@@ -1228,6 +1229,8 @@ export function createIdealGraph(
     console.time('BundleOverlapScores');
     calculateAllOverlapScores();
     console.timeEnd('BundleOverlapScores');
+
+    findMergeCandidates(bundleGraph, Array.from(sharedBundles), 0.9);
 
     for (let bundleGroupId of bundleGraph.getNodeIdsConnectedFrom(rootNodeId)) {
       // Find shared bundles in this bundle group.


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

Add `sharedBundleMergeThreshold` config option

In apps with lots of dynamic imports, many shared bundles are often removed
from the output to prevent an overload in network requests according to the
`maxParallelRequests` config. In these cases, setting `sharedBundleMergeThreshold` can
merge shared bundles with a high overlap in their source bundles (bundles that share the bundle).
This config trades-off potential overfetching to reduce asset duplication.

The following config would merge shared bundles that have a 75% or higher overlap in source bundles.

```json
{
  "@atlaspack/bundler-default": {
    "sharedBundleMergeThreshold": 0.75
  }
}
```

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
