### PR TITLE
Add GitHub action to check for modified rust files in PRs and notify devs if they have not include the rust package in their changeset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,32 @@ jobs:
               octokit: github
             });
 
+  # Check if Rust files changed and rust package is bumped
+  check-rust-changes:
+    name: 🦀 Rust Changeset Check (ferris-atlaspack-bot)
+    runs-on: ubuntu-24.04
+    if: github.ref_name != 'main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate token for Ferris bot
+        id: ferris_token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.FERRIS_APP_ID }}
+          private-key: ${{ secrets.FERRIS_APP_PRIVATE_KEY }}
+      - name: Run Rust Changeset Check (ferris-atlaspack-bot)
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.ferris_token.outputs.token }}
+          script: |
+            const { checkRustChanges } = require('./scripts/check-rust-changes.js');
+            await checkRustChanges({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pullNumber: context.payload.pull_request.number,
+              octokit: github
+            });
+
   # Build and store native packages
   build_native:
     strategy:

--- a/.mocharc.js
+++ b/.mocharc.js
@@ -8,9 +8,15 @@ function isFileArg(file) {
   );
 }
 
+const TEST_FILE_PATTERN =
+  '{*.{js,ts,cts,mts,cjs,mjs},**/*.{test,spec}.{js,ts,mts,cts,cjs,mjs}}';
+
 const spec = args.some(isFileArg)
   ? args.filter(isFileArg)
-  : 'packages/*/!(integration-tests|e2e-tests)/test/{*.{js,ts,cts,mts,cjs,mjs},**/*.{test,spec}.{js,ts,mts,cts,cjs,mjs}}';
+  : [
+      `packages/*/!(integration-tests|e2e-tests)/test/${TEST_FILE_PATTERN}`,
+      `scripts/test/${TEST_FILE_PATTERN}`,
+    ];
 
 module.exports = {
   spec,

--- a/scripts/check-rust-changes.js
+++ b/scripts/check-rust-changes.js
@@ -1,0 +1,188 @@
+/* eslint-disable no-console */
+
+/**
+ * @typedef CheckRustChangesOptions
+ * @property number pullNumber
+ * @property string owner
+ * @property string repo
+ * @property {import('@actions/github-script').AsyncFunctionArguments} octokit
+ */
+
+const commentTitle = `## 🦀 Ferris' Rust Changeset Check`;
+
+async function getCommentId({octokit, owner, repo, pullNumber}) {
+  const comments = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: pullNumber,
+  });
+
+  const comment = comments.data.find(
+    (comment) =>
+      comment.body.includes(commentTitle) &&
+      comment.user.login === 'ferris-atlaspack-bot[bot]',
+  );
+
+  if (comment) {
+    console.log('Existing ferris-atlaspack-bot comment found in PR');
+  } else {
+    console.log('No ferris-atlaspack-bot comment found in PR');
+  }
+
+  return comment?.id;
+}
+
+async function checkForRustFileChanges({octokit, owner, repo, pullNumber}) {
+  const files = await octokit.rest.pulls.listFiles({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+
+  const hasRustFiles = files.data.some(({filename}) =>
+    filename.endsWith('.rs'),
+  );
+
+  if (hasRustFiles) {
+    console.log('Rust files found in PR');
+  } else {
+    console.log('No Rust files found in PR');
+  }
+
+  return hasRustFiles;
+}
+
+async function checkForRustPackageBump({octokit, owner, repo, pullNumber}) {
+  const files = await octokit.rest.pulls.listFiles({
+    owner,
+    repo,
+    pull_number: pullNumber,
+  });
+
+  // Check for changeset files
+  const changesetFiles = files.data.filter(
+    ({filename}) =>
+      filename.startsWith('.changeset/') && filename.endsWith('.md'),
+  );
+
+  if (changesetFiles.length === 0) {
+    console.log('No changeset files found in PR');
+    return false;
+  }
+
+  // Get the content of each changeset file to check for @atlaspack/rust bumps
+  const changesetContents = await Promise.all(
+    changesetFiles.map(async ({filename}) => {
+      const content = await octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path: filename,
+        ref: `pull/${pullNumber}/head`,
+      });
+
+      // Decode the content (it's base64 encoded)
+      const decodedContent = Buffer.from(
+        content.data.content,
+        'base64',
+      ).toString('utf-8');
+      return decodedContent;
+    }),
+  );
+
+  // Check if any changeset contains a bump for @atlaspack/rust
+  const hasRustBump = changesetContents.some((content) =>
+    content.includes('@atlaspack/rust'),
+  );
+
+  if (hasRustBump) {
+    console.log('@atlaspack/rust bump found in changeset files');
+  } else {
+    console.log('No @atlaspack/rust bump found in changeset files');
+  }
+
+  return hasRustBump;
+}
+
+/**
+ * Check if Rust files have been changed and if the @atlaspack/rust package is bumped
+ * @param CheckRustChangesOptions options
+ */
+export async function checkRustChanges(prOptions) {
+  const {octokit, owner, repo, pullNumber} = prOptions;
+
+  const [hasRustFiles, commentId, hasRustBump] = await Promise.all([
+    checkForRustFileChanges(prOptions),
+    getCommentId(prOptions),
+    checkForRustPackageBump(prOptions),
+  ]);
+
+  // If no Rust files changed, we don't need to do anything
+  if (!hasRustFiles) {
+    process.exitCode = 0;
+
+    // If no Rust files changed, delete any existing comment
+    if (commentId) {
+      await octokit.rest.issues.deleteComment({
+        owner,
+        repo,
+        comment_id: commentId,
+      });
+
+      console.log(
+        'Detected existing ferris-atlaspack-bot comment in PR but now there are no Rust files, so deleting it',
+      );
+    }
+
+    return;
+  }
+
+  // If Rust files changed and rust package is bumped, no need for PR comment
+  if (hasRustBump) {
+    process.exitCode = 0;
+
+    // If we previously left a PR comment, delete it
+    if (commentId) {
+      await octokit.rest.issues.updateComment({
+        owner,
+        repo,
+        comment_id: commentId,
+        body: `
+${commentTitle}
+I can see you have now included \`@atlaspack/rust\` in your changeset. This means your Rust changes will be published.
+Now I'm a [happy crab](https://youtu.be/LDU_Txk06tM?si=L80HlbKGtjXAmi6R&t=71) 🦀🎉
+`.trim(),
+      });
+
+      console.log(
+        'Detected existing ferris-atlaspack-bot comment in PR but now there is a Rust bump, so updating it',
+      );
+    }
+
+    return;
+  }
+
+  // If comment already exists, just leave it in place
+  if (commentId) {
+    process.exitCode = 1;
+    console.log(
+      'Rust files changed but @atlaspack/rust package not bumped. Comment already exists.',
+    );
+  }
+
+  // Add the comment
+  await octokit.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pullNumber,
+    body: `
+${commentTitle}
+Ferris says: Hi! I noticed you changed some \`.rs\` files but you didn't bump the Rust package.
+
+If you want your Rust changes published, you will need to bump the \`@atlaspack/rust\` package in your changeset.
+`.trim(),
+  });
+
+  console.log(
+    'Rust files changed but @atlaspack/rust package not bumped. Left a comment.',
+  );
+}

