### PR TITLE
Fix content key not found exceptions

### DIFF
--- a/.changeset/small-cooks-chew.md
+++ b/.changeset/small-cooks-chew.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/feature-flags': patch
+'@atlaspack/core': patch
+---
+
+Fix content key not found exceptions when bundling is aborted after a unsafe to incrementally bundle asset graph request

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -180,10 +180,18 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
   }
 
   setNeedsBundling() {
+    if (!getFeatureFlag('incrementalBundlingVersioning')) {
+      // In legacy mode, we rely solely on safeToIncrementallyBundle to
+      // invalidate incremental bundling, so we skip bumping the version.
+      return;
+    }
     this.#bundlingVersion += 1;
   }
 
   getBundlingVersion(): number {
+    if (!getFeatureFlag('incrementalBundlingVersioning')) {
+      return 0;
+    }
     return this.#bundlingVersion;
   }
 
@@ -193,6 +201,11 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
    * but just update assets into the bundle graph output.
    */
   canIncrementallyBundle(lastVersion: number): boolean {
+    if (!getFeatureFlag('incrementalBundlingVersioning')) {
+      return (
+        this.safeToIncrementallyBundle && !this.#disableIncrementalBundling
+      );
+    }
     return (
       this.safeToIncrementallyBundle &&
       this.#bundlingVersion === lastVersion &&

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -175,10 +175,16 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     };
   }
 
+  /**
+   * Force incremental bundling to be disabled.
+   */
   setDisableIncrementalBundling(disable: boolean) {
     this.#disableIncrementalBundling = disable;
   }
 
+  /**
+   * Make sure this asset graph is marked as needing a full bundling pass.
+   */
   setNeedsBundling() {
     if (!getFeatureFlag('incrementalBundlingVersioning')) {
       // In legacy mode, we rely solely on safeToIncrementallyBundle to
@@ -188,6 +194,12 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     this.#bundlingVersion += 1;
   }
 
+  /**
+   * Get the current bundling version.
+   *
+   * Each bundle pass should keep this version around. Whenever an asset graph has a new version,
+   * bundling should be re-run.
+   */
   getBundlingVersion(): number {
     if (!getFeatureFlag('incrementalBundlingVersioning')) {
       return 0;

--- a/packages/core/core/src/AssetGraph.js
+++ b/packages/core/core/src/AssetGraph.js
@@ -182,6 +182,10 @@ export default class AssetGraph extends ContentGraph<AssetGraphNode> {
     this.#disableIncrementalBundling = disable;
   }
 
+  testing_getDisableIncrementalBundling(): boolean {
+    return this.#disableIncrementalBundling;
+  }
+
   /**
    * Make sure this asset graph is marked as needing a full bundling pass.
    */

--- a/packages/core/core/src/requests/AssetGraphRequest.js
+++ b/packages/core/core/src/requests/AssetGraphRequest.js
@@ -84,6 +84,11 @@ export default function createAssetGraphRequest(
       let assetGraphRequest = await await builder.build();
 
       // early break for incremental bundling if production or flag is off;
+      assetGraphRequest.assetGraph.setDisableIncrementalBundling(
+        !input.options.shouldBundleIncrementally ||
+          input.options.mode === 'production',
+      );
+
       if (
         !input.options.shouldBundleIncrementally ||
         input.options.mode === 'production'
@@ -511,6 +516,7 @@ export class AssetGraphBuilder {
 
       if (didEntriesChange) {
         this.assetGraph.safeToIncrementallyBundle = false;
+        this.assetGraph.setNeedsBundling();
       }
     }
   }
@@ -554,10 +560,12 @@ export class AssetGraphBuilder {
             invariant(otherAsset.type === 'asset');
             if (!this._areDependenciesEqualForAssets(asset, otherAsset.value)) {
               this.assetGraph.safeToIncrementallyBundle = false;
+              this.assetGraph.setNeedsBundling();
             }
           } else {
             // adding a new entry or dependency
             this.assetGraph.safeToIncrementallyBundle = false;
+            this.assetGraph.setNeedsBundling();
           }
         }
         this.changedAssets.set(asset.id, asset);
@@ -566,6 +574,7 @@ export class AssetGraphBuilder {
       this.assetGraph.resolveAssetGroup(input, assets, request.id);
     } else {
       this.assetGraph.safeToIncrementallyBundle = false;
+      this.assetGraph.setNeedsBundling();
     }
 
     this.isSingleChangeRebuild = false;

--- a/packages/core/core/test/AssetGraph.test.js
+++ b/packages/core/core/test/AssetGraph.test.js
@@ -2,6 +2,7 @@
 import assert from 'assert';
 import invariant from 'assert';
 import nullthrows from 'nullthrows';
+import {serialize, deserialize} from '@atlaspack/build-cache';
 import AssetGraph, {
   nodeFromAssetGroup,
   nodeFromDep,
@@ -689,5 +690,37 @@ describe('AssetGraph', () => {
     node = nullthrows(graph.getNodeByContentKey(barAssetGroupNode.id));
     invariant(node.type === 'asset_group');
     assert(!node.hasDeferred);
+  });
+
+  it('should serialize the bundling version and incremental bundling flag', () => {
+    const graph = new AssetGraph();
+    graph.setDisableIncrementalBundling(true);
+    graph.setNeedsBundling();
+    const serialized = serialize(graph);
+    const deserialized = deserialize(serialized);
+
+    assert.equal(deserialized.getBundlingVersion(), 1);
+    assert.equal(deserialized.testing_getDisableIncrementalBundling(), true);
+  });
+
+  describe('setNeedsBundling', () => {
+    it('should increment the bundling version', () => {
+      const graph = new AssetGraph();
+      assert.equal(graph.getBundlingVersion(), 0);
+      graph.setNeedsBundling();
+      assert.equal(graph.getBundlingVersion(), 1);
+      graph.setNeedsBundling();
+      assert.equal(graph.getBundlingVersion(), 2);
+    });
+  });
+
+  describe('canIncrementallyBundle', () => {
+    it('should return true if the bundling version has changed', () => {
+      const graph = new AssetGraph();
+      const lastVersion = graph.getBundlingVersion();
+      assert.equal(graph.canIncrementallyBundle(lastVersion), true);
+      graph.setNeedsBundling();
+      assert.equal(graph.canIncrementallyBundle(lastVersion), false);
+    });
   });
 });

--- a/packages/core/core/test/RequestTracker.test.js
+++ b/packages/core/core/test/RequestTracker.test.js
@@ -8,6 +8,7 @@ import RequestTracker, {
   runInvalidation,
   getBiggestFSEventsInvalidations,
   invalidateRequestGraphFSEvents,
+  requestTypes,
 } from '../src/RequestTracker';
 import {Graph} from '@atlaspack/graph';
 import {LMDBLiteCache} from '@atlaspack/cache';
@@ -19,6 +20,12 @@ import {toProjectPath} from '../src/projectPath';
 import {DEFAULT_FEATURE_FLAGS, setFeatureFlags} from '../../feature-flags/src';
 import sinon from 'sinon';
 import type {AtlaspackOptions} from '../src/types';
+import createAtlaspackBuildRequest from '../src/requests/AtlaspackBuildRequest';
+import Atlaspack from '../src/Atlaspack';
+import {MemoryFS, NodeFS} from '@atlaspack/fs';
+import {OverlayFS} from '../../fs/src/OverlayFS';
+import path from 'path';
+import createAssetGraphRequest from '../src/requests/AssetGraphRequest';
 
 const options = {
   ...DEFAULT_OPTIONS,
@@ -540,6 +547,144 @@ describe('RequestTracker', () => {
           ]);
         });
       });
