### PR TITLE
De-duplicate ifTrueBundles and ifFalseBundles arrays when creating conditional manifest

### DIFF
--- a/.changeset/kind-doors-change.md
+++ b/.changeset/kind-doors-change.md
@@ -1,0 +1,9 @@
+---
+'@atlaspack/reporter-conditional-manifest': patch
+'@atlaspack/integration-tests': patch
+'@atlaspack/feature-flags': patch
+'@atlaspack/bundler-default': patch
+'@atlaspack/utils': patch
+---
+
+Fix duplicate assets appearing in conditional manifest when two conditional imports use the same file paths

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -40,6 +40,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   condbHtmlPackagerChange: false,
   applyScopeHoistingImprovement: false,
   inlineConstOptimisationFix: false,
+  conditionalBundlingDeduplicateBundles: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -111,6 +111,10 @@ export type FeatureFlags = {|
    * Enable a change where a constant module only have the namespacing object added in bundles where it is required
    */
   inlineConstOptimisationFix: boolean,
+  /**
+   * De-duplicate any bundles that appear twice in the same list of bundles in the conditional manifest.
+   */
+  conditionalBundlingDeduplicateBundles: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -1108,33 +1108,41 @@ describe('conditional bundling', function () {
             ]
           }
 
-        index.js:
+        index.jsx:
           import { Component1 } from './c';
           import { Component2 } from './d';
 
           export const App = (props) => {
-            Component1;
-            Component2;
+            return (
+              <>
+                <Component1 {...props} />
+                <Component2 {...props} />
+              </>
+            );
           };
 
-        a.js:
-          export default 'module-a';
+        a.jsx:
+          import React from 'react';
+          const ModuleA = <p>module-a</p>;
+          export default ModuleA;
 
-        b.js:
-          export default 'module-b';
+        b.jsx:
+          import React from 'react';
+          const ModuleB = <p>module-b</p>;
+          export default ModuleB;
 
-        c.js:
+        c.jsx:
           import React from 'react';
           const Imported1 = importCond('cond', './a', './b');
-          export const Component1 = () => { return Imported1 };
+          export const Component1 = (props) => { return <Imported1 {...props} />; };
 
-        d.js:
+        d.jsx:
           import React from 'react';
           const Imported2 = importCond('cond', './a', './b');
-          export const Component2 = () => { return Imported2 };
+          export const Component2 = (props) => { return <Imported2 {...props} />; };
       `;
 
-    let bundleGraph = await bundle(path.join(dir, '/index.js'), {
+    let bundleGraph = await bundle(path.join(dir, '/index.jsx'), {
       inputFS: overlayFS,
       featureFlags: {
         conditionalBundlingApi: true,
@@ -1161,6 +1169,7 @@ describe('conditional bundling', function () {
     assert.deepEqual(conditionalManifest, {
       'index.js': {
         cond: {
+          // a.js and b.js should only appear once each
           ifFalseBundles: [nullthrows(bundleNames.get('b.[hash].js'))],
           ifTrueBundles: [nullthrows(bundleNames.get('a.[hash].js'))],
         },

--- a/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
+++ b/packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js
@@ -72,14 +72,33 @@ export async function report({
           const bundleInfo =
             manifest[bundle.target.name]?.[relativeBundlePath] ?? {};
 
-          bundleInfo[key] = {
-            ifTrueBundles: mapBundles(cond.ifTrueBundles)
-              .concat(bundleInfo[key]?.ifTrueBundles ?? [])
-              .sort(),
-            ifFalseBundles: mapBundles(cond.ifFalseBundles)
-              .concat(bundleInfo[key]?.ifFalseBundles ?? [])
-              .sort(),
-          };
+          if (getFeatureFlag('conditionalBundlingDeduplicateBundles')) {
+            bundleInfo[key] = {
+              ifTrueBundles: [
+                ...new Set(
+                  mapBundles(cond.ifTrueBundles)
+                    .concat(bundleInfo[key]?.ifTrueBundles ?? [])
+                    .sort(),
+                ),
+              ],
+              ifFalseBundles: [
+                ...new Set(
+                  mapBundles(cond.ifFalseBundles)
+                    .concat(bundleInfo[key]?.ifFalseBundles ?? [])
+                    .sort(),
+                ),
+              ],
+            };
+          } else {
+            bundleInfo[key] = {
+              ifTrueBundles: mapBundles(cond.ifTrueBundles)
+                .concat(bundleInfo[key]?.ifTrueBundles ?? [])
+                .sort(),
+              ifFalseBundles: mapBundles(cond.ifFalseBundles)
+                .concat(bundleInfo[key]?.ifFalseBundles ?? [])
+                .sort(),
+            };
+          }
 
           manifest[bundle.target.name] ??= {};
           manifest[bundle.target.name][relativeBundlePath] = bundleInfo;


### PR DESCRIPTION
Conditional bundling bug fix:

Add de-duplication so that assets don't appear duplicated inside the conditional manifest.

In other words, we want to de-duplicate stuff like this:
<img width="944" alt="Screenshot 2025-06-24 at 16 00 46" src="https://github.com/user-attachments/assets/f6a58fed-f5e5-42fb-acf5-36d6ab6c905c" />


<!-- Provide a summary of your changes in the title field above -->

## Motivation

When `importCond` is used twice in the same bundle with the exact same arguments, we will add the conditional bundles to `ifTrueBundles` and `ifFalseBundles` twice.

For example, imagine we have two files that get bundled into the same asset (let's call it `navigation-stuff.4abe98ff.js`) at build-time:

```jsx
// src/navigation/dev-panel/index.tsx

import React from 'react';

const Component = importCond('my-feature-gate', '@private/component/index-new.tsx', '@private/component/index-old.tsx')
export const DevPanel = (props) => {
    return (
        <>
            <DevStuff />
            <Component ... />
            {/* and so on... */}
        </>
    );
};
```

```jsx
// src/navigation/product-panel/index.tsx

import React from 'react';

const Component = importCond('my-feature-gate', '@private/component/index-new.tsx', '@private/component/index-old.tsx')
export const ProductPanel = (props) => {
    return (
        <>
            <ProductStuff ... />
            <Component ... />
            {/* and so on... */}
        </>
    );
};
```

`index-new.js` and `index-old.js` will get added to the `ifTrueBundles` and `ifFalseBundles` arrays for `navigation-stuff.4abe98ff.js` _twice_, because there are two `importCond` function calls that end up in the same bundle.

## Changes

Add some basic de-duplication in `packages/reporters/conditional-manifest/src/ConditionalManifestReporter.js`, which is where we create the conditional manifest.

I considered adding this de-duplication into `getConditionalBundleMapping` directly too, but it seemed superfluous - @JakeLane let me know if you have a different opinion here.

Note that this PR will need to be updated once https://github.com/atlassian-labs/atlaspack/pull/640 is merged in

## Checklist

- [x] Make a PR to add de-duplication to the old Jira SSR too
- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
