### PR TITLE
Upgrade git2 to 0.20.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1985,9 +1985,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "git2"
-version = "0.20.0"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fda788993cc341f69012feba8bf45c0ba4f3291fcc08e214b4d5a7332d88aff"
+checksum = "2deb07a133b1520dc1a5690e9bd08950108873d7ed5de38dcc74d3b5ebffa110"
 dependencies = [
  "bitflags 2.6.0",
  "libc",
@@ -2784,9 +2784,9 @@ dependencies = [
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.0+1.9.0"
+version = "0.18.1+1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1a117465e7e1597e8febea8bb0c410f1c7fb93b1e1cddf34363f8390367ffec"
+checksum = "e1dcb20f84ffcdd825c7a311ae347cce604a6f084a767dec4a4929829645290e"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ dyn-hash = "0.2.0"
 env_logger = "0.11.8"
 flate2 = "1.1.1"
 getrandom = { version = "0.2.15", default-features = false }
-git2 = { version = "0.20.0", default-features = false }
+git2 = { version = "0.20.2", default-features = false }
 glob = "0.3.2"
 glob-match = "0.2.1"
 heed = "0.21.0"


### PR DESCRIPTION
I am hoping https://github.com/rust-lang/git2-rs/pull/1160 will address
flakyness in `vcs-cache.js` tests.

Test Plan: yarn test:integration
