### PR TITLE
Packager optimisation around getting referenced assets

### DIFF
--- a/packages/core/core/src/BundleGraph.js
+++ b/packages/core/core/src/BundleGraph.js
@@ -1284,6 +1284,143 @@ export default class BundleGraph {
     );
   }
 
+  getReferencedAssets(
+    bundle: Bundle,
+    cache: Map<Bundle, Set<string>>,
+  ): Set<string> {
+    const result = new Set();
+
+    const siblingBundles = new Set(
+      this.getBundleGroupsContainingBundle(bundle).flatMap((bundleGroup) =>
+        this.getBundlesInBundleGroup(bundleGroup, {includeInline: true}),
+      ),
+    );
+
+    const candidates = new Map();
+
+    this.traverseAssets(bundle, (asset) => {
+      // If the asset is available in multiple bundles in the same target, it's referenced.
+      const bundlesWithAsset = this.getBundlesWithAsset(asset);
+      if (
+        bundlesWithAsset.filter(
+          (b) =>
+            b.target.name === bundle.target.name &&
+            b.target.distDir === bundle.target.distDir,
+        ).length > 1
+      ) {
+        result.add(asset.id);
+        return;
+      }
+
+      const assetNodeId = nullthrows(
+        this._graph.getNodeIdByContentKey(asset.id),
+      );
+
+      if (
+        this._graph
+          .getNodeIdsConnectedTo(assetNodeId, bundleGraphEdgeTypes.references)
+          .map((id) => this._graph.getNode(id))
+          .some(
+            (node) =>
+              node?.type === 'dependency' &&
+              (node.value.priority === Priority.lazy ||
+                node.value.priority === Priority.conditional) &&
+              node.value.specifierType !== SpecifierType.url,
+          )
+      ) {
+        // If this asset is referenced by any async dependency, it's referenced.
+        result.add(asset.id);
+        return;
+      }
+
+      const dependencies = this._graph
+        .getNodeIdsConnectedTo(assetNodeId)
+        .map((id) => nullthrows(this._graph.getNode(id)))
+        .filter((node) => node.type === 'dependency')
+        .map((node) => {
+          invariant(node.type === 'dependency');
+          return node.value;
+        });
+
+      candidates.set(asset.id, {
+        asset,
+        dependencies,
+        bundlesWithAsset,
+      });
+    });
+
+    const visitedBundles: Set<Bundle> = new Set();
+
+    // Check if any of this bundle's descendants, referencers, bundles referenced
+    // by referencers, or descendants of its referencers use the asset without
+    // an explicit reference edge. This can happen if e.g. the asset has been
+    // deduplicated.
+    [...siblingBundles].forEach((referencer) => {
+      this.traverseBundles((descendant, _, actions) => {
+        if (descendant.id === bundle.id) {
+          return;
+        }
+
+        if (visitedBundles.has(descendant)) {
+          actions.skipChildren();
+          return;
+        }
+
+        visitedBundles.add(descendant);
+
+        if (
+          descendant.type !== bundle.type ||
+          descendant.env.context !== bundle.env.context
+        ) {
+          actions.skipChildren();
+          return;
+        }
+
+        for (let assetId of this.getBundleDirectReferences(descendant, cache)) {
+          if (candidates.has(assetId)) {
+            result.add(assetId);
+          }
+        }
+      }, referencer);
+    });
+
+    return result;
+  }
+
+  getBundleDirectReferences(
+    bundle: Bundle,
+    cache: Map<Bundle, Set<string>>,
+  ): Set<string> {
+    const cachedResult = cache.get(bundle);
+    if (cachedResult != null) {
+      return cachedResult;
+    }
+
+    const directReferences = new Set();
+    const bundleAssets = this.getBundleContainedAssets(bundle);
+    const bundleDependencies = this.getBundleContainedDependencies(bundle);
+
+    for (const dependency of bundleDependencies) {
+      this._graph.forEachNodeIdConnectedFrom(
+        this._graph.getNodeIdByContentKey(dependency),
+        (assetId) => {
+          const asset = nullthrows(this._graph.getNode(assetId));
+          if (asset.type !== 'asset') {
+            return;
+          }
+
+          if (!bundleAssets.has(asset.id)) {
+            directReferences.add(asset.id);
+          }
+        },
+      );
+    }
+
+    cache.set(bundle, directReferences);
+
+    return directReferences;
+  }
+
   isAssetReferenced(bundle: Bundle, asset: Asset): boolean {
     // If the asset is available in multiple bundles in the same target, it's referenced.
     if (
@@ -1813,6 +1950,36 @@ export default class BundleGraph {
       dependencyNodeId,
       bundleGraphEdgeTypes.contains,
     );
+  }
+
+  getBundleContainedAssets(bundle: Bundle): Set<string> {
+    const assets = new Set();
+    this._graph.forEachNodeIdConnectedFrom(
+      this._graph.getNodeIdByContentKey(bundle.id),
+      (nodeId) => {
+        const node = nullthrows(this._graph.getNode(nodeId));
+        if (node.type === 'asset') {
+          assets.add(node.value.id);
+        }
+      },
+      bundleGraphEdgeTypes.contains,
+    );
+    return assets;
+  }
+
+  getBundleContainedDependencies(bundle: Bundle): Set<string> {
+    const dependencies = new Set();
+    this._graph.forEachNodeIdConnectedFrom(
+      this._graph.getNodeIdByContentKey(bundle.id),
+      (nodeId) => {
+        const node = nullthrows(this._graph.getNode(nodeId));
+        if (node.type === 'dependency') {
+          dependencies.add(node.value.id);
+        }
+      },
+      bundleGraphEdgeTypes.contains,
+    );
+    return dependencies;
   }
 
   filteredTraverse<TValue, TContext>(

--- a/packages/core/core/src/public/BundleGraph.js
+++ b/packages/core/core/src/public/BundleGraph.js
@@ -185,6 +185,16 @@ export default class BundleGraph<TBundle: IBundle>
     );
   }
 
