### PR TITLE
Remove package.json#exports (temporarily) 

### DIFF
--- a/.changeset/fast-dots-impress.md
+++ b/.changeset/fast-dots-impress.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/workers': patch
+'@atlaspack/logger': patch
+'@atlaspack/core': patch
+---
+
+Remove package.json#exports

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -56,17 +56,6 @@
     "graphviz": "^0.0.9",
     "tempy": "^0.2.1"
   },
-  "exports": {
-    "./*": "./*",
-    ".": {
-      "types": "./index.d.ts",
-      "default": "./lib/index.js"
-    },
-    "./worker": {
-      "@atlaspack::sources": "./src/worker.js",
-      "default": "./lib/worker.js"
-    }
-  },
   "browser": {
     "./src/serializerCore.js": "./src/serializerCore.browser.js"
   },

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -12,12 +12,6 @@
   },
   "main": "lib/Logger.js",
   "source": "src/Logger.js",
-  "exports": {
-    ".": {
-      "@atlaspack::sources": "./src/Logger.js",
-      "default": "./lib/Logger.js"
-    }
-  },
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -16,13 +16,6 @@
   "engines": {
     "node": ">= 16.0.0"
   },
-  "exports": {
-    ".": {
-      "types": "./index.d.ts",
-      "@atlaspack::sources": "./src/index.js",
-      "default": "./lib/index.js"
-    }
-  },
   "dependencies": {
     "@atlaspack/build-cache": "2.13.3",
     "@atlaspack/diagnostic": "2.14.1",


### PR DESCRIPTION
## Motivation

Removing `package.json#exports` from the Atlaspack packages to avoid confusion between Nodejs's built-in conditional exports and our custom babel-register JIT `package.json#source`/`package.json#main` rewrite.

The migration to TypeScript will use Nodejs conditional exports for TypeScript packages and the babel-register hack for Flow packages.

Eventually the babel-register hack will be removed and switching between `src`/`lib` will be done with built-in Nodejs conditional exports 

## Changes

- Remove `package.json#exports`

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
