### PR TITLE
Remove exit:true for Mocha tests

### DIFF
--- a/.changeset/fair-insects-sell.md
+++ b/.changeset/fair-insects-sell.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/test-utils': patch
+---
+
+- Add ATLASPACK_MOCHA_HANG_DEBUG for debugging hanging tests
+- Ensure at least one test always runs to clean up worker farms
+- Cleanup AtlaspackV3 worker farm

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -18,6 +18,4 @@ module.exports = {
     '@atlaspack/babel-register',
     '@atlaspack/test-utils/src/mochaSetup.js',
   ],
-  // TODO: Remove this when https://github.com/nodejs/node/pull/28788 is resolved
-  exit: true,
 };

--- a/docs/debugging-tests.md
+++ b/docs/debugging-tests.md
@@ -1,0 +1,14 @@
+# Useful tools for debugging tests
+
+## Environment variables
+
+### `ATLASPACK_MOCHA_HANG_DEBUG`
+
+Enable debug mode for Mocha test hangs.
+
+- **Values**: `'true'` | `'false'`
+- **Default**: `'false'`
+- **Usage**: `ATLASPACK_MOCHA_HANG_DEBUG=true yarn test:integration` or `ATLASPACK_MOCHA_HANG_DEBUG=true yarn test:js:unit`
+
+When enabled, this environment variable runs [`why-is-node-running`](https://github.com/mafintosh/why-is-node-running) for Mocha tests. If the tests complete but Mocha appears to have hung and won't exit you can send the `SIGHUP` signal to the process (see the command and PID at the top of the Mocha
+output). `why-is-node-running` will show what is holding on to open handles. Most of the time this is a worker farm that hasn't had `end()` called on it.

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -24,15 +24,23 @@ const options = {
   ...DEFAULT_OPTIONS,
   cache: new LMDBLiteCache(DEFAULT_OPTIONS.cacheDir),
 };
