### PR TITLE
Hoist assets with no incoming dependencies

### DIFF
--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -208,6 +208,26 @@ export function findAsset(
   });
 }
 
+export function findBundle(
+  bundleGraph: BundleGraph<PackagedBundle>,
+  mainEntryAssetFileName: string,
+): PackagedBundle {
+  let asset = nullthrows(
+    findAsset(bundleGraph, mainEntryAssetFileName),
+    `Couldn't find asset ${mainEntryAssetFileName}`,
+  );
+
+  const bundle = bundleGraph
+    .getBundles()
+    .find((b) => b.getMainEntry() === asset);
+
+  invariant(
+    bundle != null,
+    `Couldn't find bundle with mainEntryAsset ${mainEntryAssetFileName}`,
+  );
+  return bundle;
+}
+
 export function findDependency(
   bundleGraph: BundleGraph<PackagedBundle>,
   assetFileName: string,


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

scopeHoisting is less effective in Atlaspack when compared to Webpack. This PR _attempts_ to use a reasonable algorithm to try to hoist as many assets as possible.

We sort the assets by least incomingDependencies then start hoisting everything with no incomingDependencies while updating the incomingDependencies list of other assets as we go so that we can hoist more assets.

There is something wrong with this PR: [branch deploy](https://jstrauss-prod-test.atlassian.net/wiki/spaces/PTS1/pages/239501314/This+is+a+super+long+title+for+a+page+which+wraps+when+the+inspector+is+open+in+chrome?useFrontendBranch=PCC-5240-disable-inline-requires&NO_SSR=1)

## Changes



## Checklist

- [ ] Existing or new tests cover this change
- [ ] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
