### PR TITLE
Merge common shared bundles

### DIFF
--- a/.changeset/perfect-pianos-judge.md
+++ b/.changeset/perfect-pianos-judge.md
@@ -1,0 +1,98 @@
+---
+'@atlaspack/bundler-default': major
+---
+
+# Breaking change
+
+This new config replaces the previously released `sharedBundleMergeThreshold`.
+
+The following options are available for each merge group.
+
+# Options
+
+## overlapThreshold
+
+> The same as `sharedBundleMergeThreshold` from #535
+
+Merge bundles share a percentage of source bundles
+
+```json
+"@atlaspack/bundler-default": {
+  "sharedBundleMerge": [{
+    "overlapThreshold": 0.75
+  }]
+}
+```
+
+## maxBundleSize
+
+Merge bundles that are smaller than a configured amount of bytes.
+
+> Keep in mind these bytes are pre-optimisation
+
+```json
+"@atlaspack/bundler-default": {
+  "sharedBundleMerge": [{
+    "maxBundleSize": 20000
+  }]
+}
+```
+
+## sourceBundles
+
+Merge bundles that share a set of source bundles. The matching is relative to the project root, like how manual shared bundle roots work.
+
+```json
+"@atlaspack/bundler-default": {
+  "sharedBundleMerge": [{
+    "sourceBundles": ["src/important-route", "src/important-route-2"]
+  }]
+}
+```
+
+## minBundlesInGroup
+
+Merge bundles that belong to a bundle group that's larger than a set amount. This is useful for targetting bundles that would be deleted by the `maxParallelRequests` option.
+
+```json
+"@atlaspack/bundler-default": {
+  "maxParallelRequests": 30,
+  "sharedBundleMerge": [{
+    "minBundlesInGroup": 30
+  }]
+}
+```
+
+# Combining options
+
+When multiple options are provided, all must be true for a merge to be relevant.
+
+For example, merge bundles that are smaller than 20kb and share at least 50% of the same source bundles.
+
+```json
+"@atlaspack/bundler-default": {
+  "sharedBundleMerge": [{
+    "overlapThreshold": 0.5,
+    "maxBundleSize": 20000
+  }]
+}
+```
+
+# Multiple merges
+
+You can also have multiple merge configs.
+
+```json
+"@atlaspack/bundler-default": {
+  "sharedBundleMerge": [
+     {
+        "overlapThreshold": 0.75,
+        "maxBundleSize": 20000
+     },
+     {
+        "minBundlesInGroup": 30
+        "sourceBundles": ["src/important-route", "src/important-route-2"]
+     }
+  ]
+}
+```

--- a/.changeset/perfect-pianos-judge.md
+++ b/.changeset/perfect-pianos-judge.md
@@ -2,15 +2,15 @@
 '@atlaspack/bundler-default': major
 ---
 
-# Breaking change
+### Breaking change
 
 This new config replaces the previously released `sharedBundleMergeThreshold`.
 
 The following options are available for each merge group.
 
-# Options
+### Options
 
-## overlapThreshold
+#### overlapThreshold
 
 > The same as `sharedBundleMergeThreshold` from #535
 
@@ -24,7 +24,7 @@ Merge bundles share a percentage of source bundles
 }
 ```
 
-## maxBundleSize
+#### maxBundleSize
 
 Merge bundles that are smaller than a configured amount of bytes.
 
@@ -38,7 +38,7 @@ Merge bundles that are smaller than a configured amount of bytes.
 }
 ```
 
-## sourceBundles
+#### sourceBundles
 
 Merge bundles that share a set of source bundles. The matching is relative to the project root, like how manual shared bundle roots work.
 
@@ -50,7 +50,7 @@ Merge bundles that share a set of source bundles. The matching is relative to th
 }
 ```
 
-## minBundlesInGroup
+#### minBundlesInGroup
 
 Merge bundles that belong to a bundle group that's larger than a set amount. This is useful for targetting bundles that would be deleted by the `maxParallelRequests` option.
 
@@ -63,7 +63,7 @@ Merge bundles that belong to a bundle group that's larger than a set amount. Thi
 }
 ```
 
-# Combining options
+## Combining options
 
 When multiple options are provided, all must be true for a merge to be relevant.
 