-const farm = new WorkerFarm({workerPath: require.resolve('../src/worker')});
 
 describe('RequestTracker', () => {
+  let farm;
+  before(() => {
+    farm = new WorkerFarm({workerPath: require.resolve('../src/worker')});
+  });
+
   beforeEach(async () => {
     await options.cache.ensure();
 
     for (const key of options.cache.keys()) {
       await options.cache.getNativeRef().delete(key);
     }
+  });
+
+  after(() => {
+    farm.end();
   });
 
   it('should not run requests that have not been invalidated', async () => {

--- a/packages/core/core/test/requests/ConfigRequest.test.js
+++ b/packages/core/core/test/requests/ConfigRequest.test.js
@@ -23,13 +23,21 @@ const mockCast = (f: any): any => f;
 
 describe('ConfigRequest tests', () => {
   const projectRoot = 'project_root';
-  const farm = new WorkerFarm({
-    workerPath: require.resolve('../../src/worker'),
-    maxConcurrentWorkers: 1,
+  let farm;
+  let fs;
+  before(() => {
+    farm = new WorkerFarm({
+      workerPath: require.resolve('../../src/worker'),
+      maxConcurrentWorkers: 1,
+    });
   });
-  let fs = new MemoryFS(farm);
+
   beforeEach(() => {
     fs = new MemoryFS(farm);
+  });
+
+  after(() => {
+    farm.end();
   });
 
   const getMockRunApi = (

--- a/packages/core/e2e-tests/.mocharc.json
+++ b/packages/core/e2e-tests/.mocharc.json
@@ -4,7 +4,5 @@
     "@atlaspack/babel-register",
     "@atlaspack/test-utils/src/mochaSetup.js"
   ],
-  "timeout": 50000,
-  "_todo": "Remove exit: true when https://github.com/nodejs/node/pull/28788 is resolved",
-  "exit": true
+  "timeout": 50000
 }

--- a/packages/core/e2e-tests/test/e2e-tests.test.js
+++ b/packages/core/e2e-tests/test/e2e-tests.test.js
@@ -19,7 +19,7 @@ async function runPlaywrightTest(
   });
 
   await atlaspack.run();
-  await atlaspack.watch();
+  const subscription = await atlaspack.watch();
 
   const browser = await chromium.launch();
   const context = await browser.newContext();
@@ -27,10 +27,13 @@ async function runPlaywrightTest(
 
   await page.goto('http://localhost:1234');
 
-  await fn({page});
-
-  await context.close();
-  await browser.close();
+  try {
+    await fn({page});
+  } finally {
+    await context.close();
+    await browser.close();
+    await subscription.unsubscribe();
+  }
 }
 
 describe('Atlaspack Playwright E2E tests', () => {

--- a/packages/core/integration-tests/.mocharc.js
+++ b/packages/core/integration-tests/.mocharc.js
@@ -11,9 +11,6 @@ const config = {
   extension: ['js', 'mjs', 'cjs', 'ts', 'cts', 'mts'],
   require: mochaRequire,
   timeout: 50000,
-  _todo:
-    'Remove exit: true when https://github.com/nodejs/node/pull/28788 is resolved',
-  exit: true,
 };
 
 if (process.env.ATLASPACK_INTEGRATION_TESTS_CI === 'true') {

--- a/packages/core/integration-tests/test/react-refresh.js
+++ b/packages/core/integration-tests/test/react-refresh.js
@@ -37,12 +37,7 @@ if (MessageChannel) {
         '/integration/react-refresh-automatic',
       );
 
-      let b,
-        root,
-        randoms,
-        subscription,
-        ports,
-        window = {};
+      let b, root, randoms, subscription, ports, window;
 
       beforeEach(async () => {
         ({b, root, randoms, subscription, window, ports} = await setup(
@@ -78,12 +73,7 @@ if (MessageChannel) {
     describe('synchronous', () => {
       const testDir = path.join(__dirname, '/integration/react-refresh');
 
-      let b,
-        root,
-        window,
-        subscription,
-        ports,
-        randoms = {};
+      let b, root, window, subscription, ports, randoms;
 
       beforeEach(async () => {
         ({b, root, window, subscription, randoms, ports} = await setup(
@@ -164,12 +154,7 @@ if (MessageChannel) {
         '/integration/react-refresh-lazy-child',
       );
 
-      let b,
-        root,
-        window,
-        subscription,
-        ports,
-        randoms = {};
+      let b, root, window, subscription, ports, randoms;
 
       beforeEach(async () => {
         ({b, root, window, subscription, randoms, ports} = await setup(
@@ -210,11 +195,7 @@ if (MessageChannel) {
         '/integration/react-refresh-circular',
       );
 
-      let b,
-        root,
-        subscription,
-        window,
-        ports = {};
+      let b, root, subscription, ports, window;
 
       beforeEach(async () => {
         ({b, root, subscription, window, ports} = await setup(

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -27,6 +27,7 @@
     "posthtml-parser": "^0.10.1",
     "resolve": "^1.12.0",
     "ws": "^7.0.0",
-    "tempy": "^0.2.1"
+    "tempy": "^0.2.1",
+    "why-is-node-running": "^3.2.2"
   }
 }

--- a/packages/core/test-utils/src/mochaSetup.js
+++ b/packages/core/test-utils/src/mochaSetup.js
@@ -1,10 +1,10 @@
 if (process.env.ATLASPACK_MOCHA_HANG_DEBUG === 'true') {
   const whyIsNodeRunning = require('why-is-node-running').default;
   // eslint-disable-next-line no-console
-  console.log(`\n\n🛠️ Mocha process PID: ${process.pid}`);
+  console.log(`\n\n🛠️  Mocha process PID: ${process.pid}`);
   // eslint-disable-next-line no-console
   console.log(
-    `🛠️ Run 'kill -SIGHUP ${process.pid}' to get information about open handles\n\n`,
+    `🛠️  Run 'kill -SIGHUP ${process.pid}' to get information about open handles\n\n`,
   );
 
   process.on('SIGHUP', () => {

--- a/packages/core/test-utils/src/mochaSetup.js
+++ b/packages/core/test-utils/src/mochaSetup.js
@@ -1,3 +1,17 @@
+if (process.env.ATLASPACK_MOCHA_HANG_DEBUG === 'true') {
+  const whyIsNodeRunning = require('why-is-node-running').default;
+  // eslint-disable-next-line no-console
+  console.log(`\n\n🛠️ Mocha process PID: ${process.pid}`);
+  // eslint-disable-next-line no-console
+  console.log(
+    `🛠️ Run 'kill -SIGHUP ${process.pid}' to get information about open handles\n\n`,
+  );
+
+  process.on('SIGHUP', () => {
+    whyIsNodeRunning();
+  });
+}
+
 process.on('unhandledRejection', (reason) => {
   throw reason;
 });

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -92,7 +92,9 @@ export async function ncp(source: FilePath, destination: FilePath) {
 after(async () => {
   // Spin down the worker farm to stop it from preventing the main process from exiting
   await workerFarm.end();
-  napiWorkerPool.shutdown();
+  if (isAtlaspackV3) {
+    napiWorkerPool.shutdown();
+  }
 });
 
 const chalk = new _chalk.Instance();

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -1480,3 +1480,9 @@ it.v3.only = function (...args: mixed[]) {
     origIt.only.apply(this, args);
   }
 };
+
+// If no tests run, then `after()` is not called, and so worker farms are never cleaned up.
+// This test ensures that at least one test runs, and so `after()` is called.
+it('dummy test to ensure there is at least one test', () => {
+  assert(true);
+});

--- a/packages/core/test-utils/src/utils.js
+++ b/packages/core/test-utils/src/utils.js
@@ -89,14 +89,11 @@ export async function ncp(source: FilePath, destination: FilePath) {
   });
 }
 
-// Mocha is currently run with exit: true because of this issue preventing us
-// from properly ending the workerfarm after the test run:
-// https://github.com/nodejs/node/pull/28788
-//
-// TODO: Remove exit: true in .mocharc.json and instead add the following in this file:
-//   // Spin down the worker farm to stop it from preventing the main process from exiting
-//   await workerFarm.end();
-// when https://github.com/nodejs/node/pull/28788 is resolved.
+after(async () => {
+  // Spin down the worker farm to stop it from preventing the main process from exiting
+  await workerFarm.end();
+  napiWorkerPool.shutdown();
+});
 
 const chalk = new _chalk.Instance();
 const warning = chalk.keyword('orange');

--- a/packages/core/workers/test/workerfarm.test.cjs
+++ b/packages/core/workers/test/workerfarm.test.cjs
@@ -292,6 +292,7 @@ describe('WorkerFarm', function () {
     await dispose();
     result = await workerfarm.run(ref);
     assert.equal(result, 'Shared reference does not exist');
+    await workerfarm.end();
   });
 
   it('Should resolve shared references in workers', async () => {
@@ -311,6 +312,7 @@ describe('WorkerFarm', function () {
 
     await dispose();
     assert(workerfarm.workerApi.resolveSharedReference(sharedValue) == null);
+    await workerfarm.end();
   });
 
   it('Should support shared references in local worker', async () => {
@@ -329,6 +331,7 @@ describe('WorkerFarm', function () {
     await dispose();
     result = await workerfarm.run(ref);
     assert.equal(result, 'Shared reference does not exist');
+    await workerfarm.end();
   });
 
   it('should resolve shared references in local worker', async () => {
@@ -348,6 +351,7 @@ describe('WorkerFarm', function () {
 
     await dispose();
     assert(workerfarm.workerApi.resolveSharedReference(sharedValue) == null);
+    await workerfarm.end();
   });
 
   it('Should dispose of shared references when ending', async () => {
@@ -361,5 +365,6 @@ describe('WorkerFarm', function () {
     assert.equal(workerfarm.sharedReferences.size, 1);
     await workerfarm.end();
     assert.equal(workerfarm.sharedReferences.size, 0);
+    await workerfarm.end();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -17329,6 +17329,11 @@ which@^4.0.0:
   dependencies:
     isexe "^3.1.1"
 
+why-is-node-running@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-3.2.2.tgz#4c563f5068c5960167220f1b7102ae501cefefb9"
+  integrity sha512-NKUzAelcoCXhXL4dJzKIwXeR8iEVqsA0Lq6Vnd0UXvgaKbzVo4ZTHROF2Jidrv+SgxOQ03fMinnNhzZATxOD3A==
+
 wide-align@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.3.tgz#ae074e6bdc0c14a431e804e624549c633b000457"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

We've had Mocha doing a force `exit` at the end of tests when they "hang". This potentially masks issues where resources (such as worker pools) are not properly cleaned up. I was able to reproduce a "hang" when using Atlaspack V3 via the `Atlaspack` JS API that wasn't reproducible in a test because of this.

The reason for having that `exit: true` dates back to an issue from 2019 or earlier which is long resolved.

## Changes

* Removed the "exit: true" from all the Mocha configs, and restored the `after()` hook to dispose of shared test worker pools in test-utils.
* Added a `ATLASPACK_MOCHA_HANG_DEBUG` env var for tests that can help to debug hangs by setting up https://github.com/mafintosh/why-is-node-running and allowing you to dump out what handles are still open
* Fixed several unit and integration tests which were keeping open handles and stopping the process from exit'ing

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