--- a/scripts/check-rust-changes.js
+++ b/scripts/check-rust-changes.js
@@ -9,6 +9,13 @@
  */
 
 const commentTitle = `## ðŸ¦€ Ferris' Rust Changeset Check`;
+const debugMode = process.env.DEBUG_CHECK_RUST_CHANGES === 'true';
+
+function debugLog(message) {
+  if (debugMode) {
+    console.log(message);
+  }
+}
 
 async function getCommentId({octokit, owner, repo, pullNumber}) {
   const comments = await octokit.rest.issues.listComments({
@@ -24,9 +31,9 @@ async function getCommentId({octokit, owner, repo, pullNumber}) {
   );
 
   if (comment) {
-    console.log('Existing ferris-atlaspack-bot comment found in PR');
+    debugLog('Existing ferris-atlaspack-bot comment found in PR');
   } else {
-    console.log('No ferris-atlaspack-bot comment found in PR');
+    debugLog('No ferris-atlaspack-bot comment found in PR');
   }
 
   return comment?.id;
@@ -44,9 +51,9 @@ async function checkForRustFileChanges({octokit, owner, repo, pullNumber}) {
   );
 
   if (hasRustFiles) {
-    console.log('Rust files found in PR');
+    debugLog('Rust files found in PR');
   } else {
-    console.log('No Rust files found in PR');
+    debugLog('No Rust files found in PR');
   }
 
   return hasRustFiles;
@@ -66,7 +73,7 @@ async function checkForRustPackageBump({octokit, owner, repo, pullNumber}) {
   );
 
   if (changesetFiles.length === 0) {
-    console.log('No changeset files found in PR');
+    debugLog('No changeset files found in PR');
     return false;
   }
 
@@ -104,9 +111,9 @@ async function checkForRustPackageBump({octokit, owner, repo, pullNumber}) {
   });
 
   if (hasRustBump) {
-    console.log('@atlaspack/rust bump found in changeset files');
+    debugLog('@atlaspack/rust bump found in changeset files');
   } else {
-    console.log('No @atlaspack/rust bump found in changeset files');
+    debugLog('No @atlaspack/rust bump found in changeset files');
   }
 
   return hasRustBump;
@@ -136,7 +143,7 @@ async function checkRustChanges(prOptions) {
         comment_id: commentId,
       });
 
-      console.log(
+      debugLog(
         'Detected existing ferris-atlaspack-bot comment in PR but now there are no Rust files, so deleting it',
       );
     }
@@ -163,7 +170,7 @@ Now I'm a [happy crab](https://youtu.be/LDU_Txk06tM?si=L80HlbKGtjXAmi6R&t=71) ðŸ
 `.trim(),
       });
 
-      console.log(
+      debugLog(
         'Detected existing ferris-atlaspack-bot comment in PR but now there is a Rust bump, so updating it',
       );
     }
@@ -174,7 +181,7 @@ Now I'm a [happy crab](https://youtu.be/LDU_Txk06tM?si=L80HlbKGtjXAmi6R&t=71) ðŸ
   // If comment already exists, just leave it in place
   if (commentId) {
     process.exitCode = 1;
-    console.log(
+    debugLog(
       'Rust files changed but @atlaspack/rust package not bumped. Comment already exists.',
     );
 
@@ -194,7 +201,7 @@ If you want your Rust changes published, you will need to bump the \`@atlaspack/
 `.trim(),
   });
 
