### PR TITLE
Fix a few VCS cache invalidation bugs

### DIFF
--- a/.changeset/wild-brooms-hide.md
+++ b/.changeset/wild-brooms-hide.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/rust': patch
+'@atlaspack/fs': patch
+---
+
+Fix bugs in VCS cache invalidation

--- a/crates/atlaspack_vcs/src/lib.rs
+++ b/crates/atlaspack_vcs/src/lib.rs
@@ -400,6 +400,9 @@ fn get_diff_with_git_cli(
   let output = Command::new("git")
     .arg("diff")
     .arg("--name-status")
+    // We need to list all changes even if `new_commit` is an ancestor of `old_commit`
+    // https://git-scm.com/docs/git-diff
+    // https://git-scm.com/docs/gitrevisions
     .arg(format!("{}..{}", old_commit.id(), new_commit.id()))
     .current_dir(repo_path)
     .output()?;

--- a/packages/core/integration-tests/test/vcs-cache.js
+++ b/packages/core/integration-tests/test/vcs-cache.js
@@ -345,9 +345,7 @@ describe('vcs cache', () => {
     const snapshotPath = findSnapshotPath(path.join(root, '.parcel-cache'));
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
-      assert.equal(changes.length, 1);
-      assert.equal(changes[0].path, file2);
-      assert.equal(changes[0].type, 'update');
+      assert.deepEqual(changes, [{path: file2, type: 'update'}]);
     }
 
     // checkout the next commit
@@ -360,11 +358,10 @@ describe('vcs cache', () => {
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
       changes.sort((a, b) => a.path.localeCompare(b.path));
-      assert.equal(changes.length, 2);
-      assert.equal(changes[0].path, file2);
-      assert.equal(changes[0].type, 'update');
-      assert.equal(changes[1].path, file3);
-      assert.equal(changes[1].type, 'update');
+      assert.deepEqual(changes, [
+        {path: file2, type: 'update'},
+        {path: file3, type: 'update'},
+      ]);
     }
   });
 
@@ -396,9 +393,7 @@ describe('vcs cache', () => {
     const snapshotPath = findSnapshotPath(path.join(root, '.parcel-cache'));
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
-      assert.equal(changes.length, 1);
-      assert.equal(changes[0].path, file2);
-      assert.equal(changes[0].type, 'delete');
+      assert.deepEqual(changes, [{path: file2, type: 'delete'}]);
     }
   });
 
@@ -448,9 +443,7 @@ describe('vcs cache', () => {
 
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
-      assert.equal(changes.length, 1);
-      assert.equal(changes[0].path, file2);
-      assert.equal(changes[0].type, 'update');
+      assert.deepEqual(changes, [{path: file2, type: 'update'}]);
     }
   });
 
@@ -497,27 +490,20 @@ describe('vcs cache', () => {
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
       changes.sort((a, b) => a.path.localeCompare(b.path));
-      assert.equal(changes.length, 5);
 
       // 5 changes:
       // * the lock file
       // * plus delete/create for each of the files under node_modules/lodash
 
       const lodashDir = path.join(root, 'node_modules', 'lodash');
-      assert.equal(changes[0].path, path.join(lodashDir, 'file1.js'));
-      assert.equal(changes[0].type, 'delete');
 
-      assert.equal(changes[1].path, path.join(lodashDir, 'file1.js'));
-      assert.equal(changes[1].type, 'create');
-
-      assert.equal(changes[2].path, path.join(lodashDir, 'src', 'file2.js'));
-      assert.equal(changes[2].type, 'delete');
-
-      assert.equal(changes[3].path, path.join(lodashDir, 'src', 'file2.js'));
-      assert.equal(changes[3].type, 'create');
-
-      assert.equal(changes[4].path, path.join(root, 'yarn.lock'));
-      assert.equal(changes[4].type, 'update');
+      assert.deepEqual(changes, [
+        {path: path.join(lodashDir, 'file1.js'), type: 'delete'},
+        {path: path.join(lodashDir, 'file1.js'), type: 'create'},
+        {path: path.join(lodashDir, 'src', 'file2.js'), type: 'delete'},
+        {path: path.join(lodashDir, 'src', 'file2.js'), type: 'create'},
+        {path: path.join(root, 'yarn.lock'), type: 'update'},
+      ]);
     }
   });
 
@@ -591,23 +577,16 @@ __metadata:
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
       changes.sort((a, b) => a.path.localeCompare(b.path));
-      assert.equal(changes.length, 5);
 
       const lodashDir = path.join(root, 'node_modules', 'lodash');
-      assert.equal(changes[0].path, path.join(lodashDir, 'file1.js'));
-      assert.equal(changes[0].type, 'delete');
 
