### PR TITLE
Load more conditional bundles in HTML when root bundles config enabled

### DIFF
--- a/.changeset/yellow-fans-argue.md
+++ b/.changeset/yellow-fans-argue.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/integration-tests': patch
+'@atlaspack/feature-flags': patch
+'@atlaspack/packager-html': patch
+---
+
+Load same conditional bundles as conditional manifest in HTML

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -37,6 +37,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   conditionalBundlingReporterDuplicateFix: false,
   resolveBundlerConfigFromCwd: false,
   conditionalBundlingReporterSameConditionFix: false,
+  condbHtmlPackagerChange: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -98,6 +98,10 @@ export type FeatureFlags = {|
    * Fix a bug where the conditional manifest reporter would drop bundles that have the same condition
    */
   conditionalBundlingReporterSameConditionFix: boolean,
+  /**
+   * Enable a change to the html packager to load more bundles when conditional bundling fallback mode is enabled
+   */
+  condbHtmlPackagerChange: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -18,6 +18,7 @@
     "@atlaspack/plugin": "2.14.10",
     "@atlaspack/types": "2.15.0",
     "@atlaspack/utils": "2.14.10",
+    "@atlaspack/feature-flags": "2.16.0",
     "nullthrows": "^1.1.1",
     "posthtml": "^0.16.5"
   },


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

The current behaviour for the `evaluateRootConditionalBundles` config item is not sufficient for all gates in Jira. We need to load the same bundles as in the manifest.

## Changes

This change refactors to use `getConditionalBundleMapping` as the source of truth for loading the HTML, when we're in environments that don't evaluate the condition in the webserver.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
