### PR TITLE
DevScript: Workspace versions validator

### DIFF
--- a/packages/dev/esm-fuzzer/package.json
+++ b/packages/dev/esm-fuzzer/package.json
@@ -10,8 +10,8 @@
     "@babel/generator": "^7.22.10",
     "@babel/template": "^7.22.5",
     "@babel/types": "^7.22.11",
-    "@atlaspack/core": "^2.19.2",
-    "@atlaspack/fs": "^2.15.15",
+    "@atlaspack/core": "2.19.2",
+    "@atlaspack/fs": "2.15.15",
     "nanoid": "^3.1.12",
     "nullthrows": "^1.1.1"
   },

--- a/packages/examples/conditional-bundling/package.json
+++ b/packages/examples/conditional-bundling/package.json
@@ -19,8 +19,8 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24",
-    "@atlaspack/reporter-conditional-manifest": "^2.15.2",
+    "@atlaspack/cli": "2.13.24",
+    "@atlaspack/reporter-conditional-manifest": "2.15.2",
     "@types/react-dom": "^17.0.2",
     "express": "*"
   },

--- a/packages/examples/eslint/package.json
+++ b/packages/examples/eslint/package.json
@@ -7,9 +7,9 @@
     "build": "atlaspack build src/index.js"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24",
-    "@atlaspack/config-default": "^3.1.22",
-    "@atlaspack/validator-eslint": "^2.14.20"
+    "@atlaspack/cli": "2.13.24",
+    "@atlaspack/config-default": "3.1.22",
+    "@atlaspack/validator-eslint": "2.14.20"
   },
   "type": "commonjs"
 }

--- a/packages/examples/kitchen-sink/package.json
+++ b/packages/examples/kitchen-sink/package.json
@@ -13,7 +13,7 @@
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24"
+    "@atlaspack/cli": "2.13.24"
   },
   "targets": {
     "browserModern": {

--- a/packages/examples/react-hmr/package.json
+++ b/packages/examples/react-hmr/package.json
@@ -7,7 +7,7 @@
     "start": "atlaspack src/index.html --https --open"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24"
+    "@atlaspack/cli": "2.13.24"
   },
   "dependencies": {
     "react": "^17.0.2",

--- a/packages/examples/react-refresh/package.json
+++ b/packages/examples/react-refresh/package.json
@@ -7,7 +7,7 @@
     "start": "atlaspack src/index.html --open"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24"
+    "@atlaspack/cli": "2.13.24"
   },
   "dependencies": {
     "react": "^17.0.2",

--- a/packages/examples/simple/package.json
+++ b/packages/examples/simple/package.json
@@ -7,7 +7,7 @@
     "build": "atlaspack build src/index.js"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24"
+    "@atlaspack/cli": "2.13.24"
   },
   "type": "commonjs"
 }

--- a/packages/examples/typechecking/package.json
+++ b/packages/examples/typechecking/package.json
@@ -7,9 +7,9 @@
     "build": "atlaspack build src/index.ts"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24",
-    "@atlaspack/config-default": "^3.1.22",
-    "@atlaspack/validator-typescript": "^2.14.20"
+    "@atlaspack/cli": "2.13.24",
+    "@atlaspack/config-default": "3.1.22",
+    "@atlaspack/validator-typescript": "2.14.20"
   },
   "type": "commonjs"
 }

--- a/packages/examples/typescript/package.json
+++ b/packages/examples/typescript/package.json
@@ -7,7 +7,7 @@
     "build": "atlaspack build src/index.ts"
   },
   "devDependencies": {
-    "@atlaspack/cli": "^2.13.24"
+    "@atlaspack/cli": "2.13.24"
   },
   "main": "dist/main.js",
   "module": "dist/module.js",

--- a/packages/optimizers/inline-requires/package.json
+++ b/packages/optimizers/inline-requires/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@atlaspack/feature-flags": "2.19.2",
     "@atlaspack/plugin": "2.14.20",