@@ -78,7 +78,7 @@ For example, merge bundles that are smaller than 20kb and share at least 50% of 
 }
 ```
 
-# Multiple merges
+## Multiple merges
 
 You can also have multiple merge configs.
 

--- a/.changeset/quiet-files-jump.md
+++ b/.changeset/quiet-files-jump.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/graph': minor
+---
+
+Add static intersect, size and equals methods to BitSet

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -22,6 +22,7 @@
     "@atlaspack/plugin": "2.14.10",
     "@atlaspack/rust": "3.3.5",
     "@atlaspack/utils": "2.14.10",
-    "nullthrows": "^1.1.1"
+    "nullthrows": "^1.1.1",
+    "many-keys-map": "^2.0.1"
   }
 }

--- a/packages/bundlers/default/src/bundleMerge.js
+++ b/packages/bundlers/default/src/bundleMerge.js
@@ -4,133 +4,251 @@ import invariant from 'assert';
 import nullthrows from 'nullthrows';
 import type {NodeId} from '@atlaspack/graph';
 import type {Bundle, IdealBundleGraph} from './idealGraph';
-import {ContentGraph} from '@atlaspack/graph';
+import {ContentGraph, BitSet} from '@atlaspack/graph';
+import {memoize, clearCaches} from './memoize';
+
+function getBundlesForBundleGroup(
+  bundleGraph: IdealBundleGraph,
+  bundleGroupId: NodeId,
+): number {
+  let count = 0;
+  bundleGraph.traverse((nodeId) => {
+    if (bundleGraph.getNode(nodeId)?.bundleBehavior !== 'inline') {
+      count++;
+    }
+  }, bundleGroupId);
+  return count;
+}
+
+let getBundleOverlapBitSet = (
+  sourceBundlesA: BitSet,
+  sourceBundlesB: BitSet,
+): number => {
+  let allSourceBundles = BitSet.union(sourceBundlesA, sourceBundlesB);
+  let sharedSourceBundles = BitSet.intersect(sourceBundlesA, sourceBundlesB);
+
+  return sharedSourceBundles.size() / allSourceBundles.size();
+};
 
 // Returns a decimal showing the proportion source bundles are common to
 // both bundles versus the total number of source bundles.
 function checkBundleThreshold(
-  bundleA: Bundle,
-  bundleB: Bundle,
+  bundleA: MergeCandidate,
+  bundleB: MergeCandidate,
   threshold: number,
 ): boolean {
-  let sharedSourceBundles = 0;
-  let allSourceBundles = new Set([
-    ...bundleA.sourceBundles,
-    ...bundleB.sourceBundles,
-  ]);
-
-  for (let bundle of bundleB.sourceBundles) {
-    if (bundleA.sourceBundles.has(bundle)) {
-      sharedSourceBundles++;
-    }
-  }
-
-  let score = sharedSourceBundles / allSourceBundles.size;
-  return score >= threshold;
+  return (
+    getBundleOverlapBitSet(
+      bundleA.sourceBundleBitSet,
+      bundleB.sourceBundleBitSet,
+    ) >= threshold
+  );
 }
 
-function checkAncestorOverlap(
-  bundleA: Bundle,
-  bundleB: Bundle,
-  importantAncestorBundles: Array<Array<NodeId>>,
-): boolean {
-  if (importantAncestorBundles.length === 0) {
+let checkAncestorOverlap = memoize(
+  (bundle: Bundle, importantAncestorBundles: Array<NodeId>): boolean => {
+    return importantAncestorBundles.every((ancestorId) =>
+      bundle.sourceBundles.has(ancestorId),
+    );
+  },
+);
+
+let hasSuitableBundleGroup = memoize(
+  (
+    bundleGraph: IdealBundleGraph,
+    bundle: Bundle,
+    minBundlesInGroup: number,
+  ): boolean => {
+    for (let sourceBundle of bundle.sourceBundles) {
+      let bundlesInGroup = getBundlesForBundleGroup(bundleGraph, sourceBundle);
+
+      if (bundlesInGroup >= minBundlesInGroup) {
+        return true;
+      }
+    }
     return false;
-  }
+  },
+);
 
-  for (let ancestorBundle of importantAncestorBundles) {
-    let bundleAHasAllAncestors = ancestorBundle.every((ancestorId) =>
-      bundleA.sourceBundles.has(ancestorId),
-    );
-
-    let bundleBHasAllAncestors = ancestorBundle.every((ancestorId) =>
-      bundleB.sourceBundles.has(ancestorId),
-    );
-
-    if (bundleAHasAllAncestors && bundleBHasAllAncestors) {
-      return true;
+function validMerge(
+  bundleGraph: IdealBundleGraph,
+  config: MergeGroup,
+  bundleA: MergeCandidate,
+  bundleB: MergeCandidate,
+): boolean {
+  if (config.maxBundleSize != null) {
+    if (
+      bundleA.bundle.size > config.maxBundleSize ||
+      bundleB.bundle.size > config.maxBundleSize
+    ) {
+      return false;
     }
   }
 
-  return false;
+  if (config.overlapThreshold != null) {
+    if (!checkBundleThreshold(bundleA, bundleB, config.overlapThreshold)) {
+      return false;
+    }
+  }
+
+  if (config.importantAncestorBundles != null) {
+    if (
+      !checkAncestorOverlap(bundleA.bundle, config.importantAncestorBundles) ||
+      !checkAncestorOverlap(bundleB.bundle, config.importantAncestorBundles)
+    ) {
+      return false;
+    }
+  }
+
+  if (config.minBundlesInGroup != null) {
+    if (
+      !hasSuitableBundleGroup(
+        bundleGraph,
+        bundleA.bundle,
+        config.minBundlesInGroup,
+      ) ||
+      !hasSuitableBundleGroup(
+        bundleGraph,
+        bundleB.bundle,
+        config.minBundlesInGroup,
+      )
+    ) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function getMergeClusters(
-  graph: ContentGraph<NodeId>,
-  candidates: Set<NodeId>,
+  graph: ContentGraph<NodeId, EdgeType>,
+  candidates: Map<NodeId, EdgeType>,
 ): Array<Array<NodeId>> {
   let clusters = [];
 
-  for (let candidate of candidates) {
+  for (let [candidate, edgeType] of candidates.entries()) {
     let cluster: Array<NodeId> = [];
 
-    graph.traverse((nodeId) => {
-      cluster.push(nullthrows(graph.getNode(nodeId)));
-      // Remove node from candidates as it has already been processed
-      candidates.delete(nodeId);
-    }, candidate);
-
+    graph.traverse(
+      (nodeId) => {
+        cluster.push(nullthrows(graph.getNode(nodeId)));
+        // Remove node from candidates as it has already been processed
+        candidates.delete(nodeId);
+      },
+      candidate,
+      edgeType,
+    );
     clusters.push(cluster);
   }
 
   return clusters;
 }
 
-export function findMergeCandidates(
+type MergeCandidate = {|
+  bundle: Bundle,
+  id: NodeId,
+  sourceBundleBitSet: BitSet,
+  contentKey: string,
+|};
+function getPossibleMergeCandidates(
   bundleGraph: IdealBundleGraph,
   bundles: Array<NodeId>,
-  threshold: number,
-  importantAncestorBundles: Array<Array<NodeId>> = [],
-): Array<Array<NodeId>> {
-  let graph = new ContentGraph<NodeId>();
-  let seen = new Set<string>();
-  let candidates = new Set<NodeId>();
-
-  // Build graph of clustered merge candidates
-  for (let bundleId of bundles) {
+): Array<[MergeCandidate, MergeCandidate]> {
+  let mergeCandidates = bundles.map((bundleId) => {
     let bundle = bundleGraph.getNode(bundleId);
-    invariant(bundle && bundle !== 'root');
-    if (bundle.type !== 'js') {
-      continue;
+    invariant(bundle && bundle !== 'root', 'Bundle should exist');
+
+    let sourceBundleBitSet = new BitSet(bundleGraph.nodes.length);
+    for (let sourceBundle of bundle.sourceBundles) {
+      sourceBundleBitSet.add(sourceBundle);
     }
 
-    for (let otherBundleId of bundles) {
-      if (bundleId === otherBundleId) {
-        continue;
-      }
+    return {
+      id: bundleId,
+      bundle,
+      sourceBundleBitSet,
+      contentKey: bundleId.toString(),
+    };
+  });
 
-      let key = [bundleId, otherBundleId].sort().join(':');
+  const uniquePairs = [];
 
-      if (seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-
-      let otherBundle = bundleGraph.getNode(otherBundleId);
-      invariant(otherBundle && otherBundle !== 'root');
+  for (let i = 0; i < mergeCandidates.length; i++) {
+    for (let j = i + 1; j < mergeCandidates.length; j++) {
+      let a = mergeCandidates[i];
+      let b = mergeCandidates[j];
 
       if (
-        checkBundleThreshold(bundle, otherBundle, threshold) ||
-        checkAncestorOverlap(bundle, otherBundle, importantAncestorBundles)
+        // $FlowFixMe both bundles will always have internalizedAssets
+        a.bundle.internalizedAssets.equal(b.bundle.internalizedAssets)
       ) {
-        let bundleNode = graph.addNodeByContentKeyIfNeeded(
-          bundleId.toString(),
-          bundleId,
-        );
-        let otherBundleNode = graph.addNodeByContentKeyIfNeeded(
-          otherBundleId.toString(),
-          otherBundleId,
-        );
-
-        // Add edge in both directions
-        graph.addEdge(bundleNode, otherBundleNode);
-        graph.addEdge(otherBundleNode, bundleNode);
-
-        candidates.add(bundleNode);
-        candidates.add(otherBundleNode);
+        uniquePairs.push([a, b]);
       }
     }
   }
+  return uniquePairs;
+}
+
+type MergeGroup = {|
+  overlapThreshold?: number,
+  maxBundleSize?: number,
+  importantAncestorBundles?: Array<NodeId>,
+  minBundlesInGroup?: number,
+|};
+type EdgeType = number;
+
+export function findMergeCandidates(
+  bundleGraph: IdealBundleGraph,
+  bundles: Array<NodeId>,
+  config: Array<MergeGroup>,
+): Array<Array<NodeId>> {
+  let graph = new ContentGraph<NodeId, EdgeType>();
+  let candidates = new Map<NodeId, EdgeType>();
+
+  let allPossibleMergeCandidates = getPossibleMergeCandidates(
+    bundleGraph,
+    bundles,
+  );
+
+  // Build graph of clustered merge candidates
+  for (let i = 0; i < config.length; i++) {
+    // Ensure edge type coresponds to config index
+    let edgeType = i + 1;
+
+    for (let group of allPossibleMergeCandidates) {
+      let candidateA = group[0];
+      let candidateB = group[1];
+
+      if (!validMerge(bundleGraph, config[i], candidateA, candidateB)) {
+        continue;
+      }
+
+      let bundleNode = graph.addNodeByContentKeyIfNeeded(
+        candidateA.contentKey,
+        candidateA.id,
+      );
+      let otherBundleNode = graph.addNodeByContentKeyIfNeeded(
+        candidateB.contentKey,
+        candidateB.id,
+      );
+
+      // Add edge in both directions
+      graph.addEdge(bundleNode, otherBundleNode, edgeType);
+      graph.addEdge(otherBundleNode, bundleNode, edgeType);
+
+      candidates.set(bundleNode, edgeType);
+      candidates.set(otherBundleNode, edgeType);
+    }
+
+    // Remove bundles that have been allocated to a higher priority merge
+    allPossibleMergeCandidates = allPossibleMergeCandidates.filter(
+      (group) =>
+        !graph.hasContentKey(group[0].contentKey) &&
+        !graph.hasContentKey(group[1].contentKey),
+    );
+  }
+
+  clearCaches();
 
   return getMergeClusters(graph, candidates);
 }

--- a/packages/bundlers/default/src/bundleMerge.js
+++ b/packages/bundlers/default/src/bundleMerge.js
@@ -2,9 +2,9 @@
 
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
+import {ContentGraph, BitSet} from '@atlaspack/graph';
 import type {NodeId} from '@atlaspack/graph';
 import type {Bundle, IdealBundleGraph} from './idealGraph';
-import {ContentGraph, BitSet} from '@atlaspack/graph';
 import {memoize, clearCaches} from './memoize';
 
 function getBundlesForBundleGroup(
@@ -45,7 +45,7 @@ function checkBundleThreshold(
   );
 }
 
-let checkAncestorOverlap = memoize(
+let checkSharedSourceBundles = memoize(
   (bundle: Bundle, importantAncestorBundles: Array<NodeId>): boolean => {
     return importantAncestorBundles.every((ancestorId) =>
       bundle.sourceBundles.has(ancestorId),
@@ -91,10 +91,10 @@ function validMerge(
     }
   }
 
-  if (config.importantAncestorBundles != null) {
+  if (config.sourceBundles != null) {
     if (
-      !checkAncestorOverlap(bundleA.bundle, config.importantAncestorBundles) ||
-      !checkAncestorOverlap(bundleB.bundle, config.importantAncestorBundles)
+      !checkSharedSourceBundles(bundleA.bundle, config.sourceBundles) ||
+      !checkSharedSourceBundles(bundleB.bundle, config.sourceBundles)
     ) {
       return false;
     }
@@ -189,10 +189,10 @@ function getPossibleMergeCandidates(
   return uniquePairs;
 }
 
-type MergeGroup = {|
+export type MergeGroup = {|
   overlapThreshold?: number,
   maxBundleSize?: number,
-  importantAncestorBundles?: Array<NodeId>,
+  sourceBundles?: Array<NodeId>,
   minBundlesInGroup?: number,
 |};
 type EdgeType = number;

--- a/packages/bundlers/default/src/bundleMerge.js
+++ b/packages/bundlers/default/src/bundleMerge.js
@@ -180,7 +180,7 @@ function getPossibleMergeCandidates(
 
       if (
         // $FlowFixMe both bundles will always have internalizedAssets
-        a.bundle.internalizedAssets.equal(b.bundle.internalizedAssets)
+        a.bundle.internalizedAssets.equals(b.bundle.internalizedAssets)
       ) {
         uniquePairs.push([a, b]);
       }

--- a/packages/bundlers/default/src/bundlerConfig.js
+++ b/packages/bundlers/default/src/bundlerConfig.js
@@ -21,6 +21,13 @@ type ManualSharedBundles = Array<{|
   split?: number,
 |}>;
 
+export type MergeCandidates = Array<{|
+  overlapThreshold?: number,
+  maxBundleSize?: number,
+  sourceBundles?: Array<string>,
+  minBundlesInGroup?: number,
+|}>;
+
 type BaseBundlerConfig = {|
   http?: number,
   minBundles?: number,
@@ -30,6 +37,7 @@ type BaseBundlerConfig = {|
   manualSharedBundles?: ManualSharedBundles,
   loadConditionalBundlesInParallel?: boolean,
   sharedBundleMergeThreshold?: number,
+  sharedBundleMerge?: MergeCandidates,
 |};
 
 type BundlerConfig = {|
@@ -45,6 +53,7 @@ export type ResolvedBundlerConfig = {|
   manualSharedBundles: ManualSharedBundles,
   loadConditionalBundlesInParallel?: boolean,
   sharedBundleMergeThreshold: number,
+  sharedBundleMerge?: MergeCandidates,
 |};
 
 function resolveModeConfig(
@@ -80,6 +89,7 @@ const HTTP_OPTIONS = {
     maxParallelRequests: 6,
     disableSharedBundles: false,
     sharedBundleMergeThreshold: 1,
+    sharedBundleMerge: [],
   },
   '2': {
     minBundles: 1,
@@ -88,6 +98,7 @@ const HTTP_OPTIONS = {
     maxParallelRequests: 25,
     disableSharedBundles: false,
     sharedBundleMergeThreshold: 1,
+    sharedBundleMerge: [],
   },
 };
 
@@ -126,6 +137,30 @@ const CONFIG_SCHEMA: SchemaEntity = {
           },
         },
         required: ['name', 'assets'],
+        additionalProperties: false,
+      },
+    },
+    sharedBundleMerge: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          overlapThreshold: {
+            type: 'number',
+          },
+          maxBundleSize: {
+            type: 'number',
+          },
+          sourceBundles: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          minBundlesInGroup: {
+            type: 'number',
+          },
+        },
         additionalProperties: false,
       },
     },
@@ -243,6 +278,8 @@ export async function loadBundlerConfig(
     sharedBundleMergeThreshold:
       modeConfig.sharedBundleMergeThreshold ??
       defaults.sharedBundleMergeThreshold,
+    sharedBundleMerge:
+      modeConfig.sharedBundleMerge ?? defaults.sharedBundleMerge,
     maxParallelRequests:
       modeConfig.maxParallelRequests ?? defaults.maxParallelRequests,
     projectRoot: options.projectRoot,

--- a/packages/bundlers/default/src/bundlerConfig.js
+++ b/packages/bundlers/default/src/bundlerConfig.js
@@ -36,7 +36,6 @@ type BaseBundlerConfig = {|
   disableSharedBundles?: boolean,
   manualSharedBundles?: ManualSharedBundles,
   loadConditionalBundlesInParallel?: boolean,
-  sharedBundleMergeThreshold?: number,
   sharedBundleMerge?: MergeCandidates,
 |};
 
@@ -52,7 +51,6 @@ export type ResolvedBundlerConfig = {|
   disableSharedBundles: boolean,
   manualSharedBundles: ManualSharedBundles,
   loadConditionalBundlesInParallel?: boolean,
-  sharedBundleMergeThreshold: number,
   sharedBundleMerge?: MergeCandidates,
 |};
 
@@ -88,7 +86,6 @@ const HTTP_OPTIONS = {
     minBundleSize: 30000,
     maxParallelRequests: 6,
     disableSharedBundles: false,
-    sharedBundleMergeThreshold: 1,
     sharedBundleMerge: [],
   },
   '2': {
@@ -97,7 +94,6 @@ const HTTP_OPTIONS = {
     minBundleSize: 20000,
     maxParallelRequests: 25,
     disableSharedBundles: false,
-    sharedBundleMergeThreshold: 1,
     sharedBundleMerge: [],
   },
 };
@@ -275,9 +271,6 @@ export async function loadBundlerConfig(
   return {
     minBundles: modeConfig.minBundles ?? defaults.minBundles,
     minBundleSize: modeConfig.minBundleSize ?? defaults.minBundleSize,
-    sharedBundleMergeThreshold:
-      modeConfig.sharedBundleMergeThreshold ??
-      defaults.sharedBundleMergeThreshold,
     sharedBundleMerge:
       modeConfig.sharedBundleMerge ?? defaults.sharedBundleMerge,
     maxParallelRequests:

--- a/packages/bundlers/default/src/memoize.js
+++ b/packages/bundlers/default/src/memoize.js
@@ -1,0 +1,35 @@
+// @flow strict
+
+// $FlowFixMe
+import ManyKeysMap from 'many-keys-map';
+
+let caches = [];
+
+export function clearCaches() {
+  for (let cache of caches) {
+    cache.clear();
+  }
+}
+
+export function memoize<Args: Array<mixed>, Return>(
+  fn: (...args: Args) => Return,
+): (...args: Args) => Return {
+  let cache = new ManyKeysMap();
+  caches.push(cache);
+
+  return function (...args: Args): Return {
+    // Navigate through the cache hierarchy
+    let cached = cache.get(args);
+    if (cached !== undefined) {
+      // If the result is cached, return it
+      return cached;
+    }
+
+    // Calculate the result and cache it
+    const result = fn.apply(this, args);
+    // $FlowFixMe
+    cache.set(args, result);
+
+    return result;
+  };
+}

--- a/packages/core/graph/src/BitSet.js
+++ b/packages/core/graph/src/BitSet.js
@@ -104,7 +104,7 @@ export class BitSet {
     return setBitsCount;
   }
 
-  equal(other: BitSet): boolean {
+  equals(other: BitSet): boolean {
     for (let i = 0; i < this.bits.length; i++) {
       if (this.bits[i] !== other.bits[i]) {
         return false;

--- a/packages/core/graph/src/BitSet.js
+++ b/packages/core/graph/src/BitSet.js
@@ -28,6 +28,12 @@ export class BitSet {
     return res;
   }
 
+  static intersect(a: BitSet, b: BitSet): BitSet {
+    let res = a.clone();
+    res.intersect(b);
+    return res;
+  }
+
   get capacity(): number {
     return this.bits.length * 32;
   }
@@ -80,6 +86,31 @@ export class BitSet {
     for (let i = 0; i < this.bits.length; i++) {
       this.bits[i] &= ~other.bits[i];
     }
+  }
+
+  size(): number {
+    let bits = this.bits;
+    let setBitsCount = 0;
+
+    for (let k = 0; k < bits.length; k++) {
+      let chunk = bits[k];
+
+      while (chunk !== 0) {
+        chunk &= chunk - 1; // Clear the least significant bit set
+        setBitsCount++;
+      }
+    }
+
+    return setBitsCount;
+  }
+
+  equal(other: BitSet): boolean {
+    for (let i = 0; i < this.bits.length; i++) {
+      if (this.bits[i] !== other.bits[i]) {
+        return false;
+      }
+    }
+    return true;
   }
 
   forEach(fn: (bit: number) => void) {

--- a/packages/core/graph/test/BitSet.test.js
+++ b/packages/core/graph/test/BitSet.test.js
@@ -107,4 +107,46 @@ describe('BitSet', () => {
     assertValues(set2, [3, 5]);
     assertValues(set3, [1, 3, 5]);
   });
+
+  it('BitSet.intersect should create a new BitSet with the intersect', () => {
+    let set1 = new BitSet(5);
+    set1.add(1);
+    set1.add(3);
+
+    let set2 = new BitSet(5);
+    set2.add(3);
+    set2.add(5);
+
+    let set3 = BitSet.intersect(set1, set2);
+    assertValues(set1, [1, 3]);
+    assertValues(set2, [3, 5]);
+    assertValues(set3, [3]);
+  });
+
+  it('should identify equality with another BitSet', () => {
+    let set1 = new BitSet(5);
+    set1.add(1);
+    set1.add(3);
+
+    let set2 = new BitSet(5);
+    set2.add(3);
+    set2.add(5);
+
+    let set3 = set1.clone();
+
+    assert(set1.equals(set3));
+    assert(!set1.equals(set2));
+  });
+
+  it('should calculate size of BitSet', () => {
+    let set1 = new BitSet(5);
+    set1.add(1);
+    set1.add(3);
+
+    assert.equal(set1.size(), 2);
+
+    set1.add(3);
+    set1.add(4);
+    assert.equal(set1.size(), 3);
+  });
 });

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -2360,7 +2360,7 @@ describe('bundler', function () {
   });
 
   describe('shared bundle merging', () => {
-    it('should support bundling merging', async () => {
+    it('should support bundling merging with overlap threshold', async () => {
       await fsFixture(overlayFS, __dirname)`
         bundle-merge
           shared-one.js:
