### PR TITLE
Prevent persisting credentials in Changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,6 +181,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/create-github-app-token@v2
         id: app-token
         with:


### PR DESCRIPTION
Although we fixed CI not running when Version Packages get opened, it seems to still happen when Changesets makes an update to an existing Version Packages PR.

This is apparently a known issue, with a recommended fix, which has been added here.

https://github.com/changesets/action/issues/70#issuecomment-813015134

[no-changeset]: Updating workflow