-    "@atlaspack/rust": "^3.4.1",
+    "@atlaspack/rust": "3.4.1",
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/types": "2.15.10",
     "@swc/core": "^1.10.0",

--- a/scripts/validate-workspace-versions.mjs
+++ b/scripts/validate-workspace-versions.mjs
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-// This package goes through an ensures all versions of local packages
+// This package goes through and ensures all versions of local packages
 // in the workspace package.json files point to the local version of those
 // packages.
 //
@@ -39,7 +39,9 @@ for (const [pkgPath, pkg] of packages.entries()) {
     }
   }
 
-  for (const [packageName, version] of Object.entries(pkg.devDependencies || {})) {
+  for (const [packageName, version] of Object.entries(
+    pkg.devDependencies || {},
+  )) {
     const current = packagesVersions.get(packageName);
     if (current && version !== '*' && version != current) {
       console.log(
@@ -48,7 +50,9 @@ for (const [pkgPath, pkg] of packages.entries()) {
     }
   }
 
-  for (const [packageName, version] of Object.entries(pkg.optionalDependencies || {})) {
+  for (const [packageName, version] of Object.entries(
+    pkg.optionalDependencies || {},
+  )) {
     const current = packagesVersions.get(packageName);
     if (current && version !== '*' && version != current) {
       console.log(

--- a/scripts/validate-workspace-versions.mjs
+++ b/scripts/validate-workspace-versions.mjs
@@ -1,0 +1,59 @@
+/* eslint-disable no-console */
+// This package goes through an ensures all versions of local packages
+// in the workspace package.json files point to the local version of those
+// packages.
+//
+// This avoids scenarios where merges/rebases mess up the "package.json#dependencies"
+// and installs the workspace packages from npm
+import * as path from 'node:path';
+import * as fs from 'node:fs';
+import * as url from 'node:url';
+import glob from 'glob';
+
+const dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const root = path.dirname(dirname);
+
+const rootPkg = JSON.parse(
+  fs.readFileSync(path.join(root, 'package.json'), 'utf8'),
+);
+
+const packages = new Map();
+const packagesVersions = new Map();
+
+for (const workspace of rootPkg.workspaces) {
+  for (const pkgPath of glob.sync(`${workspace}/package.json`, {cwd: root})) {
+    const abs = path.join(root, pkgPath);
+    const pkg = JSON.parse(fs.readFileSync(abs, 'utf8'));
+    packages.set(abs, pkg);
+    packagesVersions.set(pkg.name, pkg.version);
+  }
+}
+
+for (const [pkgPath, pkg] of packages.entries()) {
+  for (const [packageName, version] of Object.entries(pkg.dependencies || {})) {
+    const current = packagesVersions.get(packageName);
+    if (current && version !== '*' && version != current) {
+      console.log(
+        `Miss\n\tExpected ${packageName}@${current}\n\tGot      ${packageName}@${version}\n\t${pkgPath}`,
+      );
+    }
+  }
+
+  for (const [packageName, version] of Object.entries(pkg.devDependencies || {})) {
+    const current = packagesVersions.get(packageName);
+    if (current && version !== '*' && version != current) {
+      console.log(
+        `Miss\n\tExpected ${packageName}@${current}\n\tGot      ${packageName}@${version}\n\t${pkgPath}`,
+      );
+    }
+  }
+
+  for (const [packageName, version] of Object.entries(pkg.optionalDependencies || {})) {
+    const current = packagesVersions.get(packageName);
+    if (current && version !== '*' && version != current) {
+      console.log(
+        `Miss\n\tExpected ${packageName}@${current}\n\tGot      ${packageName}@${version}\n\t${pkgPath}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Motivation

Sometimes a rebase or merge can cause drift between workspace `dependencies` and `devDependencies` causing yarn to install dependencies from npm rather than using their local versions.

This script scans the workspace packages to make sure the versions match the ones in the workspace

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: Dev Script
