### PR TITLE
Use brute-force watch backend on cache tests

### DIFF
--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -57,6 +57,7 @@ let packageManager = new NodePackageManager(inputFS, '/');
       {
         inputFS: overlayFS,
         shouldDisableCache: false,
+        watchBackend: 'brute-force',
         featureFlags: {
           ...featureFlags,
           cachePerformanceImprovements,


### PR DESCRIPTION
This reduces test duration.

[no-changeset]: N/A

Test Plan: N/A
