### PR TITLE
Fix creating tag on GH canary releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,7 +157,7 @@ jobs:
       - name: Get canary version
         if: ${{ inputs.type == 'canary' }}
         id: canary-version
-        run: echo "VERSION_TAG=$(npm show @atlaspack/cli@canary --json | jq .version -r)" >> "$GITHUB_OUTPUT"
+        run: echo "VERSION_TAG=$(cat packages/core/cli/package.json | jq .version -r)" >> "$GITHUB_OUTPUT"
       - name: Create tag
         uses: actions/github-script@v5
         if: ${{ inputs.type == 'canary' }}

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test:js:unit": "cross-env NODE_ENV=test mocha --conditions=\"@atlaspack::sources\" --timeout 5000",
     "test:unit": "yarn test:js:unit && cargo test",
     "dev:release": "lerna publish -y --canary --preid dev --dist-tag=dev --exact --force-publish=* --no-git-tag-version --no-push",
-    "canary:release": "lerna publish -y --canary --preid canary --dist-tag=canary --exact --force-publish=* --no-git-tag-version --no-push",
+    "canary:release": "lerna publish -y --canary --preid canary --dist-tag=canary --exact --force-publish=* --no-push",
     "tag:prerelease": "lerna version --exact --force-publish=* --no-git-tag-version --no-push",
     "tag:release": "lerna version --exact --force-publish=* --no-git-tag-version --no-push",
     "release": "lerna publish -y from-package --pre-dist-tag=next --no-git-tag-version --no-push",


### PR DESCRIPTION
The current canary release job is flaky.

The reason is it is trying to create a git tag for the currently published NPM
package version right after publishing.

However, querying NPM after publish is not reliable because NPM is eventually
consistent.

This commit tries to change the canary job to allow lerna to commit the version
bump, then use the package.json information to find the published version.

[no-changeset]: Workflow changes

Test Plan: N/A
