### PR TITLE
Fix Node builtin polyfilling for libraries

### DIFF
--- a/.changeset/bright-badgers-behave.md
+++ b/.changeset/bright-badgers-behave.md
@@ -1,0 +1,14 @@
+---
+'@atlaspack/node-resolver-core': patch
+'@atlaspack/feature-flags': patch
+---
+
+Fixes the handling of node builtins in library mode.
+
+Previously, the function to check whether a node builtin should be external didn't account
+for the case where `includeNodeModules` was set to just `true`.
+
+This caused library builds to include require statements to node builtins in the bundle,
+even when targeting a browser environment.
+
+Enabling the `libraryBuiltinsFix` feature flag will fix this issue.

--- a/packages/core/feature-flags/src/index.js
+++ b/packages/core/feature-flags/src/index.js
@@ -42,6 +42,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   condbDevFallbackDev: false,
   condbDevFallbackProd: false,
   incrementalBundlingVersioning: process.env.NODE_ENV === 'test',
+  libraryBuiltinsFix: process.env.NODE_ENV === 'test',
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/feature-flags/src/types.js
+++ b/packages/core/feature-flags/src/types.js
@@ -128,6 +128,11 @@ export type FeatureFlags = {|
    * a full bundling pass is required based on the AssetGraph's bundlingVersion.
    */
   incrementalBundlingVersioning: boolean,
+  /**
+   * Fixes a bug where node builtins were not being correctly polyfilled for
+   * library builds.
+   */
+  libraryBuiltinsFix: boolean,
 |};
 
 declare export var CONSISTENCY_CHECK_VALUES: $ReadOnlyArray<string>;

--- a/packages/utils/node-resolver-core/src/Wrapper.js
+++ b/packages/utils/node-resolver-core/src/Wrapper.js
@@ -368,8 +368,14 @@ export default class NodeResolver {
     {includeNodeModules}: Environment,
     name: string,
   ): ?boolean {
-    if (includeNodeModules === false) {
-      return false;
+    if (getFeatureFlag('libraryBuiltinsFix')) {
+      if (typeof includeNodeModules === 'boolean') {
+        return includeNodeModules;
+      }
+    } else {
+      if (includeNodeModules === false) {
+        return false;
+      }
     }
 
     if (Array.isArray(includeNodeModules)) {


### PR DESCRIPTION
## Motivation

Under the particular set of circumstances that:
- We're building a library (`isLibrary: true`)
- We have a non-global output format (`commonjs`)
- We want to bundle node modules (`includeNodeModules: true`)
- We're targeting a browser-like environment (`web-worker`)

The node resolver would incorrectly insert require statements for these node builtins, instead of polyfilling them.

This may seem like a niche case, but it's the recommended setup for targeting SSR environments.

This is caused by the fact that the `shouldIncludeNodeModule` that determines whether a builtin is external or not kinda just doesn't consider that `includeNodeModules` might be "`true`".

## Changes

This change modifies the first check of the function, whether `includeNodeModules` is false, to just whether it's a boolean, and returns that if so.

As ever, locked behind a feature flag, `libraryBuiltinsFix`.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required