### PR TITLE
bump @atlaspack/rust

### DIFF
--- a/.changeset/beige-balloons-add.md
+++ b/.changeset/beige-balloons-add.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/rust': minor
+---
+
+The @atlaspack/rust package should have been bumped in [pull request 633](https://github.com/atlassian-labs/atlaspack/pull/633). This has resulted in the JS half of those changes being released, but not the Rust half.
+
+Rectifying by creating a new changeset now.


### PR DESCRIPTION
The `@atlaspack/rust` package should have been bumped in #633. This has resulted in the JS half of those changes being released, but not the Rust half.

Rectifying by creating a new changeset now.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder