### PR TITLE
Do not run CI on node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,14 +130,10 @@ jobs:
             node: 22
           - os: ubuntu-22.04
             node: 20
-          - os: ubuntu-22.04
-            node: 18
 
           # MacOS ARM64
           - os: macos-15
             node: 20
-          - os: macos-15
-            node: 18
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -168,14 +164,10 @@ jobs:
           # Linux AMD64
           - os: ubuntu-22.04
             node: 20
-          - os: ubuntu-22.04
-            node: 18
 
           # MacOS ARM64
           - os: macos-15
             node: 20
-          - os: macos-15
-            node: 18
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -206,14 +198,10 @@ jobs:
           # Linux AMD64
           - os: ubuntu-22.04
             node: 20
-          - os: ubuntu-22.04
-            node: 18
 
           # MacOS ARM64
           - os: macos-15
             node: 20
-          - os: macos-15
-            node: 18
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove node 18 on test suites and CI jobs.

[no-changeset] CI changes

Test Plan: CI