+    });
+  });
+
+  describe('incremental bundling', () => {
+    it('works', async () => {
+      const fs = new OverlayFS(new MemoryFS(farm), new NodeFS());
+      const appRoot = __dirname;
+      await fs.mkdirp(path.join(appRoot, 'app'));
+      await fs.writeFile(path.join(appRoot, 'app', 'package.json'), '{}');
+      await fs.writeFile(path.join(appRoot, 'app', '.git'), '');
+      await fs.writeFile(
+        path.join(appRoot, 'app', '.parcelrc'),
+        '{"extends":"@atlaspack/config-default"}',
+      );
+      await fs.writeFile(
+        path.join(appRoot, 'app', 'target.js'),
+        'console.log("hello")',
+      );
+
+      const atlaspack = new Atlaspack({
+        workerFarm: farm,
+        entries: [path.join(appRoot, 'app', 'target.js')],
+        cache: new LMDBLiteCache(DEFAULT_OPTIONS.cacheDir),
+        inputFS: fs,
+        outputFS: fs,
+      });
+      await atlaspack._init();
+      const options = atlaspack._getResolvedAtlaspackOptions();
+      const tracker = new RequestTracker({farm, options});
+      let {ref: optionsRef} = await farm.createSharedReference(options, false);
+
+      const getAssetRequests = () =>
+        runRequestSpy
+          .getCalls()
+          .map((call) => call.args[0])
+          .filter((request) => request.type === requestTypes.asset_request);
+
+      // Running the build once builds one asset
+      const runRequestSpy = sinon.spy(tracker, 'runRequest');
+      await tracker.runRequest(
+        createAtlaspackBuildRequest({
+          optionsRef,
+          requestedAssetIds: new Set(),
+        }),
+      );
+      assert.equal(getAssetRequests().length, 1);
+      runRequestSpy.resetHistory();
+
+      // Running the build again with no invalidations does not build any assets
+      await tracker.runRequest(
+        createAtlaspackBuildRequest({
+          optionsRef,
+          requestedAssetIds: new Set(),
+        }),
+      );
+      assert.equal(getAssetRequests().length, 0);
+      runRequestSpy.resetHistory();
+
+      // Running the build again with a file change builds the asset again
+      tracker.respondToFSEvents(
+        [
+          {
+            type: 'update',
+            path: path.join(appRoot, 'app', 'target.js'),
+          },
+        ],
+        Number.MAX_VALUE,
+      );
+      await tracker.runRequest(
+        createAtlaspackBuildRequest({
+          optionsRef,
+          requestedAssetIds: new Set(),
+        }),
+      );
+      assert.equal(getAssetRequests().length, 1);
+      runRequestSpy.resetHistory();
+
+      // Run the asset graph request, but not bundling
+      await fs.writeFile(
+        path.join(appRoot, 'app', 'target.js'),
+        'require("./dep.js")',
+      );
+      await fs.writeFile(
+        path.join(appRoot, 'app', 'dep.js'),
+        'console.log("dep")',
+      );
+      tracker.respondToFSEvents(
+        [
+          {
+            type: 'update',
+            path: path.join(appRoot, 'app', 'target.js'),
+          },
+        ],
+        Number.MAX_VALUE,
+      );
+      const assetGraphRequestResult = await tracker.runRequest(
+        createAssetGraphRequest({
+          name: 'Main',
+          entries: [
+            toProjectPath(
+              path.join(appRoot, 'app'),
+              path.join(appRoot, 'app', 'target.js'),
+            ),
+          ],
+          optionsRef,
+          shouldBuildLazily: false,
+          lazyIncludes: [],
+          lazyExcludes: [],
+          requestedAssetIds: new Set(),
+        }),
+      );
+      assert.equal(getAssetRequests().length, 2);
+      assert.equal(
+        assetGraphRequestResult.assetGraph.safeToIncrementallyBundle,
+        false,
+      );
+
+      // Now make another change
+      tracker.respondToFSEvents(
+        [
+          {
+            type: 'update',
+            path: path.join(appRoot, 'app', 'target.js'),
+          },
+          {
+            type: 'update',
+            path: path.join(appRoot, 'app', 'dep.js'),
+          },
+        ],
+        Number.MAX_VALUE,
+      );
+      // And run the build again
+      await tracker.runRequest(
+        createAtlaspackBuildRequest({
+          optionsRef,
+          requestedAssetIds: new Set(),
+        }),
+      );
     });
   });
 });

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -40,6 +40,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   cliProgressReportingImprovements: false,
   condbDevFallbackDev: false,
   condbDevFallbackProd: false,
