### PR TITLE
Add bundleId to write bundles request result

### DIFF
--- a/.changeset/fuzzy-fireants-sleep.md
+++ b/.changeset/fuzzy-fireants-sleep.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/types-internal': patch
+'@atlaspack/types': patch
+'@atlaspack/core': patch
+---
+
+Add bundleId to write bundle request results

--- a/packages/core/core/src/requests/WriteBundleRequest.js
+++ b/packages/core/core/src/requests/WriteBundleRequest.js
@@ -196,6 +196,7 @@ async function run({input, options, api}) {
 
   let res = {
     filePath,
+    bundleId: bundle.id,
     type: info.type,
     stats: {
       size,

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -84,6 +84,7 @@ async function run({input, api, farm, options}) {
         ).replace(bundle.hashReference, hash);
         res.set(bundle.id, {
           filePath: joinProjectPath(bundle.target.distDir, name),
+          bundleId: bundle.id,
           type: bundle.type, // FIXME: this is wrong if the packager changes the type...
           stats: {
             time: 0,

--- a/packages/core/core/src/types.js
+++ b/packages/core/core/src/types.js
@@ -573,6 +573,7 @@ export type BundleGroupNode = {|
 
 export type PackagedBundleInfo = {|
   filePath: ProjectPath,
+  bundleId: ContentKey,
   type: string,
   stats: Stats,
 |};


### PR DESCRIPTION
When building cache analysis tools, it is useful to be able to link a write
bundles request to the bundle that it has written, since the final output path
of a bundle is not available otherwise.

This modifies the WriteBundleRequest to include the bundleId that has been
written in the request result, which will get persisted to its request node on
the cache.

Test Plan: N/A
