### PR TITLE
Resovle bundler config from CWD up

### DIFF
--- a/.changeset/mean-numbers-mate.md
+++ b/.changeset/mean-numbers-mate.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/feature-flags': minor
+'@atlaspack/bundler-default': minor
+---
+
+Add a feature flag for resolving the configuration for `@atlaspack/bundler-default` from CWD, rather than exclusively from the project root.

--- a/packages/bundlers/default/src/bundlerConfig.js
+++ b/packages/bundlers/default/src/bundlerConfig.js
@@ -7,6 +7,7 @@ import type {
   BuildMode,
   PluginLogger,
 } from '@atlaspack/types';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 import {type SchemaEntity, validateSchema} from '@atlaspack/utils';
 import invariant from 'assert';
 
@@ -155,9 +156,17 @@ export async function loadBundlerConfig(
   options: PluginOptions,
   logger: PluginLogger,
 ): Promise<ResolvedBundlerConfig> {
-  let conf = await config.getConfig<BundlerConfig>([], {
-    packageKey: '@atlaspack/bundler-default',
-  });
+  let conf;
+
+  if (getFeatureFlag('resolveBundlerConfigFromCwd')) {
+    conf = await config.getConfigFrom(`${process.cwd()}/index`, [], {
+      packageKey: '@atlaspack/bundler-default',
+    });
+  } else {
+    conf = await config.getConfig<BundlerConfig>([], {
+      packageKey: '@atlaspack/bundler-default',
+    });
+  }
 
   if (!conf) {
     const modDefault = {

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -24,6 +24,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   inlineStringReplacementPerf: false,
   conditionalBundlingAsyncRuntime: false,
   conditionalBundlingReporterDuplicateFix: false,
+  resolveBundlerConfigFromCwd: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -78,6 +78,10 @@ export type FeatureFlags = {|
    * Fix a bug where the conditional manifest reporter would report and write the same manifest multiple times
    */
   conditionalBundlingReporterDuplicateFix: boolean,
+  /**
+   * Enable resolution of bundler config starting from the CWD
+   */
+  resolveBundlerConfigFromCwd: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =


### PR DESCRIPTION
## Motivation

Some of the products that consume Atlaspack have multiple apps in one monorepo, which each require their own configuration.

Ordinarily Atlaspack would look only for a package.json at the project root to get the config, but this ties everything in the monorepo to a single set of config.

Ideally we'd fix this with the config overhaul, but that's a substantial piece of work, and we need to get this specific issue fixed before we can roll out APVM.

## Changes

As an interim measure, the search for config files will now start at the CWD. For most products the CWD and project root will be the same, but for the sub-apps model described above, which use `yarn workspace ...` to run their commands, this will allow individualised config that lives with the app.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
