### PR TITLE
Make changesets run after canary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -173,9 +173,7 @@ jobs:
   build-and-release-changesets:
     name: Build and release Changesets
     if: github.ref_name == 'main'
-    needs:
-      - build-native-linux
-      - build-native-macos
+    needs: build-and-release
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

Originally I had changesets and canary release running simultaneously, since they have nothing to do with each other.

Unfortunately it seems that the NPM backend doesn't like this, and the builds fail when they try to release. Re-running the process works fine.

## Changes

In the near future we'll get rid of canary and dev releases (in favour of [Changesets Snapshots](https://github.com/changesets/changesets/blob/main/docs/snapshot-releases.md)), and so this won't be a problem anymore, but for now the easiest thing is to just make them run sequentially.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[no-changeset]: Updating workflow
