### PR TITLE
Add scope hoisting of assets inside wrapped assets

### DIFF
--- a/.changeset/small-fireants-approve.md
+++ b/.changeset/small-fireants-approve.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/feature-flags': minor
+---
+
+Adds a feature flag for `applyScopeHoistingImprovement`

--- a/.changeset/small-students-march.md
+++ b/.changeset/small-students-march.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/packager-js': minor
+---
+
+Expands the situations where scope hoisting may be applied to include assets with no dependencies, regardless of whether if they have a wrapped ancestor.
+
+Can be enabled with the `applyScopeHoistingImprovement` feature flag.

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -38,6 +38,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   resolveBundlerConfigFromCwd: false,
   conditionalBundlingReporterSameConditionFix: false,
   condbHtmlPackagerChange: false,
+  applyScopeHoistingImprovement: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -102,6 +102,11 @@ export type FeatureFlags = {|
    * Enable a change to the html packager to load more bundles when conditional bundling fallback mode is enabled
    */
   condbHtmlPackagerChange: boolean,
+  /**
+   * Enable a setting that allows for more assets to be scope hoisted, if
+   * they're safe to do so.
+   */
+  applyScopeHoistingImprovement: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -98,7 +98,6 @@ export class ScopeHoistingPackager {
   topLevelNames: Map<string, number> = new Map();
   seenAssets: Set<string> = new Set();
   wrappedAssets: Set<string> = new Set();
-  assetInlineableCache: Map<Asset, boolean> = new Map();
   hoistedRequires: Map<string, Map<string, string>> = new Map();
   needsPrelude: boolean = false;
   usedHelpers: Set<string> = new Set();
@@ -353,11 +352,6 @@ export class ScopeHoistingPackager {
     ];
 
     return `$parcel$global.rwr(${params.join(', ')});`;
-  }
-
-  newWrapGroupId(): number {
-    this.wrapGroupsCount++;
-    return this.wrapGroupsCount;
   }
 
   async loadAssets(): Promise<Array<Asset>> {
@@ -1108,10 +1102,6 @@ ${code}
       (!this.bundle.hasAsset(resolved) && !this.externalAssets.has(resolved)) ||
       (this.wrappedAssets.has(resolved.id) && resolved !== parentAsset)
     );
-  }
-
-  getFileName(asset: Asset): string {
-    return require('path').basename(asset.filePath);
   }
 
   getSymbolResolution(

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -419,16 +419,18 @@ export class ScopeHoistingPackager {
           return;
         }
 
-        let incomingDeps =
-          this.bundleGraph.getIncomingDependencies(asset).length;
+        if (getFeatureFlag('applyScopeHoistingImprovement')) {
+          let incomingDeps =
+            this.bundleGraph.getIncomingDependencies(asset).length;
 
-        if (incomingDeps === 1) {
-          let outgoingDeps = this.bundleGraph.getDependencies(asset).length;
+          if (incomingDeps === 1) {
+            let outgoingDeps = this.bundleGraph.getDependencies(asset).length;
 
-          if (outgoingDeps === 0) {
-            // If an asset is only used in one place, and has no dependencies, it's
-            // safe to hoist
-            return;
+            if (outgoingDeps === 0) {
+              // If an asset is only used in one place, and has no dependencies, it's
+              // safe to hoist
+              return;
+            }
           }
         }
 

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -357,25 +357,12 @@ export class ScopeHoistingPackager {
   async loadAssets(): Promise<Array<Asset>> {
     let queue = new PromiseQueue({maxConcurrent: 32});
     let wrapped = [];
-
     this.bundle.traverseAssets((asset) => {
       queue.add(async () => {
         let [code, map] = await Promise.all([
           asset.getCode(),
           this.bundle.env.sourceMap ? asset.getMapBuffer() : null,
         ]);
-
-        // There are some assets in the tree that are empty, but can't be
-        // removed. If these are hoisted, it causes a reference is not defined
-        // error, as there is a * export pointing to no actual code.
-        // To get around this, we wrap these assets, which will result in an empty
-        // parcelRegister call
-        if (getFeatureFlag('applyScopeHoistingImprovement')) {
-          if (code.length === 0) {
-            this.wrappedAssets.add(asset.id);
-            wrapped.push(asset);
-          }
-        }
 
         return [asset.id, {code, map}];
       });

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -99,8 +99,6 @@ export class ScopeHoistingPackager {
   seenAssets: Set<string> = new Set();
   wrappedAssets: Set<string> = new Set();
   assetInlineableCache: Map<Asset, boolean> = new Map();
-  wrapGroupsByAsset: Map<Asset, number> = new Map();
-  wrapGroupsCount: number = 0;
   hoistedRequires: Map<string, Map<string, string>> = new Map();
   needsPrelude: boolean = false;
   usedHelpers: Set<string> = new Set();

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -418,6 +418,20 @@ export class ScopeHoistingPackager {
           actions.skipChildren();
           return;
         }
+
+        let incomingDeps =
+          this.bundleGraph.getIncomingDependencies(asset).length;
+
+        if (incomingDeps === 1) {
+          let outgoingDeps = this.bundleGraph.getDependencies(asset).length;
+
+          if (outgoingDeps === 0) {
+            // If an asset is only used in one place, and has no dependencies, it's
+            // safe to hoist
+            return;
+          }
+        }
+
         if (!asset.meta.isConstantModule) {
           this.wrappedAssets.add(asset.id);
           wrapped.push(asset);


### PR DESCRIPTION
## Motivation

We did some testing of the scope hoisting packager, and it turns out that for one of our products, only 0.6% of assets are actually hoisted, with the rest being wrapped in `parcelRegister`.

This is because anything that's dynamically imported needs to be wrapped, and all children of wrapped assets also get wrapped. It seems like the original intention for this was to handle the case of a circular dependency, but it's a pretty big blast radius.

## Changes

This change adds a new feature flag `applyScopeHoistingImprovement` which allows children of wrapped assets to be inlined into the wrapped asset. This is achieved by assigning assets to their wrapped parents and if multiple parents are detected then they becomes wrapped themselves. 

We've also had to exclude assets that contain symbols that are re-exported. Ideally this wouldn't be the case, but we need to solve more complicated cases around symbol resolution to make this work. 

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

[webpack does]: https://webpack.js.org/plugins/module-concatenation-plugin/#optimization-bailouts