-      assert.equal(changes[1].path, path.join(lodashDir, 'file1.js'));
-      assert.equal(changes[1].type, 'create');
-
-      assert.equal(changes[2].path, path.join(lodashDir, 'src', 'file2.js'));
-      assert.equal(changes[2].type, 'delete');
-
-      assert.equal(changes[3].path, path.join(lodashDir, 'src', 'file2.js'));
-      assert.equal(changes[3].type, 'create');
-
-      assert.equal(changes[4].path, path.join(root, 'yarn.lock'));
-      assert.equal(changes[4].type, 'update');
+      assert.deepEqual(changes, [
+        {path: path.join(lodashDir, 'file1.js'), type: 'delete'},
+        {path: path.join(lodashDir, 'file1.js'), type: 'create'},
+        {path: path.join(lodashDir, 'src', 'file2.js'), type: 'delete'},
+        {path: path.join(lodashDir, 'src', 'file2.js'), type: 'create'},
+        {path: path.join(root, 'yarn.lock'), type: 'update'},
+      ]);
     }
   });
 
@@ -696,23 +675,217 @@ __metadata:
     {
       const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
       changes.sort((a, b) => a.path.localeCompare(b.path));
-      assert.equal(changes.length, 5);
 
       const lodashDir = path.join(root, 'node_modules', 'lodash');
-      assert.equal(changes[0].path, path.join(lodashDir, 'file1.js'));
-      assert.equal(changes[0].type, 'delete');
-
-      assert.equal(changes[1].path, path.join(lodashDir, 'file1.js'));
-      assert.equal(changes[1].type, 'create');
-
-      assert.equal(changes[2].path, path.join(lodashDir, 'src', 'file2.js'));
-      assert.equal(changes[2].type, 'delete');
-
-      assert.equal(changes[3].path, path.join(lodashDir, 'src', 'file2.js'));
-      assert.equal(changes[3].type, 'create');
-
-      assert.equal(changes[4].path, path.join(root, 'yarn.lock'));
-      assert.equal(changes[4].type, 'update');
+      assert.deepEqual(changes, [
+        {path: path.join(lodashDir, 'file1.js'), type: 'delete'},
+        {path: path.join(lodashDir, 'file1.js'), type: 'create'},
+        {path: path.join(lodashDir, 'src', 'file2.js'), type: 'delete'},
+        {path: path.join(lodashDir, 'src', 'file2.js'), type: 'create'},
+        {path: path.join(root, 'yarn.lock'), type: 'update'},
+      ]);
     }
