### PR TITLE
Use esbuild-register only for .ts files

### DIFF
--- a/packages/dev/babel-register/index.js
+++ b/packages/dev/babel-register/index.js
@@ -26,7 +26,7 @@ require('@babel/register')({
 // This only support transpiling TypeScript to CJS
 // eslint-disable-next-line import/no-extraneous-dependencies
 require('esbuild-register/dist/node').register({
-  extensions: ['.ts', '.cts', '.mts'],
+  extensions: ['.ts'],
 });
 
 // This adds the registration to the Node args, which are passed


### PR DESCRIPTION
## Motivation

During the TypeScript migration, we will use `.mts` and `.cts` for TypeScript that is run in Nodejs natively and `esbuild-register` for TypeScript run in the old way. 

`esbuild-register` will be removed eventually

## Changes

Remove `.mts` and `.cts` extensions from `esbuild-register` in unit/integration tests.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Tests
