### PR TITLE
Fix MemoryFS watch events implementation

### DIFF
--- a/packages/core/fs/src/MemoryFS.js
+++ b/packages/core/fs/src/MemoryFS.js
@@ -549,9 +549,12 @@ export class MemoryFS implements FileSystem {
           dir += path.sep;
         }
 
-        if (event.path.startsWith(dir)) {
+        const relevantEvents = events.filter((event) =>
+          event.path.startsWith(dir),
+        );
+        if (relevantEvents.length > 0) {
           for (let watcher of watchers) {
-            watcher.trigger(events);
+            watcher.trigger(relevantEvents);
           }
         }
       }


### PR DESCRIPTION
This is broken at the moment and and such it makes other changes hard.

Test Plan: N/A
