### PR TITLE
Remove left over nullthrows numbers used for troubleshooting

### DIFF
--- a/.changeset/rare-countries-chew.md
+++ b/.changeset/rare-countries-chew.md
@@ -1,5 +1,0 @@
----
-'@atlaspack/bundler-default': patch
----
-
-Removed some unhelpful identifiers from internal error conditions

--- a/.changeset/rare-countries-chew.md
+++ b/.changeset/rare-countries-chew.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/bundler-default': patch
+---
+
+Removed some unhelpful identifiers from internal error conditions

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -1262,11 +1262,8 @@ export function createIdealGraph(
     bundleToRemoveId: NodeId,
     assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
   ) {
-    let bundleToKeep = nullthrows(bundleGraph.getNode(bundleToKeepId), '18');
-    let bundleToRemove = nullthrows(
-      bundleGraph.getNode(bundleToRemoveId),
-      '19',
-    );
+    let bundleToKeep = nullthrows(bundleGraph.getNode(bundleToKeepId));
+    let bundleToRemove = nullthrows(bundleGraph.getNode(bundleToRemoveId));
     invariant(bundleToKeep !== 'root' && bundleToRemove !== 'root');
     for (let asset of bundleToRemove.assets) {
       bundleToKeep.assets.add(asset);


### PR DESCRIPTION
## Motivation

When we were [adding shared bundle merging](https://github.com/atlassian-labs/atlaspack/pull/535), we were getting some nullthrows errors in the build but it wasn't clear where from. We added numbers to each instance of nullthrows, but forgot to take a few of them out.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Tweaks to unreleased code
