### PR TITLE
AFB-1244 - add operational only statsig flags to atlaspack for AFM statsig client validation

### DIFF
--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -27,6 +27,8 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   verboseRequestInvalidationStats: true,
   conditionalBundlingReporterDuplicateFix: false,
   resolveBundlerConfigFromCwd: false,
+  kokoTestGateOne: false,
+  kokoTestGateTwo: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -86,6 +86,14 @@ export type FeatureFlags = {|
    * Enable resolution of bundler config starting from the CWD
    */
   resolveBundlerConfigFromCwd: boolean,
+  /**
+   * Operational only feature flag for validating atlaspack integration with the AFM statsig FF client.
+   */
+  +kokoTestGateOne: boolean,
+  /**
+   * Operational only feature flag for validating atlaspack integration with the AFM statsig FF client.
+   */
+  +kokoTestGateTwo: boolean,
 |};
 
 export type ConsistencyCheckFeatureFlagValue =


### PR DESCRIPTION
Add two temporary flags to atlaspack for ATM statsig client validation.

## Motivation

To facilitate validation of new statsig client in AFM integration with Atlaspack flags.
See issue AFB-1244 for more info.

## Changes

Added two operational only flags.
- kokoTestGateOne
- kokoTestGateTwo

## Checklist

- [x] Existing or new tests cover this change - n/a
- [x] There is a changeset for this change, or one is not required


[no-changeset]: temporary flags
