### PR TITLE
Remove github tag create for canary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,21 +154,6 @@ jobs:
           npm config set "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}"
           npm config set registry https://registry.npmjs.org/
       - run: ${{ inputs.release-command }}
-      - name: Get canary version
-        if: ${{ inputs.type == 'canary' }}
-        id: canary-version
-        run: echo "VERSION_TAG=$(cat packages/core/cli/package.json | jq .version -r)" >> "$GITHUB_OUTPUT"
-      - name: Create tag
-        uses: actions/github-script@v5
-        if: ${{ inputs.type == 'canary' }}
-        with:
-          script: |
-            github.rest.git.createRef({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              ref: 'refs/tags/${{ steps.canary-version.outputs.VERSION_TAG }}'.trim(),
-              sha: context.sha
-            })
 
   build-and-release-changesets:
     name: Build and release Changesets


### PR DESCRIPTION
Changes in https://github.com/atlassian-labs/atlaspack/pull/557
are not right and will cause the wrong tag to be created.

I think it's okay to just not tag canary releases for now, instead of having
the flaky job.

Test Plan:
N/A

[no-changeset]: GitHub actions changes