-  console.log(
+  debugLog(
     'Rust files changed but @atlaspack/rust package not bumped. Left a comment.',
   );
 }

--- a/scripts/check-rust-changes.test.js
+++ b/scripts/check-rust-changes.test.js
@@ -1,0 +1,228 @@
+/* eslint-env jest */
+const assert = require('assert');
+const sinon = require('sinon');
+const {checkForRustPackageBump} = require('./check-rust-changes.js');
+
+describe('check-rust-changes test', () => {
+  let mockOctokit;
+
+  beforeEach(() => {
+    mockOctokit = {
+      rest: {
+        pulls: {
+          listFiles: sinon.stub(),
+        },
+        repos: {
+          getContent: sinon.stub(),
+        },
+      },
+    };
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  const createMockChangesetContent = (frontmatter, summary = '') => {
+    return `---
+${frontmatter}
+---
+
+${summary}`;
+  };
+
+  const setupMockFiles = (files) => {
+    mockOctokit.rest.pulls.listFiles.resolves({
+      data: files.map((filename) => ({filename})),
+    });
+  };
+
+  const setupMockContent = (contents) => {
+    mockOctokit.rest.repos.getContent.resolves({
+      data: {
+        content: Buffer.from(contents).toString('base64'),
+      },
+    });
+  };
+
+  it('should return true when @atlaspack/rust is in frontmatter', async () => {
+    const changesetContent = createMockChangesetContent(
+      "'@atlaspack/rust': minor\n'@atlaspack/core': minor",
+    );
+
+    setupMockFiles(['.changeset/test.md']);
+    setupMockContent(changesetContent);
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, true);
+  });
+
+  it('should return false when @atlaspack/rust is only in summary', async () => {
+    const changesetContent = createMockChangesetContent(
+      "'@atlaspack/core': minor",
+      "This changeset doesn't bump the `@atlaspack/rust` package",
+    );
+
+    setupMockFiles(['.changeset/test.md']);
+    setupMockContent(changesetContent);
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, false);
+  });
+
+  it('should return false when no changeset files exist', async () => {
+    setupMockFiles([]);
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, false);
+  });
+
+  it('should return false when changeset has no frontmatter', async () => {
+    const changesetContent = 'This is a changeset without frontmatter';
+
+    setupMockFiles(['.changeset/test.md']);
+    setupMockContent(changesetContent);
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, false);
+  });
+
+  it('should return false when changeset has malformed frontmatter', async () => {
+    const changesetContent = `---
+'@atlaspack/rust': minor
+This is malformed frontmatter without closing ---`;
+
+    setupMockFiles(['.changeset/test.md']);
+    setupMockContent(changesetContent);
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, false);
+  });
+
+  it('should return true when multiple changeset files exist and one has @atlaspack/rust', async () => {
+    const changesetContent1 = createMockChangesetContent(
+      "'@atlaspack/core': minor",
+    );
+    const changesetContent2 = createMockChangesetContent(
+      "'@atlaspack/rust': minor",
+    );
+
+    setupMockFiles(['.changeset/test1.md', '.changeset/test2.md']);
+
+    // Mock the content for both files
+    mockOctokit.rest.repos.getContent
+      .onFirstCall()
+      .resolves({
+        data: {content: Buffer.from(changesetContent1).toString('base64')},
+      })
+      .onSecondCall()
+      .resolves({
+        data: {content: Buffer.from(changesetContent2).toString('base64')},
+      });
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, true);
+  });
+
+  it('should return false when multiple changeset files exist but none have @atlaspack/rust', async () => {
+    const changesetContent1 = createMockChangesetContent(
+      "'@atlaspack/core': minor",
+    );
+    const changesetContent2 = createMockChangesetContent(
+      "'@atlaspack/utils': minor",
+    );
+
+    setupMockFiles(['.changeset/test1.md', '.changeset/test2.md']);
+
+    // Mock the content for both files
+    mockOctokit.rest.repos.getContent
+      .onFirstCall()
+      .resolves({
+        data: {content: Buffer.from(changesetContent1).toString('base64')},
+      })
+      .onSecondCall()
+      .resolves({
+        data: {content: Buffer.from(changesetContent2).toString('base64')},
+      });
+
+    const result = await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    assert.equal(result, false);
+  });
+
+  it('should ignore non-changeset files', async () => {
+    setupMockFiles(['package.json', 'README.md']);
+
+    await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    // Should not call getContent for non-changeset files
+    sinon.assert.notCalled(mockOctokit.rest.repos.getContent);
+  });
+
+  it('should only process changeset files', async () => {
+    setupMockFiles(['.changeset/test.md', 'package.json', 'README.md']);
+    setupMockContent('---\n---\n');
+
+    await checkForRustPackageBump({
+      octokit: mockOctokit,
+      owner: 'test',
+      repo: 'test',
+      pullNumber: 1,
+    });
+
+    // Should only call getContent once for the changeset file
+    sinon.assert.calledOnce(mockOctokit.rest.repos.getContent);
+    sinon.assert.calledWith(mockOctokit.rest.repos.getContent, {
+      owner: 'test',
+      repo: 'test',
+      path: '.changeset/test.md',
+      ref: 'pull/1/head',
+    });
+  });
+});

