### PR TITLE
BUG: Add test case demonstrating unused exports with no side-effects bug

### DIFF
--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -659,6 +659,13 @@ export function createIdealGraph(
         }
         let assetIndex = nullthrows(assetToIndex.get(node.value));
         reachable.add(assetIndex);
+        /**
+         * This is where `index.js` is being added as a reachableRoot
+         * for `two.js`.
+         *
+         *  Without the unused export, `three.js` is added. We may need
+         * a traversal which will skipUnusedAssets if they have no side-effects?
+         */
         reachableRoots[assetIndex].add(bundleRootId);
 
         if (asset.meta.isConstantModule === true) {


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## BUG REPORT

Expectation:
 When there is an unused re-export with no side-effects it should not affect the bundling algorithm

Reality:
 It does affect the bundling algorithm leading to a bundle-graph which is not "ideal"
