### PR TITLE
Never manually close the LMDB handle

### DIFF
--- a/.changeset/violet-steaks-thank.md
+++ b/.changeset/violet-steaks-thank.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Fix issue where LMDB database handle could become invalid

--- a/crates/lmdb-js-lite/__benchmarks__/prepare-read-benchmark.ts
+++ b/crates/lmdb-js-lite/__benchmarks__/prepare-read-benchmark.ts
@@ -48,7 +48,6 @@ async function main() {
     }),
   );
   await safeDB.commitWriteTransaction();
-  safeDB.close();
 }
 
 main().catch((err) => {

--- a/crates/lmdb-js-lite/__benchmarks__/write-throughput-safe.ts
+++ b/crates/lmdb-js-lite/__benchmarks__/write-throughput-safe.ts
@@ -51,7 +51,6 @@ async function main() {
       const throughput = numEntriesInserted / duration;
       console.log('Throughput:', throughput, 'entries / second');
     }
-    safeDB.close();
   }
 
   {
@@ -90,7 +89,6 @@ async function main() {
       const throughput = numEntriesInserted / duration;
       console.log('Safe Throughput:', throughput, 'entries / second');
     }
-    safeDB.close();
   }
 }
 

--- a/crates/lmdb-js-lite/__test__/index.test.ts
+++ b/crates/lmdb-js-lite/__test__/index.test.ts
@@ -25,17 +25,12 @@ describe("lmdb", () => {
   const numEntriesToTest = 100000;
   const MAP_SIZE = 1024 * 1024 * 1024;
 
-  afterEach(() => {
-    db?.close();
-  });
-
   it("can be opened", () => {
     db = new Lmdb({
       path: "./databases/test.db",
       asyncWrites,
       mapSize: MAP_SIZE,
     });
-    db.close();
     db = null;
   });
 
@@ -114,10 +109,6 @@ describe("lmdb", () => {
         await db.put(`${i}`, v8.serialize(i));
       }
       await db.commitWriteTransaction();
-    });
-
-    afterEach(() => {
-      db?.close();
     });
 
     it("read many entries, no transaction", async () => {

--- a/crates/lmdb-js-lite/src/lib.rs
+++ b/crates/lmdb-js-lite/src/lib.rs
@@ -427,6 +427,10 @@ impl LMDB {
       })?;
     Ok(())
   }
+
+  pub fn get_database(&self) -> &Arc<DatabaseHandle> {
+    &self.inner
+  }
 }
 
 impl LMDB {

--- a/crates/node-bindings/src/atlaspack/atlaspack.rs
+++ b/crates/node-bindings/src/atlaspack/atlaspack.rs
@@ -67,7 +67,7 @@ pub fn atlaspack_napi_create(
   };
 
   // Get access to LMDB reference
-  let db_handle = lmdb.get_database_napi()?.clone();
+  let db_handle = lmdb.get_database().clone();
   atlaspack_napi_run_db_health_check(&db_handle)?;
 
   // Get Atlaspack Options

--- a/crates/node-bindings/src/lmdb.rs
+++ b/crates/node-bindings/src/lmdb.rs
@@ -87,11 +87,6 @@ impl LMDB {
   }
 
   #[napi]
-  pub fn close(&mut self) {
-    self.inner.close()
-  }
-
-  #[napi]
   pub fn compact(&self, target_path: String) -> napi::Result<()> {
     self.inner.compact(target_path)
   }

--- a/packages/core/cache/test/LMDBLiteCache.test.js
+++ b/packages/core/cache/test/LMDBLiteCache.test.js
@@ -86,7 +86,6 @@ describe('LMDBLiteCache', () => {
     cache = new LMDBLiteCache(path.join(cacheDir, 'close_and_reopen_test'));
     await cache.ensure();
     await cache.setBlob('key', Buffer.from(serialize({value: 42})));
-    cache.getNativeRef().close();
     cache = new LMDBLiteCache(path.join(cacheDir, 'close_and_reopen_test'));
     await cache.ensure();
     const buffer = await cache.getBlob('key');
@@ -129,7 +128,6 @@ describe('LMDBLiteCache', () => {
       const cache = new LMDBLiteCache(testDir);
       await cache.ensure();
       await cache.setBlob(`key${i}`, Buffer.from(serialize({value: i})));
-      cache.getNativeRef().close();
 
       await new Promise((resolve) => setTimeout(resolve, 10));
     }
@@ -158,7 +156,6 @@ describe('LMDBLiteCache', () => {
       hello: 'world',
     });
     setTimeout(() => {
-      cache?.getNativeRef().close();
       cache = null;
 
       if (global.gc) {

--- a/packages/core/cache/test/workerThreadsTest.js
+++ b/packages/core/cache/test/workerThreadsTest.js
@@ -26,8 +26,6 @@ if (!isMainThread) {
       });
 
       setTimeout(() => {
-        cache.getNativeRef().close();
-
         parentPort.postMessage({
           type: 'close',
           workerId: threadId,

--- a/packages/core/rust/index.js.flow
+++ b/packages/core/rust/index.js.flow
@@ -339,7 +339,6 @@ declare export class Lmdb {
   startWriteTransaction(): Promise<void>;
   commitWriteTransaction(): Promise<void>;
   delete(key: string): Promise<void>;
-  close(): void;
   compact(targetPath: string): void;
 }
 

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -67,7 +67,6 @@ beforeEach(async () => {
   for (let i = 0; i < 5; i++) {
     try {
       cacheDir = tempy.directory();
-      cache.getNativeRef().close();
       cache = new LMDBLiteCache(cacheDir);
     } catch (err) {
       if (


### PR DESCRIPTION
Do not allow database handle to hold a closed DB reference.

Test Plan: yarn test:integration
