### PR TITLE
Fix LMDB database running out of reader slots

### DIFF
--- a/.changeset/wild-apricots-divide.md
+++ b/.changeset/wild-apricots-divide.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+Fix issue where cache database could become invalid due to stale readers

--- a/crates/lmdb-js-lite/src/writer.rs
+++ b/crates/lmdb-js-lite/src/writer.rs
@@ -375,6 +375,11 @@ impl DatabaseWriter {
       env
     }?;
 
+    // If processes are terminated, they might leave stale readers on the DB
+    // the database will be unusable after it reaches a certain number of
+    // readers, so clean-up is useful on start-up.
+    environment.clear_stale_readers()?;
+
     let mut write_txn = environment.write_txn()?;
     let database = environment.create_database(&mut write_txn, None)?;
 


### PR DESCRIPTION
It is possible on certain use cases that the LMDB database will run out of
reader slots if processes are quit while keeping the database open.

This adds a call which will check and clean stale readers, fixing a database
that has become unable to be opened.

Test Plan: N/A
