### PR TITLE
Domain sharding tests support different hashes in the outputs

### DIFF
--- a/packages/core/integration-tests/test/domain-sharding.js
+++ b/packages/core/integration-tests/test/domain-sharding.js
@@ -58,13 +58,12 @@ describe('domain-sharding', () => {
       if (!mainBundle) return assert(mainBundle);
 
       const code = await overlayFS.readFile(mainBundle.filePath, 'utf-8');
+      const re =
+        /require\((.*?)\)\(require\((.*?)\)\.shardUrl\(require\((.*?)\)\.resolve\((.*?)\),(.*?)\)\)/gm;
+      const matches = Array.from(code.matchAll(re));
 
-      assert.ok(
-        code.includes(
-          `require("85e3bc75ab94a411")(require("f41955f5cc01151").shardUrl(require("40cc202a4c7abf8d").resolve("aVRxe"), ${maxShards}))`,
-          'Expected generated code for shardUrl was not found',
-        ),
-      );
+      assert(matches.length > 0);
+      assert.equal(parseInt(matches[0][5].trim(), 10), maxShards);
     });
 
     it('for all other urls', async () => {
@@ -114,12 +113,15 @@ describe('domain-sharding', () => {
       if (!mainBundle) return assert(mainBundle);
 
       const code = await overlayFS.readFile(mainBundle.filePath, 'utf-8');
-      assert.ok(
-        code.includes(
-          `require("e480067c5bab431e")(require("5091f5df3a0c51b6").shardUrl(require("5e2c91749d676db2").getBundleURL('d8wEr') + "${commonFileName}", ${maxShards})`,
-        ),
-        'Expected generated code for shardUrl was not found',
+      const re =
+        /require\((.*?)\)\(require\((.*?)\)\.shardUrl\(require\((.*?)\)\.getBundleURL\((.*?)\).*?\+(.*?),(.*?)\)/gm;
+      const matches = Array.from(code.matchAll(re));
+      assert(matches.length > 0);
+      assert.equal(
+        matches[1][5].trim().replaceAll('"', '').replaceAll("'", ''),
+        commonFileName,
       );
+      assert.equal(parseInt(matches[1][6].trim(), 10), maxShards);
     });
 
     it('for ESM loaded bundle manifest', async () => {


### PR DESCRIPTION
## Motivation

Adding fixes to make tests more robust. Needed for the migration to TypeScript

## Changes

- Updated domain sharding tests to be resilient to changes in the hashes of assets in the bundle output 

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Updating tests
