### PR TITLE
Make VCS metrics log line verbose

### DIFF
--- a/.changeset/chilled-jeans-swim.md
+++ b/.changeset/chilled-jeans-swim.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/fs': patch
+---
+
+Reduce verbosity of logging

--- a/packages/core/fs/src/NodeVCSAwareFS.js
+++ b/packages/core/fs/src/NodeVCSAwareFS.js
@@ -162,7 +162,7 @@ export class NodeVCSAwareFS extends NodeFS {
         () => getVcsStateSnapshot(gitRepoPath, this.#excludePatterns),
       );
 
-      logger.info({
+      logger.verbose({
         origin: '@atlaspack/fs',
         message: 'Expose VCS timing metrics',
         meta: {


### PR DESCRIPTION
This is showing-up for developers as they start their servers but is just
present for internal use.

Test Plan: N/A
