### PR TITLE
Increase the integration timeout to 45 mins

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
     name: Integration tests (${{ matrix.os }}, Node ${{ matrix.node }})
     needs:
       - build_native
-    timeout-minutes: 35
+    timeout-minutes: 45
     strategy:
       # These tend to be quite flakey, so one failed instance shouldn't stop
       # others from potentially succeeding


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

The Mac integration test suite is consistently timing out atm. This PR increases the timeout from 35 mins to 45 mins to hopefully get more green builds. 

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: CI only change