+  getReferencedAssets(
+    bundle: IBundle,
+    cache: Map<Bundle, Set<string>>,
+  ): Set<string> {
+    return this.#graph.getReferencedAssets(
+      bundleToInternalBundle(bundle),
+      cache,
+    );
+  }
+
   hasParentBundleOfType(bundle: IBundle, type: string): boolean {
     return this.#graph.hasParentBundleOfType(
       bundleToInternalBundle(bundle),

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -1614,6 +1614,10 @@ export interface BundleGraph<TBundle: Bundle> {
   isAssetReachableFromBundle(asset: Asset, bundle: Bundle): boolean;
   /** Returns whether an asset is referenced outside the given bundle. */
   isAssetReferenced(bundle: Bundle, asset: Asset): boolean;
+  getReferencedAssets(
+    bundle: Bundle,
+    cache: Map<Bundle, Set<string>>,
+  ): Set<string>;
   /**
    * Resolves the export `symbol` of `asset` to the source,
    * stopping at the first asset after leaving `bundle`.


### PR DESCRIPTION
When running packaging, up to roughly 30% of the time on some threads is spent
on `ScopeHoistingPackager::loadAssets`.

In this function we are trying to determine, for each asset in a bundle,
whether it is "referenced" by the bundle.

A referenced asset is an asset that is part of the bundle's sub-tree asset
graph, but does not have a "contains" edge against the bundle.

The current algorithm for determining this will:

* For each bundle being packaged
  * For each asset
    * Check if asset is referenced by bundle
      * Check bundle edges against this asset
      * Get all bundles in this bundle's bundle group
      * Recursive - Traverse the bundle graph starting at each of these
        * Check candidate bundle edges against this asset

On certain bundles in an application (I suppose root bundles), this takes up to
2 minutes (out of 5min total runtime on my machine for all 6k bundles).

In this commit, I am prototyping a few changes to this. First, we do
reference checking in bulk.

* For each bundle being packaged
  * Before starting `loadAssets`
    * Build Set of all referenced assets for this bundle
      * Get all candidate assets to check
      * Get all bundles in this bundle's bundle group
      * Traverse the bundle graph starting at each of these
        * List directly referenced assets from this bundle (not recursive)
        * Cache this list for all other packaging in the build
      * Check if any directly referenced asset was a candidate
  * For each asset in bundle
    * Check if asset is in Set built on previous step

I am still measuring / validating my changes.

Test Plan: pending
