### PR TITLE
Fix CLI for local development

### DIFF
--- a/.changeset/wise-comics-search.md
+++ b/.changeset/wise-comics-search.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/cli': patch
+'@atlaspack/apvm': patch
+---
+
+Fixes for atlaspack link

--- a/crates/apvm/src/cmd/link_git.rs
+++ b/crates/apvm/src/cmd/link_git.rs
@@ -128,7 +128,7 @@ fn create_bin(node_modules_bin_atlaspack: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     fs::write(
       node_modules_bin_atlaspack,
-      "#!/usr/bin/env node\nrequire('@atlaspack/cli/bin/atlaspack.js\n",
+      "#!/usr/bin/env node\nrequire('@atlaspack/cli/bin/atlaspack.js')\n",
     )?;
     fs::set_permissions(node_modules_bin_atlaspack, Permissions::from_mode(0o777))?;
   }

--- a/crates/apvm/src/cmd/link_local.rs
+++ b/crates/apvm/src/cmd/link_local.rs
@@ -126,19 +126,7 @@ fn create_bin(node_modules_bin_atlaspack: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
     fs::write(
       node_modules_bin_atlaspack,
-      r#"#!/usr/bin/env node
-
-if (process.env.ATLASPACK_DEV === 'true') {{
-  if (typeof process.env.APVM_ATLASPACK_LOCAL === 'undefined') {{
-    throw new Error('APVM_ATLASPACK_LOCAL must be set when ATLASPACK_DEV is true')
-  }}
-  console.log('USING ATLASPACK SOURCES')
-  require(require('path').join(process.env.APVM_ATLASPACK_LOCAL, 'packages/dev/babel-register'))
-  require('@atlaspack/cli/src/bin.js')
-}} else {{
-  require('@atlaspack/cli/bin/atlaspack.js')
-}}
-"#,
+      "#!/usr/bin/env node\nrequire('@atlaspack/cli/bin/atlaspack.js')\n",
     )?;
     fs::set_permissions(node_modules_bin_atlaspack, Permissions::from_mode(0o777))?;
   }

--- a/packages/core/cli/bin/atlaspack.js
+++ b/packages/core/cli/bin/atlaspack.js
@@ -1,2 +1,13 @@
 #!/usr/bin/env node
-require('../lib/bin');
+'use strict';
+
+if (
+  process.env.ATLASPACK_REGISTER_USE_SRC === 'true' ||
+  process.env.ATLASPACK_BUILD_ENV === 'test' ||
+  process.env.ATLASPACK_SELF_BUILD
+) {
+  require('@atlaspack/babel-register');
+  require('../src/cli');
+} else {
+  require('../lib/cli');
+}

--- a/packages/core/cli/bin/dev-bin.js
+++ b/packages/core/cli/bin/dev-bin.js
@@ -1,8 +1,0 @@
-/**
- * DEV BIN - DO NOT PUBLISH
- *
- * This file is copied into /lib/ by `yarn run dev:prepare`
- *
- * When babel build runs it is overwritten by another asset.
- */
-require('../src/bin');

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -17,8 +17,7 @@
   "main": "lib/bin.js",
   "source": "src/bin.js",
   "scripts": {
-    "prepack": "./ensure-no-dev-lib.sh",
-    "dev:prepare": "rimraf ./lib/ && mkdir -p lib && cp ./bin/dev-bin.js ./lib/bin.js"
+    "prepack": "./ensure-no-dev-lib.sh"
   },
   "engines": {
     "node": ">= 16.0.0"

--- a/packages/core/cli/src/bin.js
+++ b/packages/core/cli/src/bin.js
@@ -1,13 +1,2 @@
-#!/usr/bin/env node
-
-'use strict';
-
-if (
-  process.env.ATLASPACK_SOURCES === 'true' ||
-  process.env.ATLASPACK_BUILD_ENV === 'test' ||
-  process.env.ATLASPACK_SELF_BUILD
-) {
-  require('@atlaspack/babel-register');
-}
-
-require('./cli');
+// This file exists for atlaspack-link support
+require('../bin/atlaspack.js');


### PR DESCRIPTION
## Motivation

## Changes

Fix local linking when using sources

```
# Link your local copy into the cwd
export APVM_ATLASPACK_LOCAL="/path/to/atlaspack"
apvm link local

# Run Atlaspack with sources
env ATLASPACK_REGISTER_USE_SRC=true npx atlaspack --version

# Run Atlaspack with built artifacts
npx atlaspack --version
```


## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
