### PR TITLE
convert packages/core/core/src/Atlaspack.js

### DIFF
--- a/packages/core/core/src/Atlaspack.js
+++ b/packages/core/core/src/Atlaspack.js
@@ -72,20 +72,20 @@ export const INTERNAL_RESOLVE: symbol = Symbol('internal_resolve');
 export const WORKER_PATH: string = path.join(__dirname, 'worker.js');
 
 export default class Atlaspack {
-  #requestTracker /*: RequestTracker*/;
-  #config /*: AtlaspackConfig*/;
-  #farm /*: WorkerFarm*/;
-  #initialized /*: boolean*/ = false;
-  #disposable /*: Disposable */;
-  #initialOptions /*: InitialAtlaspackOptions */;
-  #reporterRunner /*: ReporterRunner*/;
-  #resolvedOptions /*: ?AtlaspackOptions*/ = null;
-  #optionsRef /*: SharedReference */;
-  #watchAbortController /*: AbortController*/;
-  #watchQueue /*: PromiseQueue<?BuildEvent>*/ = new PromiseQueue<?BuildEvent>({
+  #requestTracker: RequestTracker;
+  #config: AtlaspackConfig;
+  #farm: WorkerFarm;
+  #initialized: boolean = false;
+  #disposable: Disposable;
+  #initialOptions: InitialAtlaspackOptions;
+  #reporterRunner: ReporterRunner;
+  #resolvedOptions: ?AtlaspackOptions = null;
+  #optionsRef: SharedReference;
+  #watchAbortController: AbortController;
+  #watchQueue: PromiseQueue<?BuildEvent> = new PromiseQueue<?BuildEvent>({
     maxConcurrent: 1,
   });
-  #watchEvents /*: ValueEmitter<
+  #watchEvents: ValueEmitter<
     | {|
         +error: Error,
         +buildEvent?: void,
@@ -94,14 +94,14 @@ export default class Atlaspack {
         +buildEvent: BuildEvent,
         +error?: void,
       |},
-  > */;
-  #watcherSubscription /*: ?AsyncSubscription*/;
-  #watcherCount /*: number*/ = 0;
-  #requestedAssetIds /*: Set<string>*/ = new Set();
+  >;
+  #watcherSubscription: ?AsyncSubscription;
+  #watcherCount: number = 0;
+  #requestedAssetIds: Set<string> = new Set();
 
   rustAtlaspack: AtlaspackV3 | null | void;
 
-  isProfiling /*: boolean */;
+  isProfiling: boolean;
 
   constructor(options: InitialAtlaspackOptions) {
     this.#initialOptions = options;


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

To ensure the (flow->ts) codemod functions correctly, we need to make several modifications to the Flow code. One key change involves converting Flow's class property comments into actual type annotations.

## Changes

This PR only converts the 1st file in the list. The following PRs will do the rest.
- packages/core/core/src/Atlaspack.js ✅
- packages/core/core/src/public/Asset.js
- packages/core/core/src/public/Bundle.js
- packages/core/core/src/public/Dependency.js
- packages/core/core/src/public/Environment.js
- packages/core/core/src/public/Config.js
- packages/core/core/src/public/Target.js
- packages/core/core/src/public/MutableBundleGraph.js
- packages/core/core/src/public/BundleGroup.js
- packages/core/core/src/public/PluginOptions.js
- packages/core/core/src/public/Symbols.js
- packages/core/core/src/atlaspack-v3/fs.js
- packages/core/core/src/atlaspack-v3/NapiWorkerPool.js
- packages/core/core/src/atlaspack-v3/worker/worker.js
- packages/core/core/src/atlaspack-v3/worker/compat/bitflags.js
- packages/core/core/src/atlaspack-v3/worker/compat/plugin-config.js
- packages/core/core/src/atlaspack-v3/worker/compat/mutable-asset.js
- packages/core/core/src/atlaspack-v3/worker/compat/plugin-options.js
- packages/core/core/src/atlaspack-v3/worker/compat/asset-symbols.js
- packages/core/fs/src/NodeVCSAwareFS.js
- packages/core/fs/src/MemoryFS.js
- packages/core/logger/src/Logger.js
- packages/utils/events/src/Disposable.js

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