+  incrementalBundlingVersioning: process.env.NODE_ENV === 'test',
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -117,6 +117,11 @@ export type FeatureFlags = {|
    */
   condbDevFallbackDev: boolean,
   condbDevFallbackProd: boolean,
+  /**
+   * Enable the new incremental bundling versioning logic which determines whether
+   * a full bundling pass is required based on the AssetGraph's bundlingVersion.
+   */
+  incrementalBundlingVersioning: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;


### PR DESCRIPTION
A common bug seems to be that the dev-server eventually hits exceptions:

```
"Expected content key ... to exist"
```

When this happens, the cache must be cleared, otherwise the dev-server is
unable to build.

Similar to https://github.com/atlassian-labs/atlaspack/pull/652, the reason this might happen is due to state corruption.

This PR adds a test which reproduces the exception by executing the following
sequence of events:

- Perform a build
- Perform a build which is not safe to incrementally bundle (such as adding a
  new dependency)
- "Abort" the build before bundling completes
- Perform a new build, which has changes to assets that haven't been seen by
  the bundler

This causes the asset graph to be marked as "safe to incrementally bundle",
despite the bundle graph being out-of-sync with it.

In general, removing the abort controller from the bundle graph request will
likely mitigate the issue.

However, the "safeToIncrementallyBundle" flag is slightly brittle as an
implementation here.

Ideally, our caches and state would not contain so much mutation, and the
decision of whether to skip work or re-use previous data would be purer and
moved to the bundling call-site.

As a quick fix, we can track bundling requirements differently.

For any asset graph, we will keep a marker indicating whether it needs to be
bundled. This will be an incrementing number. When we detect the graph requires
bundling, we will tick this number. Subsequent builds' asset graphs will
inherit this marker from the previous asset graph result.

When running the bundle graph request, the bundle graph will store the "asset
graph version for bundling" in itself. When triggering an incremental bundling
task, we will check whether the previous result's "asset graph version for
bundling" matches the current one.