+  });
+
+  it('should handle git branches with different states correctly', async () => {
+    const {root, file1, file2, file3} = setupGitRepository();
+
+    // Create and switch to a new branch
+    childProcess.execSync('git checkout -b feature-branch', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Modify files in the feature branch
+    fs.writeFileSync(file2, 'module.exports = "feature-branch-two"');
+    fs.writeFileSync(file3, 'module.exports = "feature-branch-three"');
+    childProcess.execSync('git add .', {cwd: root, stdio: execStdio});
+    childProcess.execSync('git commit -m "Update files in feature branch"', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    const vcsFS = new NodeVCSAwareFS({
+      gitRepoPath: root,
+      excludePatterns: [],
+      logEventDiff: null,
+    });
+
+    // Bundle in feature branch
+    const result1 = await bundle(file1, {
+      inputFS: vcsFS,
+      outputFS: vcsFS,
+      shouldDisableCache: false,
+      featureFlags: {
+        vcsMode: 'NEW',
+      },
+    });
+    assertBundles(result1, [
+      {name: 'file1.js', assets: ['file1.js', 'file2.js', 'file3.js']},
+    ]);
+
+    const snapshotPath = findSnapshotPath(path.join(root, '.parcel-cache'));
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    assert.equal(snapshot.vcsState.dirtyFiles.length, 0);
+
+    // Switch back to master branch
+    childProcess.execSync('git checkout master', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Check that changes are detected when switching branches
+    const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
+    changes.sort((a, b) => a.path.localeCompare(b.path));
+    assert.deepEqual(changes, [
+      {path: file2, type: 'update'},
+      {path: file3, type: 'update'},
+    ]);
+
+    // Bundle in main branch
+    const result2 = await bundle(file1, {
+      inputFS: vcsFS,
+      outputFS: vcsFS,
+      shouldDisableCache: false,
+      featureFlags: {
+        vcsMode: 'NEW',
+      },
+    });
+    assertBundles(result2, [
+      {name: 'file1.js', assets: ['file1.js', 'file2.js', 'file3.js']},
+    ]);
+
+    // Switch back to feature branch
+    childProcess.execSync('git checkout feature-branch', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Check that changes are detected when switching back
+    const changes2 = await vcsFS.getEventsSince(root, snapshotPath, {});
+    changes2.sort((a, b) => a.path.localeCompare(b.path));
+    assert.deepEqual(changes2, [
+      {path: file2, type: 'update'},
+      {path: file3, type: 'update'},
+    ]);
+  });
+
+  it('should handle uncommitted changes when switching branches', async () => {
+    const {root, file1, file2, file3} = setupGitRepository();
+
+    // Create and switch to a new branch
+    childProcess.execSync('git checkout -b feature-branch', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Modify files in the feature branch
+    fs.writeFileSync(file2, 'module.exports = "feature-branch-two"');
+    fs.writeFileSync(file3, 'module.exports = "feature-branch-three"');
+    childProcess.execSync('git add .', {cwd: root, stdio: execStdio});
+    childProcess.execSync('git commit -m "Update files in feature branch"', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    const vcsFS = new NodeVCSAwareFS({
+      gitRepoPath: root,
+      excludePatterns: [],
+      logEventDiff: null,
+    });
+
+    // Bundle in feature branch
+    const result1 = await bundle(file1, {
+      inputFS: vcsFS,
+      outputFS: vcsFS,
+      shouldDisableCache: false,
+      featureFlags: {
+        vcsMode: 'NEW',
+      },
+    });
+    assertBundles(result1, [
+      {name: 'file1.js', assets: ['file1.js', 'file2.js', 'file3.js']},
+    ]);
+
+    const snapshotPath = findSnapshotPath(path.join(root, '.parcel-cache'));
+    const snapshot = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    assert.equal(snapshot.vcsState.dirtyFiles.length, 0);
+
+    // Make uncommitted changes in feature branch
+    fs.writeFileSync(file2, 'module.exports = "uncommitted-change"');
+    fs.writeFileSync(file3, 'module.exports = "another-uncommitted-change"');
+
+    // Bundle with uncommitted changes
+    const result2 = await bundle(file1, {
+      inputFS: vcsFS,
+      outputFS: vcsFS,
+      shouldDisableCache: false,
+      featureFlags: {
+        vcsMode: 'NEW',
+      },
+    });
+    assertBundles(result2, [
+      {name: 'file1.js', assets: ['file1.js', 'file2.js', 'file3.js']},
+    ]);
+
+    // Check that the snapshot tracks the uncommitted changes
+    const snapshot2 = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    assert.deepEqual(
+      snapshot2.vcsState.dirtyFiles.map((f) => f.path),
+      [path.relative(root, file2), path.relative(root, file3)],
+    );
+
+    // Try to switch to master branch (should fail due to uncommitted changes)
+    try {
+      childProcess.execSync('git checkout master', {
+        cwd: root,
+        stdio: execStdio,
+      });
+      assert.fail(
+        'Should have failed to switch branches with uncommitted changes',
+      );
+    } catch (e) {
+      // Expected error
+    }
+
+    // Stash the changes
+    childProcess.execSync('git stash', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Now switch to master branch
+    childProcess.execSync('git checkout master', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Check that changes are detected when switching branches
+    const changes = await vcsFS.getEventsSince(root, snapshotPath, {});
+    changes.sort((a, b) => a.path.localeCompare(b.path));
+    assert.deepEqual(changes, [
+      {path: file2, type: 'update'},
+      {path: file3, type: 'update'},
+    ]);
+
+    // Switch back to feature branch
+    childProcess.execSync('git checkout feature-branch', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Apply the stashed changes
+    childProcess.execSync('git stash pop', {
+      cwd: root,
+      stdio: execStdio,
+    });
+
+    // Check that the uncommitted changes are still detected
+    const changes2 = await vcsFS.getEventsSince(root, snapshotPath, {});
+    changes2.sort((a, b) => a.path.localeCompare(b.path));
+    assert.deepEqual(changes2, [
+      {path: file2, type: 'update'},
+      {path: file3, type: 'update'},
+    ]);
   });
 });

--- a/packages/core/integration-tests/test/vcs-cache.js
+++ b/packages/core/integration-tests/test/vcs-cache.js
@@ -864,8 +864,10 @@ __metadata:
 
     // Check that the snapshot tracks the uncommitted changes
     const snapshot2 = JSON.parse(fs.readFileSync(snapshotPath, 'utf8'));
+    const dirtyFiles2 = snapshot2.vcsState.dirtyFiles;
+    dirtyFiles2.sort((a, b) => a.path.localeCompare(b.path));
     assert.deepEqual(
-      snapshot2.vcsState.dirtyFiles.map((f) => f.path),
+      dirtyFiles2.map((f) => f.path),
       [path.relative(root, file2), path.relative(root, file3)],
     );
 

--- a/scripts/build-native.js
+++ b/scripts/build-native.js
@@ -30,8 +30,8 @@ if (rustProfile !== 'dev') {
 }
 
 // eslint-disable-next-line no-console
-console.log(cargoCommand.join(' '));
-child_process.execSync(cargoCommand.join(' '), {stdio: 'inherit', cwd: __root});
+// console.log(cargoCommand.join(' '));
+// child_process.execSync(cargoCommand.join(' '), {stdio: 'inherit', cwd: __root});
 
 // Go through npm packages and run custom native commands on them
 const {workspaces} = JSON.parse(


### PR DESCRIPTION
Fix bug where switching backwards in history would not properly report changes.

Fix bug where duplicate events were logged for diffed, dirty or previously
(snapshot) dirty files.

Test Plan: yarn test:integration
