### PR TITLE
Fix conditional import types

### DIFF
--- a/.changeset/tame-cheetahs-suffer.md
+++ b/.changeset/tame-cheetahs-suffer.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/conditional-import-types': patch
+---
+
+Update documentation for importCond

--- a/packages/core/conditional-import-types/index.d.ts
+++ b/packages/core/conditional-import-types/index.d.ts
@@ -12,8 +12,6 @@ type ConditionalImport<
 > = CondT['default'] | CondF['default'];
 
 /**
- * **IMPORTANT: This API is currently a no-op. Do not use until this message is removed.**
- *
  * Conditionally import a dependency, based on the specified condition.
  *
  * This is a synchronous import that differs from conditionally loading a dynamic import (`import()`)
@@ -21,8 +19,8 @@ type ConditionalImport<
  * This function requires server to guarantee the dependency is loaded.
  *
  * @param condition Condition evaluated by the server
- * @param ifTrueDependency Dependency returned if the condition is true
- * @param ifFalseDependency Dependency returned if the condition is false
+ * @param ifTrueDependency Dependency returned if the condition is true. This should be a relative file path like './ui/comment-component-new.tsx'
+ * @param ifFalseDependency Dependency returned if the condition is false. This should be a relative file path like './ui/comment-component-old.tsx'
  */
 declare function importCond<CondT, CondF>(
   condition: string,


### PR DESCRIPTION
Update doc comment for conditional imports to remove outdated information and to make the parameters clearer.

## Motivation

This is now outdated:

```
**IMPORTANT: This API is currently a no-op. Do not use until this message is removed.**
```

and there was one instance where it caused confusion for a developer. We should remove it.

## Changes

* Remove outdated message
* Clarify the syntax for `ifTrueDependency` and `ifFalseDependency`

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
