### PR TITLE
Add verbose logging of request invalidation

### DIFF
--- a/.changeset/loud-maps-punch.md
+++ b/.changeset/loud-maps-punch.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Log request tracker invalidation counts on start-up

--- a/.changeset/loud-maps-punch.md
+++ b/.changeset/loud-maps-punch.md
@@ -1,5 +1,6 @@
 ---
 '@atlaspack/core': patch
+'@atlaspack/feature-flags': patch
 ---
 
 Log request tracker invalidation counts on start-up

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -1887,9 +1887,15 @@ type InvalidationStats = {|
    * Percentage of nodes that have been invalidated
    */
   nodeInvalidationRatio: number,
+  /**
+   * Details for each invalidation type
+   */
   invalidations: InvalidationFnStats[],
 |};
 
+/**
+ * Information about a certain cache invalidation type.
+ */
 type InvalidationFnStats = {|
   /**
    * Invalidation type, one of:

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -446,32 +446,44 @@ export class RequestGraph extends ContentGraph<
     this.removeCachedRequestChunkForNode(nodeId);
   }
 
-  invalidateUnpredictableNodes(): number {
-    const currentInvalidatedNodes = this.invalidNodeIds.size;
+  /**
+   * Nodes that are invalidated on start-up, such as JavaScript babel configuration files which are
+   * imported when the build kicks-off and might doing arbitrary work such as reading from the file
+   * system.
+   */
+  invalidateUnpredictableNodes() {
     for (let nodeId of this.unpredicatableNodeIds) {
       let node = nullthrows(this.getNode(nodeId));
       invariant(node.type !== FILE && node.type !== GLOB);
       this.invalidateNode(nodeId, STARTUP);
     }
-    return this.invalidNodeIds.size - currentInvalidatedNodes;
   }
 
-  invalidateOnBuildNodes(): number {
-    const currentInvalidatedNodes = this.invalidNodeIds.size;
+  /**
+   * Effectively uncacheable nodes.
+   */
+  invalidateOnBuildNodes() {
     for (let nodeId of this.invalidateOnBuildNodeIds) {
       let node = nullthrows(this.getNode(nodeId));
       invariant(node.type !== FILE && node.type !== GLOB);
       this.invalidateNode(nodeId, STARTUP);
     }
-    return this.invalidNodeIds.size - currentInvalidatedNodes;
   }
 
-  invalidateEnvNodes(env: EnvMap): number {
-    const currentInvalidatedNodes = this.invalidNodeIds.size;
+  /**
+   * Nodes invalidated by environment changes, corresponds to `env: ...` inputs.
+   */
+  invalidateEnvNodes(env: EnvMap): string[] {
+    const invalidatedKeys = [];
+
     for (let nodeId of this.envNodeIds) {
       let node = nullthrows(this.getNode(nodeId));
       invariant(node.type === ENV);
-      if (env[keyFromEnvContentKey(node.id)] !== node.value) {
+
+      const key = keyFromEnvContentKey(node.id);
+      if (env[key] !== node.value) {
+        invalidatedKeys.push(key);
+
         let parentNodes = this.getNodeIdsConnectedTo(
           nodeId,
           requestGraphEdgeTypes.invalidated_by_update,
@@ -481,17 +493,23 @@ export class RequestGraph extends ContentGraph<
         }
       }
     }
-    return this.invalidNodeIds.size - currentInvalidatedNodes;
+
+    return invalidatedKeys;
   }
 
-  invalidateOptionNodes(options: AtlaspackOptions): number {
-    const currentInvalidatedNodes = this.invalidNodeIds.size;
+  /**
+   * Nodes invalidated by option changes.
+   */
+  invalidateOptionNodes(options: AtlaspackOptions): string[] {
+    const invalidatedKeys = [];
+
     for (let nodeId of this.optionNodeIds) {
       let node = nullthrows(this.getNode(nodeId));
       invariant(node.type === OPTION);
-      if (
-        hashFromOption(options[keyFromOptionContentKey(node.id)]) !== node.hash
-      ) {
+      const key = keyFromOptionContentKey(node.id);
+
+      if (hashFromOption(options[key]) !== node.hash) {
+        invalidatedKeys.push(key);
         let parentNodes = this.getNodeIdsConnectedTo(
           nodeId,
           requestGraphEdgeTypes.invalidated_by_update,
@@ -501,7 +519,8 @@ export class RequestGraph extends ContentGraph<
         }
       }
     }
-    return this.invalidNodeIds.size - currentInvalidatedNodes;
+
+    return invalidatedKeys;
   }
 
   invalidateOnConfigKeyChange(
@@ -1735,12 +1754,23 @@ async function loadRequestGraph(options): Async<RequestGraph> {
   const snapshotKey = `snapshot-${cacheKey}`;
   const snapshotPath = path.join(options.cacheDir, snapshotKey + '.txt');
 
+  const commonMeta = {
+    cacheKey,
+    snapshotKey,
+    cacheKeyOptions: {
+      version: ATLASPACK_VERSION,
+      entries: options.entries,
+      mode: options.mode,
+      shouldBuildLazily: options.shouldBuildLazily,
+      watchBackend: options.watchBackend,
+    },
+  };
+
   logger.verbose({
     origin: '@atlaspack/core',
     message: 'Loading request graph',
     meta: {
-      cacheKey,
-      snapshotKey,
+      ...commonMeta,
     },
   });
 
@@ -1775,44 +1805,26 @@ async function loadRequestGraph(options): Async<RequestGraph> {
         origin: '@atlaspack/core',
         message: `File system event count: ${events.length}`,
         meta: {
+          ...commonMeta,
           trackableEvent: 'watcher_events_count',
           watcherEventCount: events.length,
           duration: Date.now() - startTime,
         },
       });
 
-      const invalidationCounts = {
-        unpredictable: 0,
-        onBuild: 0,
-        env: 0,
-        option: 0,
-        fsEvents: 0,
-      };
-
-      invalidationCounts.unpredictable =
-        requestGraph.invalidateUnpredictableNodes();
-      invalidationCounts.onBuild = requestGraph.invalidateOnBuildNodes();
-      invalidationCounts.env = requestGraph.invalidateEnvNodes(options.env);
-      invalidationCounts.option = requestGraph.invalidateOptionNodes(options);
-
-      const invalidationCountBeforeFsEvents = requestGraph.invalidNodeIds.size;
-      await requestGraph.respondToFSEvents(
-        options.unstableFileInvalidations || events,
+      const invalidationStats = await invalidateRequestGraph(
+        requestGraph,
         options,
-        10000,
-        true,
+        events,
       );
-      invalidationCounts.fsEvents =
-        requestGraph.invalidNodeIds.size - invalidationCountBeforeFsEvents;
 
       logger.verbose({
         origin: '@atlaspack/core',
         message: 'Request track loaded from cache',
         meta: {
-          cacheKey,
-          snapshotKey,
+          ...commonMeta,
           trackableEvent: 'request_tracker_cache_key_hit',
-          invalidationCounts,
+          invalidationStats,
         },
       });
 
@@ -1832,12 +1844,112 @@ async function loadRequestGraph(options): Async<RequestGraph> {
     message:
       'Cache entry for request tracker was not found, initializing a clean cache.',
     meta: {
-      cacheKey,
-      snapshotKey,
+      ...commonMeta,
       trackableEvent: 'request_tracker_cache_key_miss',
     },
   });
   return new RequestGraph();
+}
+
+/**
+ * A wrapper around an invalidation type / method
+ */
+type InvalidationFn = {|
+  key: string,
+  fn: () => string[] | void | Promise<void>,
+|};
+
+type InvalidationStats = {|
+  invalidations: InvalidationFnStats[],
+|};
+
+type InvalidationFnStats = {|
+  /**
+   * Invalidation type, one of:
+   *
+   * - unpredictable
+   * - onBuild
+   * - env
+   * - option
+   * - fsEvents
+   */
+  key: string,
+  /**
+   * Number of invalidated nodes coming from this invalidation type.
+   */
+  count: number,
+  /**
+   * If this is a env or option invalidation, this key will contain the list of changed values.
+   */
+  changes: null | string[],
+|};
+
+/**
+ * Respond to unpredictable, build, environment changes, option changes and file-system events
+ * invalidating RequestGraph nodes.
+ *
+ * Returns the count of nodes invalidated by each invalidation type.
+ */
+async function invalidateRequestGraph(
+  requestGraph: RequestGraph,
+  options: AtlaspackOptions,
+  events: Event[],
+): Promise<InvalidationStats> {
+  const invalidationFns: InvalidationFn[] = [
+    {
+      key: 'unpredictable',
+      fn: () => requestGraph.invalidateUnpredictableNodes(),
+    },
+    {
+      key: 'onBuild',
+      fn: () => requestGraph.invalidateOnBuildNodes(),
+    },
+    {
+      key: 'env',
+      fn: () => requestGraph.invalidateEnvNodes(options.env),
+    },
+    {
+      key: 'option',
+      fn: () => requestGraph.invalidateOptionNodes(options),
+    },
+    {
+      key: 'fsEvents',
+      fn: async () => {
+        await requestGraph.respondToFSEvents(
+          options.unstableFileInvalidations || events,
+          options,
+          10000,
+          true,
+        );
+      },
+    },
+  ];
+
+  const invalidations = [];
+  for (const invalidation of invalidationFns) {
+    invalidations.push(await runInvalidation(requestGraph, invalidation));
+  }
+
+  return {invalidations};
+}
+
+/**
+ * Runs an invalidation function and reports metrics.
+ */
+async function runInvalidation(
+  requestGraph: RequestGraph,
+  invalidationFn: InvalidationFn,
+): Promise<InvalidationFnStats> {
+  const startInvalidationCount = requestGraph.invalidNodeIds.size;
+  const result = await invalidationFn.fn();
+  const count = requestGraph.invalidNodeIds.size - startInvalidationCount;
+
+  return {
+    key: invalidationFn.key,
+    count,
+    changes:
+      typeof result === 'object' && Array.isArray(result) ? result : null,
+  };
 }
 
 function logErrorOnBailout(

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -23,6 +23,8 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   cachePerformanceImprovements: false,
   inlineStringReplacementPerf: false,
   conditionalBundlingAsyncRuntime: false,
+  // Default to true as it's a monitoring change. Can be turned off if necessary.
+  verboseRequestInvalidationStats: true,
   conditionalBundlingReporterDuplicateFix: false,
   resolveBundlerConfigFromCwd: false,
 };

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -54,6 +54,10 @@ export type FeatureFlags = {|
    */
   reduceResolverStringCreation: boolean,
   /**
+   * Add verbose metrics for request tracker invalidation
+   */
+  verboseRequestInvalidationStats: boolean,
+  /**
    * Fixes source maps for inline bundles
    */
   inlineBundlesSourceMapFixes: boolean,


### PR DESCRIPTION
Log counts of nodes invalidated for each type. Forward logs with
`trackableEvent`.

Test Plan: N/A
