### PR TITLE
Fix constant modules not being included in MSBs

### DIFF
--- a/.changeset/dirty-nails-double.md
+++ b/.changeset/dirty-nails-double.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/integration-tests': patch
+'@atlaspack/bundler-default': patch
+---
+
+Ensure that constant modules are correctly included in MSBs even if they wouldn't otherwise be.

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -204,14 +204,15 @@ export function createIdealGraph(
             config.projectRoot,
             node.value.filePath,
           );
-          if (!assetRegexes.some((regex) => regex.test(projectRelativePath))) {
-            return;
-          }
 
           // We track all matching MSB's for constant modules as they are never duplicated
           // and need to be assigned to all matching bundles
           if (node.value.meta.isConstantModule === true) {
             constantModuleToMSB.get(node.value).push(c);
+          }
+
+          if (!assetRegexes.some((regex) => regex.test(projectRelativePath))) {
+            return;
           }
           manualAssetToConfig.set(node.value, c);
           return;

--- a/packages/bundlers/default/src/idealGraph.js
+++ b/packages/bundlers/default/src/idealGraph.js
@@ -211,11 +211,9 @@ export function createIdealGraph(
             constantModuleToMSB.get(node.value).push(c);
           }
 
-          if (!assetRegexes.some((regex) => regex.test(projectRelativePath))) {
-            return;
+          if (assetRegexes.some((regex) => regex.test(projectRelativePath))) {
+            manualAssetToConfig.set(node.value, c);
           }
-          manualAssetToConfig.set(node.value, c);
-          return;
         }
 
         if (

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -2272,7 +2272,7 @@ describe('bundler', function () {
         },
         {
           // Shared bundle
-          assets: ['shared.js'],
+          assets: ['shared.js', 'constants.js'],
         },
       ]);
 

--- a/packages/core/integration-tests/test/bundler.js
+++ b/packages/core/integration-tests/test/bundler.js
@@ -2216,6 +2216,68 @@ describe('bundler', function () {
 
       await run(b);
     });
+
+    it('should support constant inlining in manual shared bundles', async function () {
+      await fsFixture(overlayFS, dir)`
+      yarn.lock: {}
+
+      package.json:
+        {
+          "@atlaspack/transformer-js": {
+            "unstable_inlineConstants": true
+          },
+          "@atlaspack/bundler-default": {
+            "minBundleSize": 0,
+            "manualSharedBundles": [{
+              "name": "shared",
+              "assets": ["shared.js"]
+            }]
+          }
+        }
+
+      index.html:
+        <script type="module" src="./index.js"></script>
+
+      index.js:
+        import {sharedFn} from './shared';
+        import {constant} from './constants';
+        sideEffectNoop(sharedFn() + constant);
+
+      shared.js:
+        import {constant} from './constants.js';
+        export function sharedFn() {
+          return constant;
+        }
+
+      constants.js:
+        export const constant = 'constant';
+    `;
+
+      let b = await bundle(path.join(dir, 'index.html'), {
+        mode: 'production',
+        defaultTargetOptions: {
+          shouldScopeHoist: true,
+          sourceMaps: false,
+          shouldOptimize: false,
+        },
+        inputFS: overlayFS,
+      });
+
+      assertBundles(b, [
+        {
+          assets: ['index.html'],
+        },
+        {
+          assets: ['index.js', 'constants.js'],
+        },
+        {
+          // Shared bundle
+          assets: ['shared.js'],
+        },
+      ]);
+
+      await run(b);
+    });
   });
 
   it.v2(


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

When enabling inline constants for one of our internal products, we had errors where "constant modules" weren't being included in MSBs if they didn't match the MSB regex which would cause an error during packaging.

## Changes

A bug was fixed in `makeManualAssetToConfigLookup` to ensure constant modules were added to the mapping _before_ the regex check and early bailout.

## Checklist

- [x] Existing or new tests cover this change (new integration test)
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
