### PR TITLE
Add new packaging progress CLI experience

### DIFF
--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -124,13 +124,7 @@ export default class PackagerRunner {
   }: Opts) {
     this.config = config;
     this.options = options;
-
-    // If we're using the new CLI progress reporting improvements, we don't
-    // want to send reporter events from here, they're in WriteBundlesRequest
-    // instead
-    this.report = getFeatureFlag('cliProgressReportingImprovements')
-      ? () => {}
-      : report;
+    this.report = report;
     this.previousDevDeps = previousDevDeps;
     this.devDepRequests = new Map();
     this.previousInvalidations = previousInvalidations;

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -124,7 +124,7 @@ export default class PackagerRunner {
   }: Opts) {
     this.config = config;
     this.options = options;
-    this.report = report;
+    this.report = () => {};
     this.previousDevDeps = previousDevDeps;
     this.devDepRequests = new Map();
     this.previousInvalidations = previousInvalidations;

--- a/packages/core/core/src/PackagerRunner.js
+++ b/packages/core/core/src/PackagerRunner.js
@@ -124,7 +124,13 @@ export default class PackagerRunner {
   }: Opts) {
     this.config = config;
     this.options = options;
-    this.report = () => {};
+
+    // If we're using the new CLI progress reporting improvements, we don't
+    // want to send reporter events from here, they're in WriteBundlesRequest
+    // instead
+    this.report = getFeatureFlag('cliProgressReportingImprovements')
+      ? () => {}
+      : report;
     this.previousDevDeps = previousDevDeps;
     this.devDepRequests = new Map();
     this.previousInvalidations = previousInvalidations;

--- a/packages/core/core/src/requests/WriteBundlesRequest.js
+++ b/packages/core/core/src/requests/WriteBundlesRequest.js
@@ -9,6 +9,7 @@ import {requestTypes} from '../RequestTracker';
 import type {PackagedBundleInfo} from '../types';
 import type BundleGraph from '../BundleGraph';
 import type {BundleInfo} from '../PackagerRunner';
+import {report} from '../ReporterRunner';
 
 import {HASH_REF_PREFIX} from '../constants';
 import {joinProjectPath} from '../projectPath';
@@ -105,6 +106,14 @@ async function run({input, api, farm, options}) {
       .length === 1;
 
   try {
+    let completeBundles = 0;
+    report({
+      type: 'buildProgress',
+      phase: 'packagingAndOptimizing',
+      totalBundles: bundles.length,
+      completeBundles,
+    });
+
     await Promise.all(
       bundles.map(async (bundle) => {
         let request = createPackageRequest({
@@ -116,6 +125,15 @@ async function run({input, api, farm, options}) {
         });
 
         let info = await api.runRequest(request);
+
+        completeBundles++;
+
+        report({
+          type: 'buildProgress',
+          phase: 'packagingAndOptimizing',
+          totalBundles: bundles.length,
+          completeBundles,
+        });
 
         if (!useMainThread) {
           // Force a refresh of the cache to avoid a race condition

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -44,6 +44,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   atlaspackV3CleanShutdown: false,
   unusedComputedPropertyFix: process.env.NODE_ENV === 'test',
   emptyFileStarRexportFix: process.env.NODE_ENV === 'test',
+  cliProgressReportingImprovements: false,
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -133,6 +133,11 @@ export type FeatureFlags = {|
    * could cause exports to undefined at runtime.
    */
   emptyFileStarRexportFix: boolean,
+
+  /**
+   * Enables the new packaging progress CLI experience
+   */
+  cliProgressReportingImprovements: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;

--- a/packages/core/types-internal/src/index.js
+++ b/packages/core/types-internal/src/index.js
@@ -2014,6 +2014,17 @@ export type PackagingProgressEvent = {|
 |};
 
 /**
+ * A new Bundle is being packaged.
+ * @section reporter
+ */
+export type PackagingAndOptimizingProgressEvent = {|
+  +type: 'buildProgress',
+  +phase: 'packagingAndOptimizing',
+  +totalBundles: number,
+  +completeBundles: number,
+|};
+
+/**
  * A new Bundle is being optimized.
  * @section reporter
  */
@@ -2032,7 +2043,8 @@ export type BuildProgressEvent =
   | BundlingProgressEvent
   | BundledProgressEvent
   | PackagingProgressEvent
-  | OptimizingProgressEvent;
+  | OptimizingProgressEvent
+  | PackagingAndOptimizingProgressEvent;
 
 /**
  * The build was successful.

--- a/packages/core/utils/src/index.js
+++ b/packages/core/utils/src/index.js
@@ -51,7 +51,10 @@ export {
 export {debugTools} from './debug-tools';
 export {DefaultMap, DefaultWeakMap} from './DefaultMap';
 export {makeDeferredWithPromise} from './Deferred';
-export {getProgressMessage} from './progress-message';
+export {
+  getProgressMessage,
+  getPackageProgressMessage,
+} from './progress-message';
 export {
   isGlob,
   isGlobMatch,

--- a/packages/core/utils/src/progress-message.js
+++ b/packages/core/utils/src/progress-message.js
@@ -18,13 +18,20 @@ export function getProgressMessage(event: BuildProgressEvent): ?string {
       return `Optimizing ${event.bundle.displayName}...`;
 
     case 'packagingAndOptimizing': {
-      let percent = Math.floor(
-        (event.completeBundles / event.totalBundles) * 100,
+      return getPackageProgressMessage(
+        event.completeBundles,
+        event.totalBundles,
       );
-
-      return `Packaging bundles ${event.completeBundles} / ${event.totalBundles} (${percent}%)`;
     }
   }
 
   return null;
+}
+
+export function getPackageProgressMessage(
+  completeBundles: number,
+  totalBundles: number,
+): string {
+  let percent = Math.floor((completeBundles / totalBundles) * 100);
+  return `Packaging bundles ${completeBundles}/${totalBundles} (${percent}%)`;
 }

--- a/packages/core/utils/src/progress-message.js
+++ b/packages/core/utils/src/progress-message.js
@@ -16,6 +16,14 @@ export function getProgressMessage(event: BuildProgressEvent): ?string {
 
     case 'optimizing':
       return `Optimizing ${event.bundle.displayName}...`;
+
+    case 'packagingAndOptimizing': {
+      let percent = Math.floor(
+        (event.completeBundles / event.totalBundles) * 100,
+      );
+
+      return `Packaging bundles ${event.completeBundles} / ${event.totalBundles} (${percent}%)`;
+    }
   }
 
   return null;

--- a/packages/reporters/cli/src/CLIReporter.js
+++ b/packages/reporters/cli/src/CLIReporter.js
@@ -3,6 +3,7 @@ import type {ReporterEvent, PluginOptions} from '@atlaspack/types';
 import type {Diagnostic} from '@atlaspack/diagnostic';
 import type {Color} from 'chalk';
 
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 import {Reporter} from '@atlaspack/plugin';
 import {
   getProgressMessage,
@@ -125,6 +126,7 @@ export async function _report(
         } else if (event.phase === 'packagingAndOptimizing') {
           updatePackageProgress(event.completeBundles, event.totalBundles);
         } else if (
+          !getFeatureFlag('cliProgressReportingImprovements') &&
           (event.phase == 'packaging' || event.phase == 'optimizing') &&
           !seenPhases.has('packaging') &&
           !seenPhases.has('optimizing')


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

This PR adds a new progress update experience during packaging via the default CLI reporter. I would like to evolve this experience a bit more overtime however this is a small improvement we can ship reasonably easily. The new experience is enabled by the `cliProgressReportingImprovements` flag. 

The new experience is designed to give a lightweight indication of how the build is progressing, in both CI and locally, showing the total number of bundles in the build, the amount of bundles completed packaging so far and the rounded percent complete. 

## Local
![Live packaging](https://github.com/user-attachments/assets/cdd084a1-851c-4bec-b8c7-84f6144c6519)

## CI/non-TTY 

In environments that don't support live updating of the output, we push a progress update everytime a threshold is reached. Currently the thresholds are just some ballpark arbitrary values and we can update them whenever. 

| Bundles | Threshold |
| - | - |
| >5000 | 5% |
| >1000 | 10% |
| <1000 | 25% | 

```
Building...
Bundling...
Packaging bundles 269/5363 (5%)
Packaging bundles 537/5363 (10%)
Packaging bundles 805/5363 (15%)
Packaging bundles 1073/5363 (20%)
Packaging bundles 1341/5363 (25%)
Packaging bundles 1609/5363 (30%)
Packaging bundles 1878/5363 (35%)
Packaging bundles 2146/5363 (40%)
Packaging bundles 2414/5363 (45%)
Packaging bundles 2682/5363 (50%)
Packaging bundles 2950/5363 (55%)
Packaging bundles 3218/5363 (60%)
Packaging bundles 3486/5363 (65%)
Packaging bundles 3755/5363 (70%)
Packaging bundles 4023/5363 (75%)
Packaging bundles 4291/5363 (80%)
Packaging bundles 4559/5363 (85%)
Packaging bundles 4827/5363 (90%)
Packaging bundles 5095/5363 (95%)
Packaging bundles 5363/5363 (100%)
✨ Built in 153.00s
```


To get this working I have added a new reporter build progress event type named `packagingAndOptimizing` (bike shedding welcome 😅 ) which fires at the start of the packaging phase and after each bundle has completed it's `PackageRequest` (which entails both "packaging" and "optimizing" of a bundle).  This event is different to the old `packaging` and `optimizing` events which each fire at the start of those events.

The new event contains the following properties:
- `totalBundles` - The total amount of bundles in the build
- `completeBundles` - The total amount of bundles that have completed packaging or already have a valid cache entry

```
export type PackagingAndOptimizingProgressEvent = {|
  +type: 'buildProgress',
  +phase: 'packagingAndOptimizing',
  +totalBundles: number,
  +completeBundles: number,
|};
```

This new event is only fired if the `cliProgressReportingImprovements` flag is enabled, the old events fire either way. 



## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
