### PR TITLE
Native: Added ATLASPACK_NATIVE_THREADS

### DIFF
--- a/.changeset/young-emus-work.md
+++ b/.changeset/young-emus-work.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Added ATLASPACK_NATIVE_THREADS env variable to control the number of threads used by the native thread schedular

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -165,10 +165,17 @@ export default class Atlaspack {
       const version = require('../package.json').version;
       await lmdb.put('current_session_version', Buffer.from(version));
 
+      let threads = undefined;
+      if (process.env.ATLASPACK_NATIVE_THREADS !== undefined) {
+        threads = parseInt(process.env.ATLASPACK_NATIVE_THREADS, 10);
+      } else if (process.env.NODE_ENV === 'test') {
+        threads = 2;
+      }
+
       rustAtlaspack = await AtlaspackV3.create({
         ...options,
         corePath: path.join(__dirname, '..'),
-        threads: process.env.NODE_ENV === 'test' ? 2 : undefined,
+        threads,
         entries: Array.isArray(entries)
           ? entries
           : entries == null


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

We need the ability to control the number of threads used by Tokio in the native context

## Changes

Added an environment variable `ATLASPACK_NATIVE_THREADS` to control the number of Tokio threads

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
