### PR TITLE
Add a handful of debugging tools

### DIFF
--- a/.changeset/clean-humans-fetch.md
+++ b/.changeset/clean-humans-fetch.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/reporter-cli': minor
+---
+
+Add the `simple-cli-reporter` debug tool, which turns off the "print every bundle" output of the CLI reporter.

--- a/.changeset/rich-hairs-poke.md
+++ b/.changeset/rich-hairs-poke.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/packager-js': minor
+---
+
+Add the `asset-file-names-in-output` debug tool, which adds a comment to each asset inserted into a bundle that help identify it

--- a/.changeset/slimy-dingos-approve.md
+++ b/.changeset/slimy-dingos-approve.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/utils': minor
+---
+
+Add the debug-tools system for altering the behaviour when attempting to identify issues.

--- a/packages/core/utils/src/debug-tools.js
+++ b/packages/core/utils/src/debug-tools.js
@@ -11,7 +11,12 @@
  * You can enable all tools by setting `ATLASPACK_DEBUG_TOOLS=all`.
  */
 
-export let debugTools = {
+type DebugTools = {|
+  'asset-file-names-in-output': boolean,
+  'simple-cli-reporter': boolean,
+|};
+
+export let debugTools: DebugTools = {
   'asset-file-names-in-output': false,
   'simple-cli-reporter': false,
 };

--- a/packages/core/utils/src/debug-tools.js
+++ b/packages/core/utils/src/debug-tools.js
@@ -1,8 +1,8 @@
 // @flow
 
 /*
- * These tools are intended for Atlaspack developers, to provide extra tools to
- * make debugging Atlaspack issues more straightforward.
+ * These tools are intended for Atlaspack developers, to provide extra utilities
+ * to make debugging Atlaspack issues more straightforward.
  *
  * To enable a tool, set the `ATLASPACK_DEBUG_TOOLS` environment variable to a
  * comma-separated list of tool names. For example:

--- a/packages/core/utils/src/debug-tools.js
+++ b/packages/core/utils/src/debug-tools.js
@@ -1,0 +1,40 @@
+// @flow
+
+/*
+ * These tools are intended for Atlaspack developers, to provide extra tools to
+ * make debugging Atlaspack issues more straightforward.
+ *
+ * To enable a tool, set the `ATLASPACK_DEBUG_TOOLS` environment variable to a
+ * comma-separated list of tool names. For example:
+ * `ATLASPACK_DEBUG_TOOLS="asset-file-names-in-output,simple-cli-reporter"`
+ *
+ * You can enable all tools by setting `ATLASPACK_DEBUG_TOOLS=all`.
+ */
+
+export let debugTools = {
+  'asset-file-names-in-output': false,
+  'simple-cli-reporter': false,
+};
+
+const envVarValue = process.env.ATLASPACK_DEBUG_TOOLS ?? '';
+
+for (let tool of envVarValue.split(',')) {
+  tool = tool.trim();
+
+  if (tool === 'all') {
+    for (let key in debugTools) {
+      debugTools[key] = true;
+    }
+    break;
+  } else if (debugTools.hasOwnProperty(tool)) {
+    debugTools[tool] = true;
+  } else if (tool === '') {
+    continue;
+  } else {
+    throw new Error(
+      `Invalid debug tool option: ${tool}. Valid options are: ${Object.keys(
+        debugTools,
+      ).join(', ')}`,
+    );
+  }
+}

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -48,6 +48,7 @@ export {
   loadConfig,
   readConfig,
 } from './config';
+export {debugTools} from './debug-tools';
 export {DefaultMap, DefaultWeakMap} from './DefaultMap';
 export {makeDeferredWithPromise} from './Deferred';
 export {getProgressMessage} from './progress-message';

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -23,7 +23,8 @@
     "@atlaspack/types": "2.15.4",
     "@atlaspack/utils": "2.15.2",
     "globals": "^13.2.0",
-    "nullthrows": "^1.1.1"
+    "nullthrows": "^1.1.1",
+    "outdent": "^0.8.0"
   },
   "type": "commonjs"
 }

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -736,10 +736,7 @@ export class ScopeHoistingPackager {
                         `;
                         lines += 3 + depLines;
                       } else {
-                        res = outdent`
-                          ${depCode}
-                          ${res}
-                        `;
+                        res = depCode + '\n' + res;
                         lines += 1 + depLines;
                       }
                       map = depMap;

--- a/packages/packagers/js/src/ScopeHoistingPackager.js
+++ b/packages/packagers/js/src/ScopeHoistingPackager.js
@@ -15,6 +15,7 @@ import {
   relativeBundlePath,
   countLines,
   normalizeSeparators,
+  debugTools,
 } from '@atlaspack/utils';
 import SourceMap from '@parcel/source-map';
 import nullthrows from 'nullthrows';
@@ -25,6 +26,7 @@ import ThrowableDiagnostic, {
 import globals from 'globals';
 import path from 'path';
 import {getFeatureFlag} from '@atlaspack/feature-flags';
+import {outdent} from 'outdent';
 
 import {ESMOutputFormat} from './ESMOutputFormat';
 import {CJSOutputFormat} from './CJSOutputFormat';
@@ -579,6 +581,10 @@ export class ScopeHoistingPackager {
     return this.buildAsset(asset, code, map);
   }
 
+  getAssetFilePath(asset: Asset): string {
+    return path.relative(this.options.projectRoot, asset.filePath);
+  }
+
   buildAsset(
     asset: Asset,
     code: string,
@@ -720,8 +726,22 @@ export class ScopeHoistingPackager {
                     ) {
                       let [depCode, depMap, depLines] =
                         this.visitAsset(resolved);
-                      res = depCode + '\n' + res;
-                      lines += 1 + depLines;
+                      if (debugTools['asset-file-names-in-output']) {
+                        let resolvedPath = this.getAssetFilePath(resolved);
+                        res = outdent`
+                          /* Scope hoisted asset: ${resolvedPath} */
+                          ${depCode}
+                          /* End: ${resolvedPath} */
+                          ${res}
+                        `;
+                        lines += 3 + depLines;
+                      } else {
+                        res = outdent`
+                          ${depCode}
+                          ${res}
+                        `;
+                        lines += 1 + depLines;
+                      }
                       map = depMap;
                     }
                   } else {
@@ -791,6 +811,11 @@ ${code}
 `;
 
       lineCount += 2;
+
+      if (debugTools['asset-file-names-in-output']) {
+        code = `/* ${this.getAssetFilePath(asset)} */\n` + code;
+        lineCount += 1;
+      }
 
       for (let [depCode, map, lines] of depContent) {
         if (!depCode) continue;

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -9,6 +9,7 @@ import {
   prettifyTime,
   prettyDiagnostic,
   throttle,
+  debugTools,
 } from '@atlaspack/utils';
 import chalk from 'chalk';
 
@@ -134,12 +135,18 @@ export async function _report(
       );
 
       if (options.mode === 'production') {
-        await bundleReport(
-          event.bundleGraph,
-          options.outputFS,
-          options.projectRoot,
-          options.detailedReport?.assetsPerBundle,
-        );
+        if (debugTools['simple-cli-reporter']) {
+          writeOut(
+            `🛠️ Built ${event.bundleGraph.getBundles().length} bundles.`,
+          );
+        } else {
+          await bundleReport(
+            event.bundleGraph,
+            options.outputFS,
+            options.projectRoot,
+            options.detailedReport?.assetsPerBundle,
+          );
+        }
       } else {
         pendingIncrementalBuild = true;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12843,6 +12843,11 @@ outdent@^0.5.0:
   resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.5.0.tgz#9e10982fdc41492bb473ad13840d22f9655be2ff"
   integrity sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==
 
+outdent@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.8.0.tgz#2ebc3e77bf49912543f1008100ff8e7f44428eb0"
+  integrity sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==
+
 p-filter@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-filter/-/p-filter-2.1.0.tgz#1b1472562ae7a0f742f0f3d3d3718ea66ff9c09c"


### PR DESCRIPTION
## Motivation

When I'm trying to identify issues with Atlaspack builds, there are a couple of things I always change to my local version to make things a bit easier.

Probably makes sense to move them out of my permanent stash and into the repo for everyone to enjoy.

## Changes

This PR introduces the concept of "debug tools", and implements the first two. It's intended that we can add others in future as ideas come up.

Debug tools are enabled via an env var (which I'm setting permanently in my shell config), with instructions added to the `debug-tools.js` file.

The two tools that are implemented here are:

### Simple CLI Reporter

When doing a build in our internal applications, several thousand bundles are created, and listing the file path of every single one takes up an annoying amount of space in the terminal and is not useful to me at all. It also means that if I have any console.log entries added, I have to scroll way up to see them.

Adding the `simple-cli-reporter` tool will change this output to just report the number of bundles created.

### Add asset paths to output

When looking at an output bundle, it can be difficult to know exactly what asset a particular `parcelRegister` call corresponds to. This is often important information, to know how the source code is structured and to be able to find things like the package.json it corresponds to.

Adding the `asset-file-names-in-output` tool will insert comments with the file path of the asset (relative to the project root):

- Above the `parcelRegister` statement when scope hoisting
- Wrapping a block of code that has been scope hoisted into a `parcelRegister` body
- At the start of the module function in the Dev Packager

## Checklist
<!-- task-checklist-ignore-start -->
- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder
<!-- task-checklist-ignore-end -->

This is only for internal Atlaspack developers, so no public documentation for this.
