### PR TITLE
export CONSISTENCY_CHECK_VALUES for consumption in other products

### DIFF
--- a/.changeset/giant-islands-cross.md
+++ b/.changeset/giant-islands-cross.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/feature-flags': minor
+---
+
+export `CONSISTENCY_CHECK_VALUES` for consumption in other products

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -5,6 +5,13 @@ import type {FeatureFlags as _FeatureFlags} from './types';
 // but we want to export FeatureFlags for Flow
 export type FeatureFlags = _FeatureFlags;
 
+export const CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string> = Object.freeze([
+  'NEW',
+  'OLD',
+  'NEW_AND_CHECK',
+  'OLD_AND_CHECK',
+]);
+
 export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   exampleConsistencyCheckFeature: 'OLD',
   exampleFeature: false,

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -100,10 +100,10 @@ export type FeatureFlags = {|
   conditionalBundlingReporterSameConditionFix: boolean,
 |};
 
-export type ConsistencyCheckFeatureFlagValue =
-  | 'NEW'
-  | 'OLD'
-  | 'NEW_AND_CHECK'
-  | 'OLD_AND_CHECK';
+declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;
+export type ConsistencyCheckFeatureFlagValue = $ElementType<
+  typeof CONSISTENCY_CHECK_VALUES,
+  number,
+>;
 
 declare export var DEFAULT_FEATURE_FLAGS: FeatureFlags;


### PR DESCRIPTION
Currently other products which consume Atlaspack must define `ConsistencyCheckFeatureFlagValue` internally. This is not ideal as there can be mismatches between the permitted values for `ConsistencyCheckFeatureFlagValue` between products.

This PR exports both the `ConsistencyCheckFeatureFlagValue` and the permitted values in the const string array `CONSISTENCY_CHECK_VALUES`.

This way, type safety is maintained with only a single source of truth for permitted values.

## Motivation

Groundwork for future work in supporting non-boolean Atlaspack flag values via the Statsig client as well as enabling migration of legacy flags.

## Changeset
This change modifies the type exports, so a minor changeset is included.
