### PR TITLE
Write and load deduplicated environments from cache

### DIFF
--- a/.changeset/smooth-suits-tan.md
+++ b/.changeset/smooth-suits-tan.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': minor
+---
+
+load and write env to cache - change is feature flagged

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -71,6 +71,7 @@ import type {
   RequestInvalidation,
   InternalFileCreateInvalidation,
   InternalGlob,
+  Environment,
 } from './types';
 import {BuildAbortError, assertSignalNotAborted, hashFromOption} from './utils';
 import {performance} from 'perf_hooks';
@@ -2263,7 +2264,7 @@ export function getBiggestFSEventsInvalidations(
  * @param {LMDBLiteCache} cache
  * @param {Environment} env
  */
-export async function storeEnvById(cache, env) {
+export async function storeEnvById(cache: Cache, env: Environment) {
   const envKey = `Environment/${ATLASPACK_VERSION}/${env.id}`;
 
   if (await cache.get(envKey)) {
@@ -2283,7 +2284,10 @@ export async function storeEnvById(cache, env) {
  * @param {LMDBLiteCache} cache
  * @param {Set<string>} environmentIds
  */
-export async function storeEnvManager(cache, environmentIds) {
+export async function storeEnvManager(
+  cache: Cache,
+  environmentIds: Iterable<string>,
+) {
   await instrument(
     `RequestTracker::writeToCache::cache.put(${`EnvironmentManager/${ATLASPACK_VERSION}`})`,
     async () => {
@@ -2300,7 +2304,7 @@ export async function storeEnvManager(cache, environmentIds) {
  * @param {LMDBLiteCache} cache
  * @returns {Promise<void>}
  */
-export async function writeEnvironments(cache) {
+export async function writeEnvironments(cache: Cache) {
   const environments = getAllEnvironments();
   const environmentIds = new Set<string>();
 
@@ -2319,7 +2323,7 @@ export async function writeEnvironments(cache) {
  * @param {LMDBLiteCache} cache
  * @returns {Promise<void>}
  */
-export async function loadEnvironmentsFromCache(cache) {
+export async function loadEnvironmentsFromCache(cache: Cache) {
   const cachedEnvIds = await cache.get(
     `EnvironmentManager/${ATLASPACK_VERSION}`,
   );

--- a/packages/core/core/src/RequestTracker.js
+++ b/packages/core/core/src/RequestTracker.js
@@ -15,7 +15,11 @@ import type {
   Graph,
 } from '@atlaspack/graph';
 import logger, {instrument} from '@atlaspack/logger';
-import {hashString} from '@atlaspack/rust';
+import {
+  hashString,
+  getAllEnvironments,
+  setAllEnvironments,
+} from '@atlaspack/rust';
 import type {Async, EnvMap} from '@atlaspack/types';
 import {
   type Deferred,
@@ -30,15 +34,15 @@ import nullthrows from 'nullthrows';
 
 import {
   ATLASPACK_VERSION,
-  VALID,
-  INITIAL_BUILD,
   FILE_CREATE,
-  FILE_UPDATE,
   FILE_DELETE,
+  FILE_UPDATE,
   ENV_CHANGE,
+  ERROR,
+  INITIAL_BUILD,
   OPTION_CHANGE,
   STARTUP,
-  ERROR,
+  VALID,
 } from './constants';
 import type {AtlaspackV3} from './atlaspack-v3/AtlaspackV3';
 import {
@@ -1572,6 +1576,12 @@ export default class RequestTracker {
         size: this.graph.nodes.length,
       });
 
+      if (getFeatureFlag('environmentDeduplication')) {
+        async (cache) => {
+          await writeEnvironments(cache);
+        };
+      }
+
       let serialisedGraph = this.graph.serialize();
 
       // Delete an existing request graph cache, to prevent invalid states
@@ -1855,6 +1865,28 @@ async function loadRequestGraph(options): Async<RequestGraph> {
       ...commonMeta,
     },
   });
+
+  if (getFeatureFlag('environmentDeduplication')) {
+    try {
+      await loadEnvironmentsFromCache(options.cache);
+      logger.verbose({
+        origin: '@atlaspack/core',
+        message: 'Environments were loaded from cache',
+        meta: {
+          ...commonMeta,
+        },
+      });
+    } catch (err) {
+      logger.warn({
+        origin: '@atlaspack/core',
+        message: 'Failed to load environments from cache',
+        meta: {
+          ...commonMeta,
+          error: err,
+        },
+      });
+    }
+  }
 
   const hasRequestGraphInCache = getFeatureFlag('cachePerformanceImprovements')
     ? await options.cache.has(requestGraphKey)
@@ -2224,4 +2256,87 @@ export function getBiggestFSEventsInvalidations(
   invalidations.sort((a, b) => b.count - a.count);
 
   return invalidations.slice(0, limit);
+}
+
+/**
+ * Stores an environment object by its ID
+ * @param {LMDBLiteCache} cache
+ * @param {Environment} env
+ */
+export async function storeEnvById(cache, env) {
+  const envKey = `Environment/${ATLASPACK_VERSION}/${env.id}`;
+
+  if (await cache.get(envKey)) {
+    return;
+  }
+
+  await instrument(
+    `RequestTracker::writeToCache::cache.put(${envKey})`,
+    async () => {
+      await cache.set(envKey, env);
+    },
+  );
+}
+
+/**
+ * Stores the list of environment IDs
+ * @param {LMDBLiteCache} cache
+ * @param {Set<string>} environmentIds
+ */
+export async function storeEnvManager(cache, environmentIds) {
+  await instrument(
+    `RequestTracker::writeToCache::cache.put(${`EnvironmentManager/${ATLASPACK_VERSION}`})`,
+    async () => {
+      await cache.set(
+        `EnvironmentManager/${ATLASPACK_VERSION}`,
+        Array.from(environmentIds),
+      );
+    },
+  );
+}
+
+/**
+ * Writes all environments and their IDs to the cache
+ * @param {LMDBLiteCache} cache
+ * @returns {Promise<void>}
+ */
+export async function writeEnvironments(cache) {
+  const environments = getAllEnvironments();
+  const environmentIds = new Set<string>();
+
+  // Store each environment individually
+  for (const env of environments) {
+    environmentIds.add(env.id);
+    await storeEnvById(cache, env);
+  }
+
+  // Store the list of environment IDs
+  await storeEnvManager(cache, environmentIds);
+}
+
+/**
+ * Loads all environments and their IDs from the cache
+ * @param {LMDBLiteCache} cache
+ * @returns {Promise<void>}
+ */
+export async function loadEnvironmentsFromCache(cache) {
+  const cachedEnvIds = await cache.get(
+    `EnvironmentManager/${ATLASPACK_VERSION}`,
+  );
+
+  if (cachedEnvIds == null) {
+    return;
+  }
+
+  const environments = [];
+  for (const envId of cachedEnvIds) {
+    const envKey = `Environment/${ATLASPACK_VERSION}/${envId}`;
+    const cachedEnv = await cache.get(envKey);
+    if (cachedEnv != null) {
+      environments.push(cachedEnv);
+    }
+  }
+  if (environments.length > 0) {
+    setAllEnvironments(environments);
+  }
 }

--- a/packages/core/core/test/EnvironmentManager.test.js
+++ b/packages/core/core/test/EnvironmentManager.test.js
@@ -1,0 +1,192 @@
+// @flow strict-local
+
+import assert from 'assert';
+import nullthrows from 'nullthrows';
+import sinon from 'sinon';
+import {ATLASPACK_VERSION} from '../src/constants';
+import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '@atlaspack/feature-flags';
+import {setAllEnvironments, getAllEnvironments} from '@atlaspack/rust';
+import {
+  loadEnvironmentsFromCache,
+  writeEnvironmentsToCache,
+} from '../src/EnvironmentManager';
+import {DEFAULT_OPTIONS} from './test-utils';
+import {LMDBLiteCache} from '@atlaspack/cache';
+
+const options = {
+  ...DEFAULT_OPTIONS,
+  cache: new LMDBLiteCache(DEFAULT_OPTIONS.cacheDir),
+};
+
+describe('EnvironmentManager', () => {
+  const env1 = {
+    id: 'd821e85f6b50315e',
+    context: 'browser',
+    engines: {browsers: ['> 0.25%']},
+    includeNodeModules: true,
+    outputFormat: 'global',
+    isLibrary: false,
+    shouldOptimize: false,
+    shouldScopeHoist: false,
+    loc: undefined,
+    sourceMap: undefined,
+    sourceType: 'module',
+    unstableSingleFileOutput: false,
+  };
+  const env2 = {
+    id: 'de92f48baa8448d2',
+    context: 'node',
+    engines: {
+      browsers: [],
+      node: '>= 8',
+    },
+    includeNodeModules: false,
+    outputFormat: 'commonjs',
+    isLibrary: true,
+    shouldOptimize: true,
+    shouldScopeHoist: true,
+    loc: null,
+    sourceMap: null,
+    sourceType: 'module',
+    unstableSingleFileOutput: false,
+  };
+
+  beforeEach(async () => {
+    await options.cache.ensure();
+
+    for (const key of options.cache.keys()) {
+      await options.cache.getNativeRef().delete(key);
+    }
+    setAllEnvironments([]);
+
+    setFeatureFlags({
+      ...DEFAULT_FEATURE_FLAGS,
+      environmentDeduplication: true,
+    });
+  });
+
+  it('should store environments by ID in the cache', async () => {
+    setAllEnvironments([env1]);
+    await writeEnvironmentsToCache(options.cache);
+
+    const cachedEnv1 = await options.cache.get(
+      `Environment/${ATLASPACK_VERSION}/${env1.id}`,
+    );
+    assert.deepEqual(cachedEnv1, env1, 'Environment 1 should be cached');
+  });
+
+  it('should list all environment IDs in the environment manager', async () => {
+    const environmentIds = [env1.id, env2.id];
+    setAllEnvironments([env1, env2]);
+    await writeEnvironmentsToCache(options.cache);
+
+    const cachedEnvIds = await options.cache.get(
+      `EnvironmentManager/${ATLASPACK_VERSION}`,
+    );
+    const cachedIdsArray = nullthrows(cachedEnvIds);
+    assert.equal(
+      cachedIdsArray.length,
+      environmentIds.length,
+      'Should have same number of IDs',
+    );
+    assert(
+      environmentIds.every((id) => cachedIdsArray.includes(id)),
+      'All environment IDs should be present in cache',
+    );
+  });
+
+  it('should write all environments to cache using writeEnvironmentsToCache', async () => {
+    setAllEnvironments([env1, env2]);
+    await writeEnvironmentsToCache(options.cache);
+
+    // Verify each environment was stored individually
+    const cachedEnv1 = await options.cache.get(
+      `Environment/${ATLASPACK_VERSION}/${env1.id}`,
+    );
+    const cachedEnv2 = await options.cache.get(
+      `Environment/${ATLASPACK_VERSION}/${env2.id}`,
+    );
+    assert.deepEqual(cachedEnv1, env1, 'Environment 1 should be cached');
+    assert.deepEqual(cachedEnv2, env2, 'Environment 2 should be cached');
+
+    // Verify environment IDs were stored in manager
+    const cachedEnvIds = await options.cache.get(
+      `EnvironmentManager/${ATLASPACK_VERSION}`,
+    );
+    const cachedIdsArray = nullthrows(cachedEnvIds);
+    assert(
+      cachedIdsArray.length === 2 &&
+        [env1.id, env2.id].every((id) => cachedIdsArray.includes(id)),
+      'Environment IDs should be stored in manager',
+    );
+  });
+
+  it('should load environments from cache on loadRequestGraph on a subsequent build', async () => {
+    // Simulate cache written on a first build
+    setAllEnvironments([env1, env2]);
+    await writeEnvironmentsToCache(options.cache);
+
+    await loadEnvironmentsFromCache(options.cache);
+
+    const loadedEnvironments = getAllEnvironments();
+    assert.equal(
+      loadedEnvironments.length,
+      2,
+      'Should load 2 environments from cache',
+    );
+
+    const env1Loaded = loadedEnvironments.find((e) => e.id === env1.id);
+    const env2Loaded = loadedEnvironments.find((e) => e.id === env2.id);
+
+    assert.deepEqual(
+      env1Loaded,
+      env1,
+      'First environment should match cached environment',
+    );
+    assert.deepEqual(
+      env2Loaded,
+      env2,
+      'Second environment should match cached environment',
+    );
+  });
+
+  it('should handle empty cache gracefully without calling setAllEnvironments', async () => {
+    const setAllEnvironmentsSpy = sinon.spy(setAllEnvironments);
+
+    await assert.doesNotReject(
+      loadEnvironmentsFromCache(options.cache),
+      'loadEnvironmentsFromCache should not throw when cache is empty',
+    );
+
+    assert.equal(
+      setAllEnvironmentsSpy.callCount,
+      0,
+      'setAllEnvironments should not be called when loading from empty cache',
+    );
+  });
+
+  it('should not load environments from a different version', async () => {
+    const setAllEnvironmentsSpy = sinon.spy(setAllEnvironments);
+    const differentVersion = '2.17.2'; // A different version than ATLASPACK_VERSION
+
+    // Store an environment with a different version
+    await options.cache.set(`Environment/${differentVersion}/${env1.id}`, env1);
+    await options.cache.set(`EnvironmentManager/${differentVersion}`, [
+      env1.id,
+    ]);
+
+    await loadEnvironmentsFromCache(options.cache);
+
+    assert.equal(
+      setAllEnvironmentsSpy.callCount,
+      0,
+      'setAllEnvironments should not be called when loading from different version',
+    );
+    const loadedEnvironments = getAllEnvironments();
+    assert.equal(
+      loadedEnvironments.length,
+      0,
+      'Should not load any environments from different version',
+    );
+  });
+});

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -8,27 +8,17 @@ import RequestTracker, {
   runInvalidation,
   getBiggestFSEventsInvalidations,
   invalidateRequestGraphFSEvents,
-  loadEnvironmentsFromCache,
-  storeEnvById,
-  storeEnvManager,
-  writeEnvironments,
 } from '../src/RequestTracker';
 import {Graph} from '@atlaspack/graph';
 import {LMDBLiteCache} from '@atlaspack/cache';
 import WorkerFarm from '@atlaspack/workers';
 import {DEFAULT_OPTIONS} from './test-utils';
-import {
-  FILE_CREATE,
-  FILE_UPDATE,
-  INITIAL_BUILD,
-  ATLASPACK_VERSION,
-} from '../src/constants';
+import {FILE_CREATE, FILE_UPDATE, INITIAL_BUILD} from '../src/constants';
 import {makeDeferredWithPromise} from '@atlaspack/utils';
 import {toProjectPath} from '../src/projectPath';
 import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
 import sinon from 'sinon';
 import type {AtlaspackOptions} from '../src/types';
-import {setAllEnvironments, getAllEnvironments} from '@atlaspack/rust';
 
 const options = {
   ...DEFAULT_OPTIONS,
@@ -704,169 +694,5 @@ describe('getBiggestFSEventsInvalidations', () => {
       {path: 'file-3', count: 8000},
       {path: 'file-2', count: 5000},
     ]);
-  });
-});
-
-describe('environment caching', () => {
-  const env1 = {
-    id: 'd821e85f6b50315e',
-    context: 'browser',
-    engines: {browsers: ['> 0.25%']},
-    includeNodeModules: true,
-    outputFormat: 'global',
-    isLibrary: false,
-    shouldOptimize: false,
-    shouldScopeHoist: false,
-    loc: undefined,
-    sourceMap: undefined,
-    sourceType: 'module',
-    unstableSingleFileOutput: false,
-  };
-  const env2 = {
-    id: 'de92f48baa8448d2',
-    context: 'node',
-    engines: {
-      browsers: [],
-      node: '>= 8',
-    },
-    includeNodeModules: false,
-    outputFormat: 'commonjs',
-    isLibrary: true,
-    shouldOptimize: true,
-    shouldScopeHoist: true,
-    loc: null,
-    sourceMap: null,
-    sourceType: 'module',
-    unstableSingleFileOutput: false,
-  };
-
-  beforeEach(async () => {
-    await options.cache.ensure();
-
-    for (const key of options.cache.keys()) {
-      await options.cache.getNativeRef().delete(key);
-    }
-    setAllEnvironments([]);
-
-    setFeatureFlags({
-      ...DEFAULT_FEATURE_FLAGS,
-      environmentDeduplication: true,
-    });
-  });
-
-  it('should store environments by ID in the cache', async () => {
-    await storeEnvById(options.cache, env1);
-
-    const cachedEnv1 = await options.cache.get(
-      `Environment/${ATLASPACK_VERSION}/${env1.id}`,
-    );
-    assert.deepEqual(cachedEnv1, env1, 'Environment 1 should be cached');
-  });
-
-  it('should list all environment IDs in the environment manager', async () => {
-    const environmentIds = ['env1', 'env2'];
-
-    await storeEnvManager(options.cache, environmentIds);
-
-    const cachedEnvIds = await options.cache.get(
-      `EnvironmentManager/${ATLASPACK_VERSION}`,
-    );
-    assert.deepEqual(cachedEnvIds, Array.from(environmentIds));
-  });
-
-  it('should write all environments to cache using writeEnvironments', async () => {
-    setAllEnvironments([env1, env2]);
-    await writeEnvironments(options.cache);
-
-    // Verify each environment was stored individually
-    const cachedEnv1 = await options.cache.get(
-      `Environment/${ATLASPACK_VERSION}/${env1.id}`,
-    );
-    const cachedEnv2 = await options.cache.get(
-      `Environment/${ATLASPACK_VERSION}/${env2.id}`,
-    );
-    assert.deepEqual(cachedEnv1, env1, 'Environment 1 should be cached');
-    assert.deepEqual(cachedEnv2, env2, 'Environment 2 should be cached');
-
-    // Verify environment IDs were stored in manager
-    const cachedEnvIds = await options.cache.get(
-      `EnvironmentManager/${ATLASPACK_VERSION}`,
-    );
-    const cachedIdsArray = nullthrows(cachedEnvIds);
-    assert(
-      cachedIdsArray.length === 2 &&
-        [env1.id, env2.id].every((id) => cachedIdsArray.includes(id)),
-      'Environment IDs should be stored in manager',
-    );
-  });
-
-  it('should load environments from cache on loadRequestGraph on a subsequent build', async () => {
-    // Simulate cache written on a first build
-    await storeEnvById(options.cache, env1);
-    await storeEnvById(options.cache, env2);
-    await storeEnvManager(options.cache, [env1.id, env2.id]);
-
-    await loadEnvironmentsFromCache(options.cache);
-
-    const loadedEnvironments = getAllEnvironments();
-    assert.equal(
-      loadedEnvironments.length,
-      2,
-      'Should load 2 environments from cache',
-    );
-
-    const env1Loaded = loadedEnvironments.find((e) => e.id === env1.id);
-    const env2Loaded = loadedEnvironments.find((e) => e.id === env2.id);
-
-    assert.deepEqual(
-      env1Loaded,
-      env1,
-      'First environment should match cached environment',
-    );
-    assert.deepEqual(
-      env2Loaded,
-      env2,
-      'Second environment should match cached environment',
-    );
-  });
-
-  it('should handle empty cache gracefully without calling setAllEnvironments', async () => {
-    const setAllEnvironmentsSpy = sinon.spy(setAllEnvironments);
-
-    await assert.doesNotReject(
-      loadEnvironmentsFromCache(options.cache),
-      'loadEnvironmentsFromCache should not throw when cache is empty',
-    );
-
-    assert.equal(
-      setAllEnvironmentsSpy.callCount,
-      0,
-      'setAllEnvironments should not be called when loading from empty cache',
-    );
-  });
-
-  it('should not load environments from a different version', async () => {
-    const setAllEnvironmentsSpy = sinon.spy(setAllEnvironments);
-    const differentVersion = '2.17.2'; // A different version than ATLASPACK_VERSION
-
-    // Store an environment with a different version
-    await options.cache.set(`Environment/${differentVersion}/${env1.id}`, env1);
-    await options.cache.set(`EnvironmentManager/${differentVersion}`, [
-      env1.id,
-    ]);
-
-    await loadEnvironmentsFromCache(options.cache);
-
-    assert.equal(
-      setAllEnvironmentsSpy.callCount,
-      0,
-      'setAllEnvironments should not be called when loading from different version',
-    );
-    const loadedEnvironments = getAllEnvironments();
-    assert.equal(
-      loadedEnvironments.length,
-      0,
-      'Should not load any environments from different version',
-    );
   });
 });

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -8,17 +8,28 @@ import RequestTracker, {
   runInvalidation,
   getBiggestFSEventsInvalidations,
   invalidateRequestGraphFSEvents,
+  loadEnvironmentsFromCache,
+  storeEnvById,
+  storeEnvManager,
+  writeEnvironments,
 } from '../src/RequestTracker';
 import {Graph} from '@atlaspack/graph';
 import {LMDBLiteCache} from '@atlaspack/cache';
 import WorkerFarm from '@atlaspack/workers';
 import {DEFAULT_OPTIONS} from './test-utils';
-import {FILE_CREATE, FILE_UPDATE, INITIAL_BUILD} from '../src/constants';
+import {
+  FILE_CREATE,
+  FILE_UPDATE,
+  INITIAL_BUILD,
+  ATLASPACK_VERSION,
+} from '../src/constants';
 import {makeDeferredWithPromise} from '@atlaspack/utils';
 import {toProjectPath} from '../src/projectPath';
 import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
 import sinon from 'sinon';
 import type {AtlaspackOptions} from '../src/types';
+import {setAllEnvironments, getAllEnvironments} from '@atlaspack/rust';
+import sinon from 'sinon';
 
 const options = {
   ...DEFAULT_OPTIONS,
@@ -694,5 +705,169 @@ describe('getBiggestFSEventsInvalidations', () => {
       {path: 'file-3', count: 8000},
       {path: 'file-2', count: 5000},
     ]);
+  });
+});
+
+describe('environment caching', () => {
+  const env1 = {
+    id: 'd821e85f6b50315e',
+    context: 'browser',
+    engines: {browsers: ['> 0.25%']},
+    includeNodeModules: true,
+    outputFormat: 'global',
+    isLibrary: false,
+    shouldOptimize: false,
+    shouldScopeHoist: false,
+    loc: undefined,
+    sourceMap: undefined,
+    sourceType: 'module',
+    unstableSingleFileOutput: false,
+  };
+  const env2 = {
+    id: 'de92f48baa8448d2',
+    context: 'node',
+    engines: {
+      browsers: [],
+      node: '>= 8',
+    },
+    includeNodeModules: false,
+    outputFormat: 'commonjs',
+    isLibrary: true,
+    shouldOptimize: true,
+    shouldScopeHoist: true,
+    loc: null,
+    sourceMap: null,
+    sourceType: 'module',
+    unstableSingleFileOutput: false,
+  };
+
+  beforeEach(async () => {
+    await options.cache.ensure();
+
+    for (const key of options.cache.keys()) {
+      await options.cache.getNativeRef().delete(key);
+    }
+    setAllEnvironments([]);
+
+    setFeatureFlags({
+      ...DEFAULT_FEATURE_FLAGS,
+      environmentDeduplication: true,
+    });
+  });
+
+  it('should store environments by ID in the cache', async () => {
+    await storeEnvById(options.cache, env1);
+
+    const cachedEnv1 = await options.cache.get(
+      `Environment/${ATLASPACK_VERSION}/${env1.id}`,
+    );
+    assert.deepEqual(cachedEnv1, env1, 'Environment 1 should be cached');
+  });
+
+  it('should list all environment IDs in the environment manager', async () => {
+    const environmentIds = ['env1', 'env2'];
+
+    await storeEnvManager(options.cache, environmentIds);
+
+    const cachedEnvIds = await options.cache.get(
+      `EnvironmentManager/${ATLASPACK_VERSION}`,
+    );
+    assert.deepEqual(cachedEnvIds, Array.from(environmentIds));
+  });
+
+  it('should write all environments to cache using writeEnvironments', async () => {
+    setAllEnvironments([env1, env2]);
+    await writeEnvironments(options.cache);
+
+    // Verify each environment was stored individually
+    const cachedEnv1 = await options.cache.get(
+      `Environment/${ATLASPACK_VERSION}/${env1.id}`,
+    );
+    const cachedEnv2 = await options.cache.get(
+      `Environment/${ATLASPACK_VERSION}/${env2.id}`,
+    );
+    assert.deepEqual(cachedEnv1, env1, 'Environment 1 should be cached');
+    assert.deepEqual(cachedEnv2, env2, 'Environment 2 should be cached');
+
+    // Verify environment IDs were stored in manager
+    const cachedEnvIds = await options.cache.get(
+      `EnvironmentManager/${ATLASPACK_VERSION}`,
+    );
+    const cachedIdsArray = nullthrows(cachedEnvIds);
+    assert(
+      cachedIdsArray.length === 2 &&
+        [env1.id, env2.id].every((id) => cachedIdsArray.includes(id)),
+      'Environment IDs should be stored in manager',
+    );
+  });
+
+  it('should load environments from cache on loadRequestGraph on a subsequent build', async () => {
+    // Simulate cache written on a first build
+    await storeEnvById(options.cache, env1);
+    await storeEnvById(options.cache, env2);
+    await storeEnvManager(options.cache, [env1.id, env2.id]);
+
+    await loadEnvironmentsFromCache(options.cache);
+
+    const loadedEnvironments = getAllEnvironments();
+    assert.equal(
+      loadedEnvironments.length,
+      2,
+      'Should load 2 environments from cache',
+    );
+
+    const env1Loaded = loadedEnvironments.find((e) => e.id === env1.id);
+    const env2Loaded = loadedEnvironments.find((e) => e.id === env2.id);
+
+    assert.deepEqual(
+      env1Loaded,
+      env1,
+      'First environment should match cached environment',
+    );
+    assert.deepEqual(
+      env2Loaded,
+      env2,
+      'Second environment should match cached environment',
+    );
+  });
+
+  it('should handle empty cache gracefully without calling setAllEnvironments', async () => {
+    const setAllEnvironmentsSpy = sinon.spy(setAllEnvironments);
+
+    await assert.doesNotReject(
+      loadEnvironmentsFromCache(options.cache),
+      'loadEnvironmentsFromCache should not throw when cache is empty',
+    );
+
+    assert.equal(
+      setAllEnvironmentsSpy.callCount,
+      0,
+      'setAllEnvironments should not be called when loading from empty cache',
+    );
+  });
+
+  it('should not load environments from a different version', async () => {
+    const setAllEnvironmentsSpy = sinon.spy(setAllEnvironments);
+    const differentVersion = '2.17.2'; // A different version than ATLASPACK_VERSION
+
+    // Store an environment with a different version
+    await options.cache.set(`Environment/${differentVersion}/${env1.id}`, env1);
+    await options.cache.set(`EnvironmentManager/${differentVersion}`, [
+      env1.id,
+    ]);
+
+    await loadEnvironmentsFromCache(options.cache);
+
+    assert.equal(
+      setAllEnvironmentsSpy.callCount,
+      0,
+      'setAllEnvironments should not be called when loading from different version',
+    );
+    const loadedEnvironments = getAllEnvironments();
+    assert.equal(
+      loadedEnvironments.length,
+      0,
+      'Should not load any environments from different version',
+    );
   });
 });

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -29,7 +29,6 @@ import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
 import sinon from 'sinon';
 import type {AtlaspackOptions} from '../src/types';
 import {setAllEnvironments, getAllEnvironments} from '@atlaspack/rust';
-import sinon from 'sinon';
 
 const options = {
   ...DEFAULT_OPTIONS,


### PR DESCRIPTION
PR, based on https://github.com/atlassian-labs/atlaspack/pull/572

---
- We want to list all environments using `getAllEnvironments` then store them into the cache inside of `RequestTracker::writeToCache`
- Environments should be stored as: `Environment/$ATLASPACK_VERSION/$ENVIRONMENT_ID`
- A separate key should be stored: `EnvironmentManager/$ATLASPACK_VERSION`. This should contain the list of environment IDs used in the last build.
- When loading the request tracker in `loadRequestGraph`, we should load the environments required for the previous build.

