### PR TITLE
export DEFAULT_FEATURE_FLAGS so it can be imported from package root

### DIFF
--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -97,3 +97,5 @@ export type ConsistencyCheckFeatureFlagValue =
   | 'OLD'
   | 'NEW_AND_CHECK'
   | 'OLD_AND_CHECK';
+
+declare export var DEFAULT_FEATURE_FLAGS: FeatureFlags;


### PR DESCRIPTION
## Motivation

Export `DEFAULT_FEATURE_FLAGS` so it will be included in the associate type declaration file and able to be imported elsewhere.

This will enable patterns like

```
import type { FeatureFlags } from '@atlaspack/feature-flags';
import { DEFAULT_FEATURE_FLAGS } from '@atlaspack/feature-flags';
```

for consumers of the atlaspack/feature-flags package.

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: typescript export change - export default feature flags
