### PR TITLE
Move adding of APV3 disposable to correct place

### DIFF
--- a/.changeset/wise-peas-visit.md
+++ b/.changeset/wise-peas-visit.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Move adding of Atlaspack V3 disposable to be conditional on Atlaspack V3

--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -187,14 +187,13 @@ export default class Atlaspack {
         defaultTargetOptions: resolvedOptions.defaultTargetOptions,
         lmdb,
       });
+      if (featureFlags.atlaspackV3CleanShutdown) {
+        this.#disposable.add(() => {
+          rustAtlaspack.end();
+        });
+      }
     }
     this.rustAtlaspack = rustAtlaspack;
-
-    if (featureFlags.atlaspackV3CleanShutdown) {
-      this.#disposable.add(() => {
-        rustAtlaspack.end();
-      });
-    }
 
     let {config} = await loadAtlaspackConfig(resolvedOptions);
     this.#config = new AtlaspackConfig(config, resolvedOptions);


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

If the `atlaspackV3CleanShutdown` feature flag is enabled but `atlaspackv3` isn't then an error will occur when Atlaspack exits as the disposable is added even if `rustAtlaspack` isn't defined.

## Changes

Move the addition of the disposable inside the "if Atlaspack v3" check.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
