### PR TITLE
Fix star re-export of empty files causing runtime errors

### DIFF
--- a/.changeset/gorgeous-teachers-reflect.md
+++ b/.changeset/gorgeous-teachers-reflect.md
@@ -1,0 +1,8 @@
+---
+'@atlaspack/feature-flags': patch
+'@atlaspack/core': patch
+'@atlaspack/rust': patch
+---
+
+Fixes an issue where star re-exports of empty files (usually occurring in compiled typescript libraries) could cause exports to undefined at runtime.
+Fix is behind the feature-flag `emptyFileStarRexportFix`.

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer/conversion.rs
@@ -203,6 +203,11 @@ pub(crate) fn convert_result(
       || hoist_result.should_wrap)
       && !asset_symbols.as_slice().iter().any(|s| s.exported == "*")
     {
+      if result.is_empty_or_empty_export {
+        asset
+          .meta
+          .insert("emptyFileStarReexport".to_string(), true.into());
+      }
       asset_symbols.push(make_export_star_symbol(&asset.id));
     }
 

--- a/packages/core/core/src/SymbolPropagation.js
+++ b/packages/core/core/src/SymbolPropagation.js
@@ -3,6 +3,7 @@
 import type {ContentKey, NodeId} from '@atlaspack/graph';
 import type {Meta, Symbol} from '@atlaspack/types';
 import type {Diagnostic} from '@atlaspack/diagnostic';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 import type {
   AssetNode,
   DependencyNode,
@@ -62,11 +63,15 @@ export function propagateSymbols({
       changedAssets,
       assetGroupsWithRemovedParents,
       (assetNode, incomingDeps, outgoingDeps) => {
-        if (
-          assetNode.value.meta.emptyFileStarReexport &&
-          incomingDeps.every((d) => d.value.specifierType === SpecifierType.esm)
-        ) {
-          assetNode.value.symbols?.delete('*');
+        if (getFeatureFlag('emptyFileStarRexportFix')) {
+          if (
+            assetNode.value.meta.emptyFileStarReexport &&
+            incomingDeps.every(
+              (d) => d.value.specifierType === SpecifierType.esm,
+            )
+          ) {
+            assetNode.value.symbols?.delete('*');
+          }
         }
 
         // exportSymbol -> identifier

--- a/packages/core/core/src/SymbolPropagation.js
+++ b/packages/core/core/src/SymbolPropagation.js
@@ -17,7 +17,7 @@ import {setEqual} from '@atlaspack/utils';
 import logger from '@atlaspack/logger';
 import {md, convertSourceLocationToHighlight} from '@atlaspack/diagnostic';
 import {instrument} from '@atlaspack/logger';
-import {BundleBehavior, Priority} from './types';
+import {BundleBehavior, Priority, SpecifierType} from './types';
 import {fromProjectPathRelative, fromProjectPath} from './projectPath';
 
 export function propagateSymbols({
@@ -62,6 +62,13 @@ export function propagateSymbols({
       changedAssets,
       assetGroupsWithRemovedParents,
       (assetNode, incomingDeps, outgoingDeps) => {
+        if (
+          assetNode.value.meta.emptyFileStarReexport &&
+          incomingDeps.every((d) => d.value.specifierType === SpecifierType.esm)
+        ) {
+          assetNode.value.symbols?.delete('*');
+        }
+
         // exportSymbol -> identifier
         let assetSymbols: ?$ReadOnlyMap<
           Symbol,

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -42,6 +42,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   inlineConstOptimisationFix: false,
   hmrImprovements: false,
   atlaspackV3CleanShutdown: false,
+  emptyFileStarRexportFix: process.env.NODE_ENV === 'test',
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -121,6 +121,12 @@ export type FeatureFlags = {|
    * Adds an end() method to AtlaspckV3 to cleanly shutdown the NAPI worker pool
    */
   atlaspackV3CleanShutdown: boolean,
+
+  /**
+   * Fixes an issue where star re-exports of empty files (usually occuring in compiled typescript libraries)
+   * could cause exports to undefined at runtime.
+   */
+  emptyFileStarRexportFix: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/empty-module/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/empty-module/a.js
@@ -1,3 +1,3 @@
-import b from './b';
+let b = require('./b');
 
 output = {b};

--- a/packages/core/integration-tests/test/integration/scope-hoisting/es6/empty-module/a.js
+++ b/packages/core/integration-tests/test/integration/scope-hoisting/es6/empty-module/a.js
@@ -1,3 +1,0 @@
-let b = require('./b');
-
-output = {b};

--- a/packages/core/integration-tests/test/javascript.js
+++ b/packages/core/integration-tests/test/javascript.js
@@ -5392,19 +5392,6 @@ describe('javascript', function () {
         assert.deepEqual(await res.output, [{default: 123, foo: 2}, 581]);
       });
 
-      it('missing exports should be replaced with an empty object', async function () {
-        let b = await bundle(
-          path.join(
-            __dirname,
-            '/integration/scope-hoisting/es6/empty-module/a.js',
-          ),
-          options,
-        );
-
-        let res = await run(b, null, {require: false});
-        assert.deepEqual(res.output, {b: {}});
-      });
-
       it('supports namespace imports of theoretically excluded reexporting assets', async function () {
         let b = await bundle(
           path.join(

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -157,6 +157,7 @@ pub struct TransformResult {
   pub is_constant_module: bool,
   pub conditions: HashSet<Condition>,
   pub magic_comments: HashMap<String, String>,
+  pub is_empty_or_empty_export: bool,
 }
 
 fn targets_to_versions(targets: &Option<HashMap<String, String>>) -> Option<Versions> {
@@ -549,6 +550,8 @@ pub fn transform(
                   tracing::warn!("You are attempting to import '{source_file}' which is an empty file and may be causing a build error.");
                 }
               }
+
+              result.is_empty_or_empty_export = collect.is_empty_or_empty_export;
 
               if let Some(bailouts) = &collect.bailouts {
                 diagnostics.extend(bailouts.iter().map(|bailout| bailout.to_diagnostic()));

--- a/packages/transformers/js/src/JSTransformer.js
+++ b/packages/transformers/js/src/JSTransformer.js
@@ -428,6 +428,7 @@ export default (new Transformer({
       shebang,
       hoist_result,
       symbol_result,
+      is_empty_or_empty_export,
       needs_esm_helpers,
       diagnostics,
       used_env,
@@ -1004,6 +1005,9 @@ export default (new Transformer({
           Object.keys(hoist_result.exported_symbols).length === 0) ||
         (hoist_result.should_wrap && !asset.symbols.hasExportSymbol('*'))
       ) {
+        if (is_empty_or_empty_export) {
+          asset.meta.emptyFileStarReexport = true;
+        }
         asset.symbols.set('*', `$${asset.id}$exports`);
       }
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

This PR fixes an issue where star re-exports of empty files (usually occurring in compiled typescript libraries) could cause exports to be undefined at runtime. This can occur as empty files are treated as CJS which potentially can have their exports mutated from outside sources and therefore get marked as potentially containing the superset of the exports for the library. 

In the past we have worked around this by [only performing this behaviour for Assets that are marked as having side effects](https://github.com/parcel-bundler/parcel/pull/9079). However in NPM packages (older versions of `@apollo/client` for example) this value is out of our control. 

The solution we've gone with here is to remove the `*` wildcard export from these empty files, when all incoming deps are ESM type, meaning export mutation shouldn't occur. 

The fix is behind the feature-flag `emptyFileStarRexportFix`.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
