### PR TITLE
Add database compaction command

### DIFF
--- a/.changeset/clever-dolls-type.md
+++ b/.changeset/clever-dolls-type.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/core': minor
+'@atlaspack/rust': minor
+---
+
+Add database compaction debug command

--- a/crates/lmdb-js-lite/src/lib.rs
+++ b/crates/lmdb-js-lite/src/lib.rs
@@ -38,6 +38,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Debug;
+use std::path::Path;
 use std::sync::LazyLock;
 use std::sync::{Arc, Mutex, Weak};
 
@@ -396,6 +397,21 @@ impl LMDB {
   #[napi]
   pub fn close(&mut self) {
     self.inner = None;
+  }
+
+  /// Compact the database to the target path
+  #[napi]
+  pub fn compact(&self, target_path: String) -> napi::Result<()> {
+    let database_handle = self.get_database_napi()?;
+    database_handle
+      .database()
+      .compact(Path::new(&target_path))
+      .map_err(|err| {
+        napi::Error::from_reason(format!(
+          "[napi] Failed to compact database at {target_path}: {err:?}"
+        ))
+      })?;
+    Ok(())
   }
 }
 

--- a/crates/lmdb-js-lite/src/writer.rs
+++ b/crates/lmdb-js-lite/src/writer.rs
@@ -403,6 +403,15 @@ impl DatabaseWriter {
   pub fn static_read_txn(&self) -> heed::Result<RoTxn<'static>> {
     self.environment.clone().static_read_txn()
   }
+
+  /// Compact the database to the target path
+  pub fn compact(&self, target_path: &Path) -> Result<()> {
+    self
+      .environment
+      .copy_to_file(target_path, heed::CompactionOption::Enabled)?;
+
+    Ok(())
+  }
 }
 
 #[cfg(test)]

--- a/crates/node-bindings/src/lmdb.rs
+++ b/crates/node-bindings/src/lmdb.rs
@@ -2,6 +2,7 @@ use napi::bindgen_prelude::Buffer;
 use napi::bindgen_prelude::Env;
 use napi::JsUnknown;
 use napi_derive::napi;
+
 #[napi]
 pub struct LMDB {
   inner: lmdb_js_lite::LMDB,
@@ -88,5 +89,10 @@ impl LMDB {
   #[napi]
   pub fn close(&mut self) {
     self.inner.close()
+  }
+
+  #[napi]
+  pub fn compact(&self, target_path: String) -> napi::Result<()> {
+    self.inner.compact(target_path)
   }
 }

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -28,7 +28,8 @@
     "@atlaspack/fs": "2.14.4",
     "@atlaspack/logger": "2.14.4",
     "@atlaspack/rust": "3.2.0",
-    "@atlaspack/utils": "2.14.4"
+    "@atlaspack/utils": "2.14.4",
+    "ncp": "^2.0.0"
   },
   "devDependencies": {
     "idb": "^5.0.8"

--- a/packages/core/cache/test/LMDBLiteCache.test.js
+++ b/packages/core/cache/test/LMDBLiteCache.test.js
@@ -51,4 +51,19 @@ describe('LMDBLiteCache', () => {
     const keys = cache.keys();
     assert.deepEqual(Array.from(keys), ['key1', 'key2']);
   });
+
+  it('can compact databases', async () => {
+    cache = new LMDBLiteCache(path.join(cacheDir, 'compact_test'));
+    await cache.ensure();
+    await cache.setBlob('key1', Buffer.from(serialize({value: 42})));
+    await cache.setBlob('key2', Buffer.from(serialize({value: 43})));
+    await cache.compact(path.join(cacheDir, 'compact_test_compacted'));
+
+    cache.getNativeRef().close();
+
+    cache = new LMDBLiteCache(path.join(cacheDir, 'compact_test_compacted'));
+    await cache.ensure();
+    const keys = cache.keys();
+    assert.deepEqual(Array.from(keys), ['key1', 'key2']);
+  });
 });

--- a/packages/core/cli/src/makeDebugCommand.js
+++ b/packages/core/cli/src/makeDebugCommand.js
@@ -83,5 +83,23 @@ export function makeDebugCommand(): commander$Command {
     });
   applyOptions(buildAssetGraph, commonOptions);
 
+  const compactCache = debug
+    .command('compact-cache')
+    .description('Compact the cache')
+    .action(async (args: string[], opts: Options, command: CommandExt) => {
+      const atlaspack = await getInstance(args, opts, command);
+      try {
+        await atlaspack.unstable_compactCache();
+        logger.info({
+          message: 'Done compacting cache',
+          origin: '@atlaspack/cli',
+        });
+        process.exit(0);
+      } catch (err) {
+        handleUncaughtException(err);
+      }
+    });
+  applyOptions(compactCache, commonOptions);
+
   return debug;
 }

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -639,6 +639,18 @@ export default class Atlaspack {
     return result;
   }
 
+  /**
+   * Copy the cache to a new directory and compact it.
+   */
+  async unstable_compactCache(): Promise<void> {
+    const cache = nullthrows(this.#resolvedOptions).cache;
+    if (cache instanceof LMDBLiteCache) {
+      await cache.compact('parcel-cache-compacted');
+    } else {
+      throw new Error('Cache is not an LMDBLiteCache');
+    }
+  }
+
   async unstable_transform(
     options: AtlaspackTransformOptions,
   ): Promise<Array<Asset>> {

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -340,6 +340,7 @@ declare export class Lmdb {
   commitWriteTransaction(): Promise<void>;
   delete(key: string): Promise<void>;
   close(): void;
+  compact(targetPath: string): void;
 }
 
 export interface InlineRequiresOptimizerInput {


### PR DESCRIPTION
Adds a command to copy over a database compacting free pages.

This should make the database files more space efficient.

Test Plan: yarn test:unit
