### PR TITLE
Handle the case that a resolution is "excluded"

### DIFF
--- a/.changeset/real-bikes-confess.md
+++ b/.changeset/real-bikes-confess.md
@@ -1,0 +1,11 @@
+---
+'@atlaspack/rust': patch
+---
+
+There are three types of results that a resolver can return:
+
+- A successful resolution
+- "Unresolved" when the resolver could not find a match
+- "Excluded" when the result should not be included in the bundle
+
+This last case wasn't being handle in the NAPI conversion layer, and so was falling through as a successful resolution with no details.

--- a/packages/core/core/src/atlaspack-v3/worker/worker.js
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.js
@@ -141,6 +141,13 @@ export class AtlaspackWorker {
         };
       }
 
+      if (result.isExcluded) {
+        return {
+          invalidations: [],
+          resolution: {type: 'excluded'},
+        };
+      }
+
       return {
         invalidations: [],
         resolution: {


### PR DESCRIPTION
There are three types of results that a resolver can return:

- A successful resolution
- "Unresolved" when the resolver could not find a match
- "Excluded" when the result should not be included in the bundle

This last case wasn't being handle in the NAPI conversion layer, and so was falling through as a successful resolution with no details.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required