### PR TITLE
Add rimraf to integration-test devDeps

### DIFF
--- a/packages/core/integration-tests/package.json
+++ b/packages/core/integration-tests/package.json
@@ -49,6 +49,7 @@
     "preact": "^10.5.9",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "rimraf": "^5.0.5",
     "source-map": "^0.5.1",
     "tailwindcss": "^3.0.2",
     "tempy": "^0.3.0",


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Can't run `yarn add -D <anything>` in `packages/core/integration-tests` because it complains that:
```
error An unexpected error occurred: "expected workspace package to exist for \"rimraf\"".
```

## Changes

Seems the dependency is missing from the `package.json`, adding it in resolves the issue.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required 
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Integration tests devdeps only
