### PR TITLE
Run eslint on pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,11 @@
     "node": ">= 16.0.0"
   },
   "lint-staged": {
-    "*.{js,json,md,ts}": "prettier --write",
+    "*.{js,ts,jsx,tsx}": [
+      "prettier --write",
+      "eslint --fix"
+    ],
+    "*.{json,md}": "prettier --write",
     "*.rs": "rustfmt"
   },
   "packageManager": "yarn@1.22.19",


### PR DESCRIPTION
I keep checking-in files with eslint errors.

This changes the pre-commit hooks to run eslint

[no-changeset]: Not applicable

Test Plan: N/A
