### PR TITLE
Merge shared bundles when they lead to less code loaded when compared to bundle group merges

### DIFF
--- a/packages/bundlers/default/src/PriorityQueue.js
+++ b/packages/bundlers/default/src/PriorityQueue.js
@@ -1,0 +1,71 @@
+// https://stackoverflow.com/a/42919752
+const top = 0;
+const parent = (i) => ((i + 1) >>> 1) - 1;
+const left = (i) => (i << 1) + 1;
+const right = (i) => (i + 1) << 1;
+
+export class PriorityQueue {
+  constructor(comparator = (a, b) => a > b) {
+    this._heap = [];
+    this._comparator = comparator;
+  }
+  size() {
+    return this._heap.length;
+  }
+  isEmpty() {
+    return this.size() == 0;
+  }
+  peek() {
+    return this._heap[top];
+  }
+  push(...values) {
+    values.forEach((value) => {
+      this._heap.push(value);
+      this._siftUp();
+    });
+    return this.size();
+  }
+  pop() {
+    const poppedValue = this.peek();
+    const bottom = this.size() - 1;
+    if (bottom > top) {
+      this._swap(top, bottom);
+    }
+    this._heap.pop();
+    this._siftDown();
+    return poppedValue;
+  }
+  replace(value) {
+    const replacedValue = this.peek();
+    this._heap[top] = value;
+    this._siftDown();
+    return replacedValue;
+  }
+  _greater(i, j) {
+    return this._comparator(this._heap[i], this._heap[j]);
+  }
+  _swap(i, j) {
+    [this._heap[i], this._heap[j]] = [this._heap[j], this._heap[i]];
+  }
+  _siftUp() {
+    let node = this.size() - 1;
+    while (node > top && this._greater(node, parent(node))) {
+      this._swap(node, parent(node));
+      node = parent(node);
+    }
+  }
+  _siftDown() {
+    let node = top;
+    while (
+      (left(node) < this.size() && this._greater(left(node), node)) ||
+      (right(node) < this.size() && this._greater(right(node), node))
+    ) {
+      let maxChild =
+        right(node) < this.size() && this._greater(right(node), left(node))
+          ? right(node)
+          : left(node);
+      this._swap(node, maxChild);
+      node = maxChild;
+    }
+  }
+}

