### PR TITLE
Use direct reference to private babel-register package in APVM Atlaspack script

### DIFF
--- a/.changeset/large-moons-sleep.md
+++ b/.changeset/large-moons-sleep.md
@@ -1,0 +1,9 @@
+---
+'@atlaspack/apvm': patch
+'@atlaspack/apvm-linux-amd64': patch
+'@atlaspack/apvm-linux-arm64': patch
+'@atlaspack/apvm-macos-amd64': patch
+'@atlaspack/apvm-macos-arm64': patch
+---
+
+Change APVM atlaspack script to work with ATLASPACK_DEV

--- a/crates/apvm/src/cmd/link_local.rs
+++ b/crates/apvm/src/cmd/link_local.rs
@@ -129,8 +129,11 @@ fn create_bin(node_modules_bin_atlaspack: &Path) -> std::io::Result<()> {
       r#"#!/usr/bin/env node
 
 if (process.env.ATLASPACK_DEV === 'true') {{
+  if (typeof process.env.APVM_ATLASPACK_LOCAL === 'undefined') {{
+    throw new Error('APVM_ATLASPACK_LOCAL must be set when ATLASPACK_DEV is true')
+  }}
   console.log('USING ATLASPACK SOURCES')
-  require('@atlaspack/babel-register')
+  require(require('path').join(process.env.APVM_ATLASPACK_LOCAL, 'packages/dev/babel-register'))
   require('@atlaspack/cli/src/bin.js')
 }} else {{
   require('@atlaspack/cli/bin/atlaspack.js')


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

The `ATLASPACK_DEV` branch of the `.bin/atlaspack` script didn't work because `@atlaspack/babel-register` is a private package, so the `reqiure('@atlaspack/register')` would fail.

## Changes

 Change the `require` call to instead directly reference the path, using `APVM_ATLASPACK_LOCAL`. Seems to work!

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
