### PR TITLE
Cleanup atlaspackV3CleanShutdown feature flag

### DIFF
--- a/.changeset/silent-pandas-beam.md
+++ b/.changeset/silent-pandas-beam.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/feature-flags': patch
+'@atlaspack/core': patch
+---
+
+Clean up `atlaspackV3CleanShutdown` feature flag.

--- a/packages/core/core/src/Atlaspack.ts
+++ b/packages/core/core/src/Atlaspack.ts
@@ -200,11 +200,9 @@ export default class Atlaspack {
         defaultTargetOptions: resolvedOptions.defaultTargetOptions,
         lmdb,
       });
-      if (featureFlags.atlaspackV3CleanShutdown) {
-        this.#disposable.add(() => {
-          rustAtlaspack.end();
-        });
-      }
+      this.#disposable.add(() => {
+        rustAtlaspack.end();
+      });
     }
     // @ts-expect-error TS2454
     this.rustAtlaspack = rustAtlaspack;

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -108,10 +108,6 @@ export type FeatureFlags = {
    */
   hmrImprovements: boolean;
 
-  /**
-   * Adds an end() method to AtlaspckV3 to cleanly shutdown the NAPI worker pool
-   */
-  atlaspackV3CleanShutdown: boolean;
 
   /**
    * Fixes a bug where imported objects that are accessed with non-static
@@ -184,7 +180,6 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   applyScopeHoistingImprovement: false,
   inlineConstOptimisationFix: false,
   hmrImprovements: false,
-  atlaspackV3CleanShutdown: false,
   unusedComputedPropertyFix: process.env.NODE_ENV === 'test',
   emptyFileStarRexportFix: process.env.NODE_ENV === 'test',
   cliProgressReportingImprovements: false,

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -108,7 +108,6 @@ export type FeatureFlags = {
    */
   hmrImprovements: boolean;
 
-
   /**
    * Fixes a bug where imported objects that are accessed with non-static
    * properties (e.g. `CONSTANTS['api_' + endpoint`]) would not be recognised as

--- a/packages/core/integration-tests/test/atlaspack-v3.ts
+++ b/packages/core/integration-tests/test/atlaspack-v3.ts
@@ -224,7 +224,6 @@ describe.v3('AtlaspackV3', function () {
         shouldDisableCache: true,
         featureFlags: {
           atlaspackV3: true,
-          atlaspackV3CleanShutdown: true,
         },
       });
       const buildResult = await atlaspack.run();


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Change is fully rolled out now, can be cleaned up.

## Changes

Cleaned up the `atlaspackV3CleanShutdown` feature flag.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