--- a/scripts/test/check-rust-changes.test.js
+++ b/scripts/test/check-rust-changes.test.js
@@ -1,7 +1,7 @@
 /* eslint-env jest */
 const assert = require('assert');
 const sinon = require('sinon');
-const {checkForRustPackageBump} = require('./check-rust-changes.js');
+const {checkForRustPackageBump} = require('../check-rust-changes.js');
 
 describe('check-rust-changes test', () => {
   let mockOctokit;


### PR DESCRIPTION
Add CI job to check for rust files in PRs and notify devs if they have not include the rust package in their changeset via a PR comment.

## Motivation

As a follow up from debugging an apparent issue with feature flag evaluation, we discovered that the developer did not include @atlaspack/rust in their changeset, so their updated code never got published to npm.

The current yarn changeset command checks for packages that are updated, but file changes to .rs files do not directly change the code in the @atlaspack/rust package, so the developer is not prompted to add @atlaspack/rust to the changeset.

## Changes

Introducing `ferris-atlaspack-bot`! Ferris will helpfully add a PR comment to notify developers to consider adding the `@atlaspack/rust` package to their changeset if they want to have their Rust changes get published.

## Cases

### Case where .rs files NOT CHANGED and @atlaspack/rust NOT IN changeset
No comment on PR

### Case where .rs file CHANGED and @atlaspack/rust PRESENT in changeset in the same push
No comment on PR

### Case where .rs files CHANGED and @atlaspack/rust NOT IN changeset
`ferris-atlaspack-bot` comment on PR:
![Pasted image 20250704162437](https://github.com/user-attachments/assets/c0fb2e0b-5fd1-45de-8a88-993451c65dab)


### Case where .rs file CHANGED, then @atlaspack/rust IS PRESENT in changeset in a following push
Update the existing `ferris-atlaspack-bot` comment on PR:
<img width="990" alt="Pasted image 20250704180640" src="https://github.com/user-attachments/assets/9d865f9f-20b6-4a6a-b750-ece139613557" />


### Case where .rs file CHANGED, but .rs file changes are NOT PRESENT in a following push (ie the PR no longer contains rust code changes)
`ferris-atlaspack-bot` comment deleted, since it is no longer relevant.

---

[no-changeset]: Only modifying repo internals, no published packages (change to pipelines does not require a changeset, see #389)