--- a/packages/bundlers/default/src/getSmallestSharedBundleMergesByLeastCodeLoaded.js
+++ b/packages/bundlers/default/src/getSmallestSharedBundleMergesByLeastCodeLoaded.js
@@ -1,0 +1,277 @@
+// @flow strict-local
+
+import invariant from 'assert';
+import path from 'path';
+import {basename} from 'path';
+
+import nullthrows from 'nullthrows';
+
+import type {NodeId} from '@atlaspack/graph';
+import type {Asset, Dependency, MutableBundleGraph} from '@atlaspack/types';
+
+import type {Bundle, IdealBundleGraph} from './idealGraph';
+import {inspect} from 'util';
+/* $FlowFixMe[untyped-import] */
+import {PriorityQueue} from './PriorityQueue';
+import type {DefaultMap} from '@atlaspack/utils';
+
+/** 100Kb */
+const MAX_SHARED_BUNDLE_SIZE = 100e3;
+
+/**
+ * @returns The sum of the size of all assets that will be loaded
+ * in sourceBundles that weren't previously loaded before
+ * merging `bundleA` into `bundleB`
+ */
+function getNewAssetsLoadedByMerge(
+  bundleGraph: IdealBundleGraph,
+  assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
+  bundleA: Bundle,
+  bundleB: Bundle,
+) {
+  /**
+   * @returns The sum of the size of all assets that will be loaded
+   * in `bundleB.sourceBundles` that weren't previously loaded before
+   * merging `bundleA` into `bundleB`
+   */
+  function getNewAssetsLoadedInBByMerge(bundleA: Bundle, bundleB: Bundle) {
+    const sourceBundlesUniqueToB = new Set();
+    for (const id of bundleB.sourceBundles) {
+      if (!bundleA.sourceBundles.has(id)) {
+        const bundle = nullthrows(bundleGraph.getNode(id));
+        if (bundle !== 'root') {
+          sourceBundlesUniqueToB.add(bundle);
+        }
+      }
+    }
+
+    const assetsUniqueToA = new Set();
+    for (const asset of bundleA.assets) {
+      if (!bundleB.assets.has(asset)) {
+        assetsUniqueToA.add(asset);
+      }
+    }
+
+    let duplicatedAssetsFromA = 0;
+    for (const sourceBundle of sourceBundlesUniqueToB) {
+      for (const asset of assetsUniqueToA) {
+        if (sourceBundle.assets.has(asset)) {
+          continue;
+        }
+        const references = nullthrows(assetReference.get(asset));
+        const sourceBundleReferencesAsset = references.some(
+          (_dependency, bundle) => bundle === sourceBundle,
+        );
+        if (!sourceBundleReferencesAsset) {
+          duplicatedAssetsFromA += asset.stats.size;
+        }
+      }
+    }
+
+    return duplicatedAssetsFromA;
+  }
+
+  /**
+   * The sum of the sizes of new assets being loaded in `sourceBundles` unique to `bundleB`
+   * that weren't previousely being loaded before `bundleA` merges into `bundleB`
+   */
+  const newAssetsLoadedInBFromA = getNewAssetsLoadedInBByMerge(
+    bundleA,
+    bundleB,
+  );
+  /**
+   * The sum of the sizes of new assets being loaded in `sourceBundles` unique to `bundleA`
+   * that weren't previousely being loaded before `bundleA` merges into `bundleB`
+   */
+  const newAssetsLoadedInAFromB = getNewAssetsLoadedInBByMerge(
+    bundleB,
+    bundleA,
+  );
+
+  return newAssetsLoadedInBFromA + newAssetsLoadedInAFromB;
+}
+
+function getBundleSizeAfterMerge(bundleA: Bundle, bundleB: Bundle) {
+  const combinedAssets = new Set([...bundleA.assets, ...bundleB.assets]);
+
+  let bundleSizeAfterMerge = 0;
+  for (const asset of combinedAssets) {
+    bundleSizeAfterMerge += asset.stats.size;
+  }
+
+  return bundleSizeAfterMerge;
+}
+
+/**
+ * Create a `compareFn` used for determining if a merge
+ * (`[bundleA, bundleB]` where `bundleA` is being merged into `bundleB`)
+ *
+ *  1. Is merging a smaller asset (`bundleA`)
+ *  2. Leads to less new code loaded after merge
+ */
+function createSortSmallestMergeByLeastCodeLoaded(
+  bundleGraph: IdealBundleGraph,
+  assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
+) {
+  [].sort();
+  function getBundle(nodeId: NodeId) {
+    const bundle = bundleGraph.getNode(nodeId);
+    invariant(bundle && bundle !== 'root');
+    return bundle;
+  }
+
+  function isMergeOutdated(merge: [NodeId, NodeId]) {
+    return merge.some((nodeId) => !bundleGraph.hasNode(nodeId));
+  }
+
+  return (mergeA: [NodeId, NodeId], mergeB: [NodeId, NodeId]) => {
+    /**
+     * These invalid merges will be removed by the `isCandidateInvalid`
+     * check in `shift`
+     */
+    if (isMergeOutdated(mergeA)) {
+      return 1;
+    } else if (isMergeOutdated(mergeB)) {
+      return -1;
+    }
+
+    const mergeBundlesA = mergeA.map(getBundle);
+    const mergeBundlesB = mergeB.map(getBundle);
+
+    const bundleSizeAfterMergeA = getBundleSizeAfterMerge(...mergeBundlesA);
+    const bundleSizeAfterMergeB = getBundleSizeAfterMerge(...mergeBundlesB);
+
+    // We want to prevent overmerging assets!!
+    if (bundleSizeAfterMergeA > MAX_SHARED_BUNDLE_SIZE) {
+      return 1;
+    } else if (bundleSizeAfterMergeB > MAX_SHARED_BUNDLE_SIZE) {
+      return -1;
+    }
+
+    const getNewAssetsLoadedAfterMergeA = getNewAssetsLoadedByMerge(
+      bundleGraph,
+      assetReference,
+      ...mergeBundlesA,
+    );
+    const getNewAssetsLoadedAfterMergeB = getNewAssetsLoadedByMerge(
+      bundleGraph,
+      assetReference,
+      ...mergeBundlesB,
+    );
+
+    return getNewAssetsLoadedAfterMergeA - getNewAssetsLoadedAfterMergeB;
+  };
+}
+
+/**
+ * @param {{ id: NodeId, bundle: Bundle }[]} sharedBundles all sharedBundles within `bundleGroupId`
+ * @returns A PriorityQueue of shared bundle merge combinations within `bundleGroupId` which lead
+ * to less code being loaded when compared to merging the bundle back into the the `bundleGroup`.
+ *
+ * The queue is sorted by:
+ *  1. Smallest bundles merged first
+ *  2. Merge combinations which lead to the least amount of new code loaded after being merged
+ */
+export function getSmallestSharedBundleMergesByLeastCodeLoaded(
+  sharedBundles: {|id: NodeId, bundle: Bundle|}[],
+  bundleGraph: IdealBundleGraph,
+  bundleGroupId: NodeId,
+  assetReference: DefaultMap<Asset, Array<[Dependency, Bundle]>>,
+): {|
+  shift():
+    | typeof undefined
+    | {|bundleToMergeId: NodeId, bundleToKeepId: NodeId|},
+|} {
+  const seen = new Set<string>();
+  const queue = new PriorityQueue(
+    createSortSmallestMergeByLeastCodeLoaded(bundleGraph, assetReference),
+  );
+  // Only consider JS shared bundles and non-reused bundles.
+  // These could potentially be considered for merging in future but they're
+  // more complicated to merge
+  const nonReusedSharedBundles = sharedBundles.filter(
+    ({bundle}) => bundle.type === 'js' && !bundle.mainEntryAsset,
+  );
+
+  const bundleGroup = nullthrows(bundleGraph.getNode(bundleGroupId));
+  invariant(bundleGroup !== 'root');
+
+  function isCandidateInvalid(
+    [bundleId, otherBundleId]: [NodeId, NodeId],
+    newCodeLoadedAfterBundleGroupMerge?: number,
+  ) {
+    if (!bundleGraph.hasNode(bundleId) || !bundleGraph.hasNode(otherBundleId)) {
+      return true;
+    }
+
+    const bundle = nullthrows(bundleGraph.getNode(bundleId));
+    invariant(bundle !== 'root');
+    const otherBundle = nullthrows(bundleGraph.getNode(otherBundleId));
+    invariant(otherBundle !== 'root');
+
+    const bundleSizeAfterMerge = getBundleSizeAfterMerge(bundle, otherBundle);
+    if (bundleSizeAfterMerge > MAX_SHARED_BUNDLE_SIZE) {
+      return true;
+    }
+
+    const newCodeLoadedAfterOtherBundleMerge = getNewAssetsLoadedByMerge(
+      bundleGraph,
+      assetReference,
+      bundle,
+      otherBundle,
+    );
+    /* $FlowIssue[reassign-const] Flow thinks that parameters are consts */
+    newCodeLoadedAfterBundleGroupMerge ??= getNewAssetsLoadedByMerge(
+      bundleGraph,
+      assetReference,
+      bundle,
+      bundleGroup,
+    );
+    return (
+      /* $FlowIssue[invalid-compare] duplicatedAssetsFromOtherBundleMerge will always be a number here */
+      newCodeLoadedAfterOtherBundleMerge >= newCodeLoadedAfterBundleGroupMerge
+    );
+  }
+
+  for (const {id: bundleId, bundle} of nonReusedSharedBundles) {
+    const newCodeLoadedAfterBundleGroupMerge = getNewAssetsLoadedByMerge(
+      bundleGraph,
+      assetReference,
+      bundle,
+      bundleGroup,
+    );
+    for (const {
+      id: otherBundleId,
+      bundle: otherBundle,
+    } of nonReusedSharedBundles) {
+      if (bundleId === otherBundleId) {
+        continue;
+      }
+      let key = [bundleId, otherBundleId].sort().join(':');
+      if (seen.has(key)) {
+        continue;
+      }
+
+      const candidate = [bundleId, otherBundleId];
+      if (!isCandidateInvalid(candidate, newCodeLoadedAfterBundleGroupMerge)) {
+        queue.push(candidate);
+      }
+    }
+  }
+
+  return {
+    shift() {
+      let candidate = queue.pop();
+      while (candidate && isCandidateInvalid(candidate)) {
+        candidate = queue.pop();
+      }
+
+      if (!candidate) {
+        return undefined;
+      }
+
+      const [bundleToMergeId, bundleToKeepId] = candidate;
+      return {bundleToMergeId, bundleToKeepId};
+    },
+  };
+}


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

The goal of this change is to explore options for reducing the amount of code loaded on transition.

## Changes

* Add PriorityQueue // https://stackoverflow.com/a/42919752
* Add [getSmallestSharedBundleMergesByLeastCodeLoaded.js](https://github.com/atlassian-labs/atlaspack/compare/PCC-5240-merge-shared-bundles-to-reduce-code-loaded?expand=1#diff-173d070ea2574506f49cbbc757ec036863c51d707783d10b2b4250a9d71e3759) which returns a Priority Queue of shared bundle merge combinations within `bundleGroupId` which lead to less code being loaded when compared to merging the bundle back into the the `bundleGroup`.
* Use `getSmallestSharedBundleMergesByLeastCodeLoaded` when merging bundles to meet `maxParallelRequests`

## Checklist

- [ ] Verify that this is preferable to always merging into the `bundleGroup`
- [ ] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: This is an experimental change. It's not intended to be merged at this point.
