### PR TITLE
Remove import "@atlaspack/*/src/**" from integration test imports 

### DIFF
--- a/.changeset/spicy-cups-invite.md
+++ b/.changeset/spicy-cups-invite.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Export ATLASPACK_VERSION and other internals

--- a/packages/core/core/src/index.js
+++ b/packages/core/core/src/index.js
@@ -1,4 +1,5 @@
 // @flow
+import * as EnvironmentManager from './EnvironmentManager';
 
 export {
   default,
@@ -9,5 +10,7 @@ export {
   INTERNAL_RESOLVE,
   INTERNAL_TRANSFORM,
 } from './Atlaspack';
-
+export {ATLASPACK_VERSION} from './constants';
+export {default as resolveOptions} from './resolveOptions';
 export * from './atlaspack-v3';
+export {EnvironmentManager};

--- a/packages/core/integration-tests/test/api.js
+++ b/packages/core/integration-tests/test/api.js
@@ -12,7 +12,7 @@ import {
   overlayFS,
 } from '@atlaspack/test-utils';
 
-import {ATLASPACK_VERSION} from '../../core/src/constants';
+import {ATLASPACK_VERSION} from '@atlaspack/core';
 
 describe('JS API', function () {
   it.v2('should respect distEntry', async function () {

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -33,13 +33,12 @@ import {md} from '@atlaspack/diagnostic';
 import fs from 'fs';
 import {NodePackageManager} from '@atlaspack/package-manager';
 import {createWorkerFarm} from '@atlaspack/core';
-import resolveOptions from '@atlaspack/core/src/resolveOptions';
+import {resolveOptions, ATLASPACK_VERSION} from '@atlaspack/core';
 import logger from '@atlaspack/logger';
 import sinon from 'sinon';
 import {version} from '@atlaspack/core/package.json';
 import {deserialize} from '@atlaspack/build-cache';
 import {hashString} from '@atlaspack/rust';
-import {ATLASPACK_VERSION} from '@atlaspack/core/src/constants';
 import {getAllEnvironments} from '@atlaspack/rust';
 import type {FeatureFlags} from '@atlaspack/feature-flags';
 
@@ -7077,7 +7076,7 @@ let packageManager = new NodePackageManager(inputFS, '/');
 
   describe('environment caching', function () {
     it('should cache and load environments between builds', async function () {
-      const EnvironmentManager = require('@atlaspack/core/src/EnvironmentManager');
+      const {EnvironmentManager} = require('@atlaspack/core');
       const loadEnvironmentsSpy = sinon.spy(
         EnvironmentManager,
         'loadEnvironmentsFromCache',

--- a/packages/core/integration-tests/test/conditional-bundling.js
+++ b/packages/core/integration-tests/test/conditional-bundling.js
@@ -12,10 +12,10 @@ import {
   overlayFS,
   removeDistDirectory,
   runBundles,
+  runBundle,
   distDir,
 } from '@atlaspack/test-utils';
 import sinon from 'sinon';
-import {runBundle} from '../../test-utils/src/utils';
 
 describe('conditional bundling', function () {
   beforeEach(async () => {

--- a/packages/core/integration-tests/test/vcs-cache.js
+++ b/packages/core/integration-tests/test/vcs-cache.js
@@ -12,7 +12,7 @@ import {
   workerFarm,
   cacheDir,
 } from '@atlaspack/test-utils';
-import {ATLASPACK_VERSION} from '@atlaspack/core/src/constants.js';
+import {ATLASPACK_VERSION} from '@atlaspack/core';
 
 it('can parse a git commit message hash', () => {
   const example = '[master (root-commit) e997505] Initial commit';


### PR DESCRIPTION
## Motivation

Make the tests more robust - needed for the TypeScript migration

## Changes

Remove `import "@atlaspack/*/src/**"` from integration test imports by publically exporting the value at the destination

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
