### PR TITLE
Ensure tracer is disabled at the end of the build

### DIFF
--- a/.changeset/late-phones-joke.md
+++ b/.changeset/late-phones-joke.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Ensure tracer is disabled if it was enabled on teardown

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -386,6 +386,11 @@ export default class Atlaspack {
       }
       if (options.shouldTrace) {
         tracer.enable();
+        // We need to ensure the tracer is disabled when Atlaspack is disposed as it is a module level object.
+        // While rare (except for tests), if another instance is created later it should not have tracing enabled.
+        this.#disposable.add(() => {
+          tracer.disable();
+        });
       }
       await this.#reporterRunner.report({
         type: 'buildStart',

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -57,6 +57,8 @@ let packageManager = new NodePackageManager(inputFS, '/');
       {
         inputFS: overlayFS,
         shouldDisableCache: false,
+        // Force FSEvents on macOS as it's significantly faster than watchman for these tests
+        watchBackend: process.platform === 'darwin' ? 'fs-events' : 'watchman',
         featureFlags: {
           ...featureFlags,
           cachePerformanceImprovements,
@@ -106,7 +108,6 @@ let packageManager = new NodePackageManager(inputFS, '/');
       getOptions(options),
     );
     let resolvedOptions = await resolveOptions(initialOptions);
-
     let b = await runBundle(entries, options, featureFlags);
 
     await assertNoFilePathInCache(

--- a/packages/core/integration-tests/test/cache.js
+++ b/packages/core/integration-tests/test/cache.js
@@ -57,8 +57,6 @@ let packageManager = new NodePackageManager(inputFS, '/');
       {
         inputFS: overlayFS,
         shouldDisableCache: false,
-        // Force FSEvents on macOS as it's significantly faster than watchman for these tests
-        watchBackend: process.platform === 'darwin' ? 'fs-events' : 'watchman',
         featureFlags: {
           ...featureFlags,
           cachePerformanceImprovements,
@@ -108,6 +106,7 @@ let packageManager = new NodePackageManager(inputFS, '/');
       getOptions(options),
     );
     let resolvedOptions = await resolveOptions(initialOptions);
+
     let b = await runBundle(entries, options, featureFlags);
 
     await assertNoFilePathInCache(

--- a/packages/core/integration-tests/test/tracing.js
+++ b/packages/core/integration-tests/test/tracing.js
@@ -6,37 +6,36 @@ import {tracer} from '@atlaspack/profiler';
 
 describe('tracing', function () {
   it('should produce a trace', async function () {
-    try {
-      await outputFS.mkdirp(path.join(__dirname, 'integration'));
-      await bundle(
-        path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
-        {
-          shouldTrace: true,
-          targets: {
-            default: {distDir},
-          },
-          additionalReporters: [
-            {
-              packageName: '@atlaspack/reporter-tracer',
-              resolveFrom: __dirname,
-            },
-          ],
-          outputFS,
+    await outputFS.mkdirp(path.join(__dirname, 'integration'));
+    await bundle(
+      path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
+      {
+        shouldTrace: true,
+        targets: {
+          default: {distDir},
         },
-      );
+        additionalReporters: [
+          {
+            packageName: '@atlaspack/reporter-tracer',
+            resolveFrom: __dirname,
+          },
+        ],
+        outputFS,
+      },
+    );
 
-      const files = outputFS.readdirSync(__dirname);
-      const profileFile = files.find((file) => file.startsWith('parcel-trace'));
-      assert(profileFile !== null);
-      const content = await outputFS.readFile(
-        path.join(__dirname, profileFile),
-        'utf8',
-      );
-      const profileContent = JSON.parse(content + ']'); // Traces don't contain a closing ] as an optimisation for partial writes
-      assert(profileContent.length > 0);
-    } finally {
-      // Disable the tracer for future tests
-      tracer.disable();
-    }
+    const files = outputFS.readdirSync(__dirname);
+    const profileFile = files.find((file) => file.startsWith('parcel-trace'));
+    assert(profileFile !== null);
+    const content = await outputFS.readFile(
+      path.join(__dirname, profileFile),
+      'utf8',
+    );
+    const profileContent = JSON.parse(content + ']'); // Traces don't contain a closing ] as an optimisation for partial writes
+    assert(profileContent.length > 0);
+    assert(
+      !tracer.enabled,
+      'Tracer should be disabled when Atlaspack is shut down',
+    );
   });
 });

--- a/packages/core/integration-tests/test/tracing.js
+++ b/packages/core/integration-tests/test/tracing.js
@@ -2,35 +2,41 @@
 import assert from 'assert';
 import path from 'path';
 import {bundle, describe, distDir, it, outputFS} from '@atlaspack/test-utils';
+import {tracer} from '@atlaspack/profiler';
 
 describe('tracing', function () {
   it('should produce a trace', async function () {
-    await outputFS.mkdirp(path.join(__dirname, 'integration'));
-    await bundle(
-      path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
-      {
-        shouldTrace: true,
-        targets: {
-          default: {distDir},
-        },
-        additionalReporters: [
-          {
-            packageName: '@atlaspack/reporter-tracer',
-            resolveFrom: __dirname,
+    try {
+      await outputFS.mkdirp(path.join(__dirname, 'integration'));
+      await bundle(
+        path.join(__dirname, '/integration/typescript-jsx/index.tsx'),
+        {
+          shouldTrace: true,
+          targets: {
+            default: {distDir},
           },
-        ],
-        outputFS,
-      },
-    );
+          additionalReporters: [
+            {
+              packageName: '@atlaspack/reporter-tracer',
+              resolveFrom: __dirname,
+            },
+          ],
+          outputFS,
+        },
+      );
 
-    const files = outputFS.readdirSync(__dirname);
-    const profileFile = files.find((file) => file.startsWith('parcel-trace'));
-    assert(profileFile !== null);
-    const content = await outputFS.readFile(
-      path.join(__dirname, profileFile),
-      'utf8',
-    );
-    const profileContent = JSON.parse(content + ']'); // Traces don't contain a closing ] as an optimisation for partial writes
-    assert(profileContent.length > 0);
+      const files = outputFS.readdirSync(__dirname);
+      const profileFile = files.find((file) => file.startsWith('parcel-trace'));
+      assert(profileFile !== null);
+      const content = await outputFS.readFile(
+        path.join(__dirname, profileFile),
+        'utf8',
+      );
+      const profileContent = JSON.parse(content + ']'); // Traces don't contain a closing ] as an optimisation for partial writes
+      assert(profileContent.length > 0);
+    } finally {
+      // Disable the tracer for future tests
+      tracer.disable();
+    }
   });
 });

--- a/patches/mocha+8.4.0.patch
+++ b/patches/mocha+8.4.0.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/mocha/lib/reporters/base.js b/node_modules/mocha/lib/reporters/base.js
+index 1f97e31..8b86b65 100644
+--- a/node_modules/mocha/lib/reporters/base.js
++++ b/node_modules/mocha/lib/reporters/base.js
+@@ -379,6 +379,9 @@ Base.prototype.epilogue = function() {
+   }
+ 
+   Base.consoleLog();
++  setTimeout(() => {
++    require('why-is-node-running').default();
++  }, 1000);
+ };
+ 
+ /**
+diff --git a/node_modules/mocha/mocha.js b/node_modules/mocha/mocha.js
+index 53ac33e..4243a15 100644
+--- a/node_modules/mocha/mocha.js
++++ b/node_modules/mocha/mocha.js
+@@ -24745,7 +24745,7 @@
+ 	    var fmt;
+ 	    Base.consoleLog(); // passes
+ 
+-	    fmt = color('bright pass', ' ') + color('green', ' %d passing') + color('light', ' (%s)');
++	    fmt = color('bright pass', ' ') + color('green', ' %d passinzzzg') + color('light', ' (%s)');
+ 	    Base.consoleLog(fmt, stats.passes || 0, ms(stats.duration)); // pending
+ 
+ 	    if (stats.pending) {
+@@ -24762,6 +24762,8 @@
+ 	    }
+ 
+ 	    Base.consoleLog();
++		Base.consoleLog("hello");
++		require('why-is-node-running').default();
+ 	  };
+ 	  /**
+ 	   * Pads the given `str` to `len`.


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Integration tests are slow, and seem to slow down over time. It was identified that the tracing test would cause the tracer to be enabled. As the tracer is a module level object, it meant that even if tracing was enabled on subsequent uses of `Atlaspack`, the tracer would remain enabled.

## Changes

Add a disposable to disable the tracer when Atlaspack is torn down if it has been enabled.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
