### PR TITLE
Remove bitsets from bundle merging

### DIFF
--- a/.changeset/spicy-shoes-hear.md
+++ b/.changeset/spicy-shoes-hear.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/bundler-default': patch
+---
+
+Change the overlap calculation system in findMergeCandidates to improve performance

--- a/.changeset/twenty-pumas-jump.md
+++ b/.changeset/twenty-pumas-jump.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/utils': minor
+---
+
+Add the `setIntersectStatic` method that doesn't mutate the passed in Sets

--- a/packages/core/utils/benchmark.js
+++ b/packages/core/utils/benchmark.js
@@ -1,0 +1,23 @@
+require('@atlaspack/babel-register');
+const b = require('benny');
+
+const {setIntersect, setIntersectStatic} = require('./src/collection.js');
+
+const setA = new Set([
+  23, 25, 29, 29, 12, 16, 14, 23, 18, 19, 16, 24, 9, 29, 26,
+]);
+const setB = new Set([24, 1, 3, 6, 1, 3, 1, 5, 20, 15, 21, 23, 13, 16, 6]);
+
+b.suite(
+  'Collection - set intersection',
+  b.add('Control', () => {
+    const setClone = new Set(setA);
+    return () => setIntersect(setClone, setB);
+  }),
+  b.add('setIntersectStatic', () => {
+    setIntersectStatic(setA, setB);
+  }),
+  b.configure({minSamples: 100}),
+  b.cycle(),
+  b.complete(),
+);

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -41,8 +41,10 @@
     "nullthrows": "^1.1.1"
   },
   "devDependencies": {
+    "@atlaspack/babel-register": "2.14.1",
     "@iarna/toml": "^2.2.0",
     "ansi-html-community": "0.0.8",
+    "benny": "^3.7.1",
     "clone": "^2.1.1",
     "fast-glob": "^3.2.12",
     "fastest-levenshtein": "^1.0.16",

--- a/packages/core/utils/src/collection.js
+++ b/packages/core/utils/src/collection.js
@@ -94,6 +94,16 @@ export function setIntersect<T>(a: Set<T>, b: $ReadOnlySet<T>): void {
   }
 }
 
+export function setIntersectStatic<T>(a: Set<T>, b: Set<T>): Set<T> {
+  let intersection = new Set();
+  for (let entry of a) {
+    if (b.has(entry)) {
+      intersection.add(entry);
+    }
+  }
+  return intersection;
+}
+
 export function setUnion<T>(a: Iterable<T>, b: Iterable<T>): Set<T> {
   return new Set([...a, ...b]);
 }

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -39,6 +39,7 @@ export {
   setSymmetricDifference,
   setEqual,
   setIntersect,
+  setIntersectStatic,
   setUnion,
 } from './collection';
 export {


### PR DESCRIPTION
## Motivation

It turns out that in the specific use case we have in finding merge candidates, creating and intersecting a BitSet is actually slower than just using the existing Sets.

The collections util only had an intersect method that mutates the first Set passed in, so I've added another one that leaves the Sets unchanged.

This speeds up the `findMergeCandidates` function by about 35%.

I've also committed the benchmarking setup I was using, for future experimenting.

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