@@ -2390,7 +2390,7 @@ describe('bundler', function () {
             {
               "@atlaspack/bundler-default": {
                 "minBundleSize": 0,
-                "sharedBundleMergeThreshold": 0.5
+                "sharedBundleMerge": [{"overlapThreshold": 0.5}]
               }
             }
           yarn.lock:
@@ -2432,6 +2432,280 @@ describe('bundler', function () {
         },
         {
           assets: ['three.js'],
+        },
+      ]);
+
+      await run(b);
+    });
+
+    it('should support bundle merging with sourceBundles', async () => {
+      await fsFixture(overlayFS, __dirname)`
+        bundle-merge-source-bundles
+          shared-one.js:
+            export const one = 'one';
+          shared-two.js:
+            export const two = 'two';
+          shared-three.js:
+            export const three = 'three';
+          shared-four.js:
+            export const four = 'four';
+          one.js:
+            import {one} from './shared-one';
+            import {two} from './shared-two';
+            import {four} from './shared-four';
+          two.js:
+            import {two} from './shared-two';
+            import {three} from './shared-three';
+            import {four} from './shared-four';
+          three.js:
+            import {three} from './shared-three';
+            import {one} from './shared-one';
+          entry.js:
+            const one = import('./one');
+            const two = import('./two');
+            const three = import('./three');
+            sideEffectNoop(Promise.all([one, two, three]));
+
+          entry.html:
+            <script type="module" src="./entry.js"></script>
+          package.json:
+            {
+              "@atlaspack/bundler-default": {
+                "minBundleSize": 0,
+                "sharedBundleMerge": [{
+                  "sourceBundles": ["one.js", "two.js"]
+                }]
+              }
+            }
+          yarn.lock:
+      `;
+
+      const b = await bundle(
+        [path.join(__dirname, 'bundle-merge-source-bundles/entry.html')],
+        {
+          inputFS: overlayFS,
+        },
+      );
+
+      assertBundles(b, [
+        {
+          assets: ['entry.html'],
+        },
+        {
+          assets: [
+            'entry.js',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
+          ],
+        },
+        {
+          // Merged shared bundle with assets needed by both one.js and two.js
+          assets: ['shared-two.js', 'shared-four.js', 'esmodule-helpers.js'],
+        },
+        {
+          assets: ['shared-one.js'],
+        },
+        {
+          assets: ['shared-three.js'],
+        },
+        {
+          assets: ['one.js'],
+        },
+        {
+          assets: ['two.js'],
+        },
+        {
+          assets: ['three.js'],
+        },
+      ]);
+
+      await run(b);
+    });
+
+    it('should support bundle merging with maxBundleSize', async () => {
+      let lotsOfCode = 'This string needs to to make the bundle large'.repeat(
+        200,
+      );
+
+      await fsFixture(overlayFS, __dirname)`
+        bundle-merge-max-size
+          shared-one.js:
+            export const one = 'one';
+          shared-two.js:
+            export const two = 'two';
+          shared-three.js:
+            export const three = '${lotsOfCode}';
+          shared-four.js:
+            export const four = 'four';
+          one.js:
+            import {one} from './shared-one';
+            import {two} from './shared-two';
+          two.js:
+            import {two} from './shared-two';
+            import {three} from './shared-three';
+          three.js:
+            import {three} from './shared-three';
+            import {four} from './shared-four';
+          four.js:
+            import {four} from './shared-four';
+            import {one} from './shared-one';
+          entry.js:
+            const one = import('./one');
+            const two = import('./two');
+            const three = import('./three');
+            const four  = import('./four');
+            sideEffectNoop(Promise.all([one, two, three, four]));
+
+          entry.html:
+            <script type="module" src="./entry.js"></script>
+          package.json:
+            {
+              "@atlaspack/bundler-default": {
+                "minBundleSize": 0,
+                "sharedBundleMerge": [{
+                  "maxBundleSize": 1000
+                }]
+              }
+            }
+          yarn.lock:
+      `;
+
+      const b = await bundle(
+        [path.join(__dirname, 'bundle-merge-max-size/entry.html')],
+        {
+          inputFS: overlayFS,
+        },
+      );
+
+      assertBundles(b, [
+        {
+          assets: ['entry.html'],
+        },
+        {
+          assets: [
+            'entry.js',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
+          ],
+        },
+        {
+          // Merge all shared bundles that are smaller than the threshold
+          assets: [
+            'shared-one.js',
+            'shared-two.js',
+            'shared-four.js',
+            'esmodule-helpers.js',
+          ],
+        },
+        {
+          assets: ['shared-three.js'],
+        },
+        {
+          assets: ['one.js'],
+        },
+        {
+          assets: ['two.js'],
+        },
+        {
+          assets: ['three.js'],
+        },
+        {
+          assets: ['four.js'],
+        },
+      ]);
+
+      await run(b);
+    });
+
+    it('should support bundle merging with minBundlesInGroup', async () => {
+      await fsFixture(overlayFS, __dirname)`
+        bundle-merge-min-bundles-in-group
+          shared-one.js:
+            export const one = 'one';
+          shared-two.js:
+            export const two = 'two';
+          shared-three.js:
+            export const three = 'three';
+          shared-four.js:
+            export const four = 'four';
+          one.js:
+            import {one} from './shared-one';
+            import {two} from './shared-two';
+          two.js:
+            import {two} from './shared-two';
+            import {three} from './shared-three';
+          three.js:
+            import {three} from './shared-three';
+            import {four} from './shared-four';
+          four.js:
+            import {four} from './shared-four';
+            import {one} from './shared-one';
+            import {two} from './shared-two';
+          entry.js:
+            const one = import('./one');
+            const two = import('./two');
+            const three = import('./three');
+            const four  = import('./four');
+            sideEffectNoop(Promise.all([one, two, three, four]));
+
+          entry.html:
+            <script type="module" src="./entry.js"></script>
+          package.json:
+            {
+              "@atlaspack/bundler-default": {
+                "minBundleSize": 0,
+                "sharedBundleMerge": [{
+                  "minBundlesInGroup": 5
+                }]
+              }
+            }
+          yarn.lock:
+      `;
+
+      const b = await bundle(
+        [path.join(__dirname, 'bundle-merge-min-bundles-in-group/entry.html')],
+        {
+          inputFS: overlayFS,
+        },
+      );
+
+      assertBundles(b, [
+        {
+          assets: ['entry.html'],
+        },
+        {
+          assets: [
+            'entry.js',
+            'bundle-url.js',
+            'cacheLoader.js',
+            'js-loader.js',
+          ],
+        },
+        {
+          // Merge all shared bundles that belong the the largest group
+          assets: [
+            'shared-one.js',
+            'shared-two.js',
+            'shared-four.js',
+            'esmodule-helpers.js',
+          ],
+        },
+        {
+          assets: ['shared-three.js'],
+        },
+        {
+          assets: ['one.js'],
+        },
+        {
+          assets: ['two.js'],
+        },
+        {
+          assets: ['three.js'],
+        },
+        {
+          assets: ['four.js'],
         },
       ]);
 

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -641,7 +641,9 @@ export function assertBundles(
   assert.equal(
     actualBundles.length,
     expectedBundles.length,
-    'expected number of bundles mismatched',
+    `Expected number of bundles mismatched\n\nActual bundles: \n\n${util.inspect(
+      actualBundles,
+    )}`,
   );
 
   for (let expectedBundle of expectedBundles) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11407,6 +11407,11 @@ make-iterator@^1.0.0:
   dependencies:
     kind-of "^6.0.2"
 
+many-keys-map@^2.0.1:
+  version "2.0.1"
+  resolved "https://packages.atlassian.com/api/npm/npm-remote/many-keys-map/-/many-keys-map-2.0.1.tgz#3ae9f97cff78e08f79311d4e9c42fb3cc583f61e"
+  integrity sha512-DHnZAD4phTbZ+qnJdjoNEVU1NecYoSdbOOoVmTDH46AuxDkEVh3MxTVpXq10GtcTC6mndN9dkv1rNfpjRcLnOw==
+
 map-cache@^0.2.0, map-cache@^0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
@@ -15593,7 +15598,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15618,15 +15623,6 @@ string-width@^1.0.1, string-width@^1.0.2:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15715,7 +15711,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15735,13 +15731,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -17293,7 +17282,7 @@ workerpool@6.1.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
   integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17314,15 +17303,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

Building on the work in #535, this PR adds a more options and configurability to shared bundle merging. We're introducing a new `sharedBundleMerge` option to the bundle config that allows you to pass multiple merge groups with different configurations. The groups are ordered by priority so any bundles merged by a former category are not-available for merging in a lower priority one. 

# Breaking change

This new config replaces the previously released `sharedBundleMergeThreshold`. 

The following options are available for each merge group.

# Options

## overlapThreshold

> The same as `sharedBundleMergeThreshold` from #535

Merge bundles share a percentage of source bundles
```json
"@atlaspack/bundler-default": {
  "sharedBundleMerge": [{
    "overlapThreshold": 0.75
  }]
}
```

## maxBundleSize

Merge bundles that are smaller than a configured amount of bytes. 
>  Keep in mind these bytes are pre-optimisation

```json
"@atlaspack/bundler-default": {
  "sharedBundleMerge": [{
    "maxBundleSize": 20000
  }]
}
```

## sourceBundles

Merge bundles that share a set of source bundles. The matching is relative to the project root, like how manual shared bundle roots work.

```json
"@atlaspack/bundler-default": {
  "sharedBundleMerge": [{
    "sourceBundles": ["src/important-route", "src/important-route-2"]
  }]
}
```

## minBundlesInGroup

Merge bundles that belong to a bundle group that's larger than a set amount. This is useful for targetting bundles that would be deleted by the `maxParallelRequests` option. 
```json
"@atlaspack/bundler-default": {
  "maxParallelRequests": 30,
  "sharedBundleMerge": [{
    "minBundlesInGroup": 30
  }]
}
```

# Combining options

When multiple options are provided, all must be true for a merge to be relevant. 

For example, merge bundles that are smaller than 20kb and share at least 50% of the same source bundles.
```json
"@atlaspack/bundler-default": {
  "sharedBundleMerge": [{
    "overlapThreshold": 0.5,
    "maxBundleSize": 20000
  }]
}
```

# Multiple merges

You can also have multiple merge configs.
```json
"@atlaspack/bundler-default": {
  "sharedBundleMerge": [
     {
        "overlapThreshold": 0.75,
        "maxBundleSize": 20000
     },
     {
        "minBundlesInGroup": 30
        "sourceBundles": ["src/important-route", "src/important-route-2"]
     }
  ]
}
```


## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
