### PR TITLE
Report top 10 paths with largest invalidations

### DIFF
--- a/.changeset/clean-eyes-rush.md
+++ b/.changeset/clean-eyes-rush.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Report large file invalidations

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -533,10 +533,11 @@ export default class Atlaspack {
           nativeInvalid = await this.rustAtlaspack.respondToFsEvents(events);
         }
 
-        let isInvalid = await this.#requestTracker.respondToFSEvents(
-          events,
-          Number.POSITIVE_INFINITY,
-        );
+        let {didInvalidate: isInvalid} =
+          await this.#requestTracker.respondToFSEvents(
+            events,
+            Number.POSITIVE_INFINITY,
+          );
 
         if (
           (nativeInvalid || isInvalid) &&

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -5,6 +5,9 @@ import nullthrows from 'nullthrows';
 import RequestTracker, {
   type RunAPI,
   cleanUpOrphans,
+  runInvalidation,
+  getBiggestFSEventsInvalidations,
+  invalidateRequestGraphFSEvents,
 } from '../src/RequestTracker';
 import {Graph} from '@atlaspack/graph';
 import {LMDBLiteCache} from '@atlaspack/cache';
@@ -14,6 +17,8 @@ import {FILE_CREATE, FILE_UPDATE, INITIAL_BUILD} from '../src/constants';
 import {makeDeferredWithPromise} from '@atlaspack/utils';
 import {toProjectPath} from '../src/projectPath';
 import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
+import sinon from 'sinon';
+import type {AtlaspackOptions} from '../src/types';
 
 const options = {
   ...DEFAULT_OPTIONS,
@@ -494,7 +499,7 @@ describe('RequestTracker', () => {
             input: null,
           });
           const requestId = tracker.graph.getNodeIdByContentKey('abc');
-          const invalidated = await tracker.respondToFSEvents(
+          const {didInvalidate: invalidated} = await tracker.respondToFSEvents(
             [
               {
                 type: 'update',
@@ -533,7 +538,7 @@ describe('RequestTracker', () => {
             input: null,
           });
           const requestId = tracker.graph.getNodeIdByContentKey('abc');
-          const invalidated = await tracker.respondToFSEvents(
+          const {didInvalidate: invalidated} = await tracker.respondToFSEvents(
             [
               {
                 type: 'create',
@@ -594,5 +599,100 @@ root --- node1 --- node2 ----------- orphan1 --- orphan2
     assert.deepEqual(cleanUpOrphans(graph), [orphan1, orphan2]);
     assert.equal(getNonNullNodes(graph).length, 4);
     assert.equal(Array.from(graph.getAllEdges()).length, 3);
+  });
+});
+
+describe('runInvalidation', () => {
+  it('calls an invalidationFn and tracks the number of invalidated nodes', async () => {
+    const mockRequestTracker = {
+      getInvalidNodeCount: sinon.stub(),
+    };
+
+    mockRequestTracker.getInvalidNodeCount.returns(10000);
+    const result = await runInvalidation(mockRequestTracker, {
+      key: 'fsEvents',
+      fn: () => {
+        mockRequestTracker.getInvalidNodeCount.returns(30000);
+        return {
+          biggestInvalidations: [{path: 'my-file', count: 10000}],
+        };
+      },
+    });
+
+    assert.equal(result.key, 'fsEvents');
+    assert.equal(result.count, 20000);
+    assert.deepEqual(result.detail, {
+      biggestInvalidations: [{path: 'my-file', count: 10000}],
+    });
+    assert(result.duration > 0, 'Duration was not reported');
+  });
+});
+
+describe('invalidateRequestGraphFSEvents', () => {
+  it('calls requestGraph.respondToFSEvents and returns the biggest invalidations', async () => {
+    const requestGraph = {
+      respondToFSEvents: sinon.stub(),
+    };
+
+    requestGraph.respondToFSEvents.returns({
+      invalidationsByPath: new Map([
+        ['file-1', 10],
+        ['file-2', 5000],
+        ['file-3', 8000],
+      ]),
+    });
+    // $FlowFixMe
+    const options: AtlaspackOptions = {
+      unstableFileInvalidations: undefined,
+    };
+
+    const result = await invalidateRequestGraphFSEvents(requestGraph, options, [
+      {
+        path: 'file-1',
+        type: 'create',
+      },
+      {
+        path: 'file-2',
+        type: 'update',
+      },
+      {
+        path: 'file-3',
+        type: 'delete',
+      },
+    ]);
+
+    assert.deepEqual(result.biggestInvalidations, [
+      {path: 'file-3', count: 8000},
+      {path: 'file-2', count: 5000},
+      {path: 'file-1', count: 10},
+    ]);
+    assert.equal(requestGraph.respondToFSEvents.callCount, 1);
+    assert.deepEqual(requestGraph.respondToFSEvents.args[0], [
+      [
+        {path: 'file-1', type: 'create'},
+        {path: 'file-2', type: 'update'},
+        {path: 'file-3', type: 'delete'},
+      ],
+      options,
+      10000,
+      true,
+    ]);
+  });
+});
+
+describe('getBiggestFSEventsInvalidations', () => {
+  it('returns the paths that invalidated the most nodes', () => {
+    const invalidationsByPath = new Map([
+      ['file-1', 10],
+      ['file-2', 5000],
+      ['file-3', 8000],
+      ['file-4', 1000],
+      ['file-5', 1000],
+    ]);
+
+    assert.deepEqual(getBiggestFSEventsInvalidations(invalidationsByPath, 2), [
+      {path: 'file-3', count: 8000},
+      {path: 'file-2', count: 5000},
+    ]);
   });
 });


### PR DESCRIPTION
Modify RequestTracker to report paths that end up triggering lots of
invalidations.

Change is flagged but the flag is turned on by default.

Test Plan: yarn test:js:unit
