### PR TITLE
Fix @atlaspack/query with cache changes

### DIFF
--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -27,65 +27,51 @@ export async function loadGraphs(cacheDir: string): Promise<{|
   bundleInfo: ?Map<ContentKey, PackagedBundleInfo>,
   cacheInfo: ?Map<string, Array<string | number>>,
 |}> {
-  function getMostRecentCacheBlobs() {
-    let files = fs.readdirSync(cacheDir);
+  let cacheInfo: Map<string, Array<string | number>> = new Map();
+  const cache = new LMDBLiteCache(cacheDir);
 
-    let result = {};
-
-    let blobsToFind: Array<{|
-      name: string,
-      check: (v: string) => boolean,
-      mtime?: Date,
-    |}> = [
-      {
-        name: 'requestGraphBlob',
-        check: (basename) =>
-          basename.startsWith('requestGraph-') &&
-          !basename.startsWith('requestGraph-nodes'),
-      },
-      {
-        name: 'bundleGraphBlob',
-        check: (basename) => basename.endsWith('BundleGraph-0'),
-      },
-      {
-        name: 'assetGraphBlob',
-        check: (basename) => basename.endsWith('AssetGraph-0'),
-      },
-    ];
-
-    for (let file of files) {
-      let basename = path.basename(file);
-      let match = blobsToFind.find(({check}) => check(basename));
-
-      if (match) {
-        let stat = fs.statSync(path.join(cacheDir, file));
-
-        if (!match.mtime || stat.mtime > match.mtime) {
-          match.mtime = stat.mtime;
-          result[match.name] = file;
-        }
-      }
+  let requestGraphBlob;
+  let requestGraphKey;
+  let bundleGraphBlob;
+  let assetGraphBlob;
+  for (let key of cache.keys()) {
+    if (key.startsWith('Asset/')) {
+      continue;
+    } else if (key.startsWith('PackagerRunner/')) {
+      continue;
     }
 
-    return result;
+    if (key.startsWith('RequestTracker/') && key.endsWith('/RequestGraph')) {
+      requestGraphBlob = key;
+      requestGraphKey = key.split('/').slice(0, -1).join('/');
+    }
+    if (key.startsWith('BundleGraph/')) {
+      bundleGraphBlob = key;
+    }
+    if (key.startsWith('AssetGraph/')) {
+      assetGraphBlob = key;
+    }
   }
 
-  let cacheInfo: Map<string, Array<string | number>> = new Map();
-
-  let {requestGraphBlob, bundleGraphBlob, assetGraphBlob} =
-    getMostRecentCacheBlobs();
-  const cache = new LMDBLiteCache(cacheDir);
+  console.log({requestGraphBlob, bundleGraphBlob, assetGraphBlob});
 
   // Get requestTracker
   let requestTracker;
-  if (requestGraphBlob) {
+  if (requestGraphBlob != null && requestGraphKey != null) {
     try {
-      let requestGraphKey = requestGraphBlob.slice(0, -'-0'.length);
       let date = Date.now();
+
+      const buffer = await cache.getBlob(requestGraphBlob);
+      const deserializer = new v8.Deserializer(buffer);
+      console.log(
+        'Wire format version stored',
+        deserializer.getWireFormatVersion(),
+      );
+
       let {requestGraph, bufferLength} = await readAndDeserializeRequestGraph(
         cache,
+        requestGraphBlob,
         requestGraphKey,
-        requestGraphKey.replace('requestGraph-', ''),
       );
 
       requestTracker = new RequestTracker({
@@ -99,17 +85,15 @@ export async function loadGraphs(cacheDir: string): Promise<{|
       cacheInfo.set('RequestGraph', [bufferLength]);
       cacheInfo.get('RequestGraph')?.push(timeToDeserialize);
     } catch (e) {
-      console.log('Error loading Request Graph\n', e);
+      console.error('Error loading Request Graph\n', e);
     }
   }
 
   // Get bundleGraph
   let bundleGraph;
-  if (bundleGraphBlob) {
+  if (bundleGraphBlob != null) {
     try {
-      let file = await cache.getLargeBlob(
-        path.basename(bundleGraphBlob).slice(0, -'-0'.length),
-      );
+      let file = await cache.getBlob(bundleGraphBlob);
 
       let timeToDeserialize = Date.now();
       let obj = v8.deserialize(file);
@@ -120,18 +104,16 @@ export async function loadGraphs(cacheDir: string): Promise<{|
       cacheInfo.set('BundleGraph', [Buffer.byteLength(file)]);
       cacheInfo.get('BundleGraph')?.push(timeToDeserialize);
     } catch (e) {
-      console.log('Error loading Bundle Graph\n', e);
+      console.error('Error loading Bundle Graph\n', e);
     }
   }
 
   // Get assetGraph
   let assetGraph;
-  if (assetGraphBlob) {
+  if (assetGraphBlob != null) {
     try {
       // TODO: this should be reviewed when `cachePerformanceImprovements` flag is removed, as we'll be writing files to LMDB cache instead of large blobs
-      let file = await cache.getLargeBlob(
-        path.basename(assetGraphBlob).slice(0, -'-0'.length),
-      );
+      let file = await cache.getBlob(assetGraphBlob);
 
       let timeToDeserialize = Date.now();
       let obj = v8.deserialize(file);
@@ -142,7 +124,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
       cacheInfo.set('AssetGraph', [Buffer.byteLength(file)]);
       cacheInfo.get('AssetGraph')?.push(timeToDeserialize);
     } catch (e) {
-      console.log('Error loading Asset Graph\n', e);
+      console.error('Error loading Asset Graph\n', e);
     }
   }
 
@@ -179,7 +161,7 @@ export async function loadGraphs(cacheDir: string): Promise<{|
       >);
     }
   } catch (e) {
-    console.log('Error loading bundleInfo\n', e);
+    console.error('Error loading bundleInfo\n', e);
   }
 
   return {assetGraph, bundleGraph, requestTracker, bundleInfo, cacheInfo};

--- a/packages/dev/query/src/index.js
+++ b/packages/dev/query/src/index.js
@@ -3,8 +3,6 @@
 import type {ContentKey, NodeId} from '@atlaspack/graph';
 import type {PackagedBundleInfo} from '@atlaspack/core/src/types';
 
-import fs from 'fs';
-import path from 'path';
 import v8 from 'v8';
 import nullthrows from 'nullthrows';
 import invariant from 'assert';


### PR DESCRIPTION
Under the `cachePerformanceImprovements` feature-flag, cache keys have changed.

This commit updates @atlaspack/query helper functions to work with that branch.

[no-changeset]: Internal use only

Test Plan: N/A
