### PR TITLE
Fix bug with environment ID being ref

### DIFF
--- a/.changeset/stale-gorillas-teach.md
+++ b/.changeset/stale-gorillas-teach.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Fix environment deduplication issues

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -29,7 +29,11 @@ import nullthrows from 'nullthrows';
 import {ContentGraph} from '@atlaspack/graph';
 import {createDependency} from './Dependency';
 import {type ProjectPath, fromProjectPathRelative} from './projectPath';
-import {fromEnvironmentId, toEnvironmentId} from './EnvironmentManager';
+import {
+  fromEnvironmentId,
+  toEnvironmentId,
+  toEnvironmentRef,
+} from './EnvironmentManager';
 import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 type InitOpts = {|
@@ -160,7 +164,7 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
 
     let env = this.envCache.get(idAndContext);
     if (env) {
-      input.env = env;
+      input.env = toEnvironmentRef(env);
     } else {
       this.envCache.set(idAndContext, fromEnvironmentId(input.env));
     }

--- a/packages/core/core/src/Environment.js
+++ b/packages/core/core/src/Environment.js
@@ -140,7 +140,7 @@ export function mergeEnvironments(
   });
 }
 
-function getEnvironmentHash(env: Environment): string {
+export function getEnvironmentHash(env: Environment): string {
   const data = {
     context: env.context,
     engines: env.engines,

--- a/packages/core/core/src/EnvironmentManager.js
+++ b/packages/core/core/src/EnvironmentManager.js
@@ -21,7 +21,7 @@ export opaque type EnvironmentId = string;
 /**
  * When deduplication is cleaned-up this will always be a string.
  */
-export type EnvironmentRef = EnvironmentId | CoreEnvironment;
+export opaque type EnvironmentRef = EnvironmentId | CoreEnvironment;
 
 /**
  * Convert environment to a ref.

--- a/packages/core/core/src/public/MutableBundleGraph.js
+++ b/packages/core/core/src/public/MutableBundleGraph.js
@@ -11,6 +11,7 @@ import type {
 } from '@atlaspack/types';
 import type {
   AtlaspackOptions,
+  BundleGraphNode,
   BundleGroup as InternalBundleGroup,
   BundleNode,
 } from '../types';
@@ -207,7 +208,8 @@ export default class MutableBundleGraph
       bundleBehavior: opts.bundleBehavior ?? null,
     });
 
-    let existing = this.#graph._graph.getNodeByContentKey(bundleId);
+    let existing: ?BundleGraphNode =
+      this.#graph._graph.getNodeByContentKey(bundleId);
     if (existing != null) {
       invariant(existing.type === 'bundle');
       return Bundle.get(existing.value, this.#graph, this.#options);


### PR DESCRIPTION
* Fix a missing ref conversion where the ref would be kept as an object even
  with the flag enabled
* Fix rust compatibility with the environment deduplication flag

A subsequent change will modify rust asset graph so it doesn't copy
environments over. We expect a non-negligible performance improvement to native
builds from that change.

Test Plan: N/A
