### PR TITLE
Add the asset name debug tool to the DevPackager

### DIFF
--- a/.changeset/tall-mice-divide.md
+++ b/.changeset/tall-mice-divide.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/packager-js': patch
+---
+
+Add the 'asset-file-names-in-output' debug tool to the DevPackager

--- a/packages/packagers/js/src/DevPackager.js
+++ b/packages/packagers/js/src/DevPackager.js
@@ -6,6 +6,7 @@ import {
   relativeBundlePath,
   countLines,
   normalizeSeparators,
+  debugTools,
 } from '@atlaspack/utils';
 import SourceMap from '@parcel/source-map';
 import {getFeatureFlag} from '@atlaspack/feature-flags';
@@ -127,11 +128,20 @@ export class DevPackager {
 
         let {code, mapBuffer} = results[i];
         let output = code || '';
+
         wrapped +=
           JSON.stringify(this.bundleGraph.getAssetPublicId(asset)) +
-          ':[function(require,module,exports,__globalThis) {\n' +
-          output +
-          '\n},';
+          ':[function(require,module,exports,__globalThis) {\n';
+
+        if (debugTools['asset-file-names-in-output']) {
+          let assetPath = path.relative(
+            this.options.projectRoot,
+            asset.filePath,
+          );
+          wrapped += `/* ${assetPath} */\n`;
+        }
+
+        wrapped += output + '\n},';
         wrapped += JSON.stringify(deps);
         wrapped += ']';
 


### PR DESCRIPTION
## Motivation

Realised as we were trying to debug locally yesterday that I didn't include the DevPackager in #659

## Checklist

<!-- task-checklist-ignore-start -->
- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder
<!-- task-checklist-ignore-end -->

Will do a follow up docs PR for all debug tools