### PR TITLE
APVM support via unified package

### DIFF
--- a/.changeset/chilly-carrots-check.md
+++ b/.changeset/chilly-carrots-check.md
@@ -1,0 +1,9 @@
+---
+'@atlaspack/apvm': patch
+'@atlaspack/apvm-linux-amd64': patch
+'@atlaspack/apvm-linux-arm64': patch
+'@atlaspack/apvm-macos-amd64': patch
+'@atlaspack/apvm-macos-arm64': patch
+---
+
+Added support for unified Atlaspack

--- a/.changeset/soft-walls-provide.md
+++ b/.changeset/soft-walls-provide.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/conditional-import-types': patch
+'@atlaspack/rust': patch
+'atlaspack': patch
+---
+
+Fixing types

--- a/crates/apvm/src/cmd/atlaspack.rs
+++ b/crates/apvm/src/cmd/atlaspack.rs
@@ -5,7 +5,7 @@ use crate::platform::bin_path::get_bin_path;
 use crate::platform::exec::exec_blocking;
 use crate::platform::exec::ExecOptions;
 use crate::platform::path_ext::PathExt;
-use crate::platform::runtime::resolve_runtime;
+use crate::platform::runtime::resolve_executable;
 
 #[derive(Debug, Parser)]
 pub struct AtlaspackCommand {
@@ -28,7 +28,7 @@ pub fn main(ctx: Context, cmd: AtlaspackCommand) -> anyhow::Result<()> {
   let package = ctx.resolver.resolve_or_default(&cmd.version)?;
   let bin_path = get_bin_path(&package);
 
-  let runtime = resolve_runtime(&ctx.env.runtime)?.try_to_string()?;
+  let runtime = resolve_executable(&ctx.env.runtime)?.try_to_string()?;
   log::info!("runtime: {:?}", runtime);
 
   let mut argv = Vec::<String>::new();

--- a/crates/apvm/src/cmd/install_npm.rs
+++ b/crates/apvm/src/cmd/install_npm.rs
@@ -5,11 +5,15 @@ use serde::Deserialize;
 use super::install::InstallCommand;
 use crate::context::Context;
 use crate::platform::archive;
+use crate::platform::constants as c;
+use crate::platform::exec::exec_blocking;
+use crate::platform::exec::ExecOptions;
 use crate::platform::fs_ext;
 use crate::platform::hash::Integrity;
 use crate::platform::http;
 use crate::platform::package::NpmPackage;
 use crate::platform::path_ext::*;
+use crate::platform::runtime::resolve_executable;
 use crate::platform::specifier::Specifier;
 use crate::public::json_serde::JsonSerde;
 use crate::public::package_kind::PackageKind;
@@ -17,6 +21,7 @@ use crate::public::package_meta::PackageMeta;
 
 #[derive(Debug, Deserialize)]
 struct NpmApiResponse {
+  version: String,
   dist: NpmApiResponseDist,
 }
 
@@ -26,17 +31,22 @@ struct NpmApiResponseDist {
   integrity: String,
 }
 
+pub fn resolve_from_npm(ctx: &Context, input: &str) -> anyhow::Result<String> {
+  let url = format!("{}/{}", ctx.env.atlaspack_npm_url, input);
+  let api_response = http::download_serde::<NpmApiResponse>(&url)?;
+  Ok(api_response.version)
+}
+
 pub fn install_from_npm(
   ctx: Context,
-  _cmd: InstallCommand,
+  cmd: InstallCommand,
   version: &Specifier,
 ) -> anyhow::Result<()> {
-  let pkg = NpmPackage::from_name(&ctx.paths.versions_v1, version)?;
-
-  let url = format!("{}/{}", ctx.env.atlaspack_npm_url, version.version());
-
   println!("Resolving");
+  let pkg = NpmPackage::from_name(&ctx.paths.versions_v1, version)?;
+  let url = format!("{}/{}", ctx.env.atlaspack_npm_url, version.version());
   let api_response = http::download_serde::<NpmApiResponse>(&url)?;
+
   let tarball_url = api_response.dist.tarball;
   let integrity = api_response.dist.integrity;
 
@@ -67,5 +77,37 @@ pub fn install_from_npm(
   )?;
 
   fs::rename(inner_temp.path(), pkg.contents())?;
+
+  if cmd.skip_postinstall {
+    return Ok(());
+  }
+
+  // If the git sha is specified, use the yarn.lock from the repo
+  if fs::exists(pkg.contents().join("GIT_SHA"))? {
+    let git_sha = fs::read_to_string(pkg.contents().join("GIT_SHA"))?;
+    let url_lock_file = format!("{}/{}/{}", c::GITHUB_RAW, git_sha, "yarn.lock");
+    let bytes = http::download_bytes(url_lock_file)?;
+    fs::write(pkg.contents().join("yarn.lock"), bytes)?;
+  }
+
+  let node_path = resolve_executable("node")?;
+  let pkg_manager_path = match resolve_executable("yarn") {
+    Ok(yarn) => Ok(yarn),
+    Err(_) => resolve_executable("npm"),
+  }?;
+
+  exec_blocking(
+    [
+      node_path.try_to_string()?.as_str(),
+      pkg_manager_path.try_to_string()?.as_str(),
+      "install",
+    ],
+    &ExecOptions {
+      cwd: Some(pkg.contents()),
+      stdio: true,
+      env: None,
+    },
+  )?;
+
   Ok(())
 }

--- a/crates/apvm/src/cmd/link.rs
+++ b/crates/apvm/src/cmd/link.rs
@@ -15,12 +15,13 @@ pub struct LinkCommand {
   /// Target version to link
   #[clap(default_value = "default")]
   pub version: String,
-
   /// Add version as an alias in the apvm.json
-  #[clap(long = "set-alias")]
   pub set_alias: Option<String>,
-
-  #[clap(long = "strict")]
+  /// Exclude node_modules when linking, reusing node_modules in the target
+  pub exclude_node_modules: bool,
+  /// Skip postinstall steps when downloading
+  pub install_skip_postinstall: bool,
+  /// Ensure linked version matches checksum in apvm.json
   pub strict: bool,
 }
 
@@ -43,7 +44,7 @@ pub fn main(ctx: Context, cmd: LinkCommand) -> anyhow::Result<()> {
         InstallCommand {
           version: cmd.version.clone(),
           force: true,
-          skip_postinstall: false,
+          skip_postinstall: cmd.install_skip_postinstall,
         },
       )?;
       let Some(package) = ctx.resolver.resolve(&specifier)? else {

--- a/crates/apvm/src/cmd/link_npm.rs
+++ b/crates/apvm/src/cmd/link_npm.rs
@@ -11,7 +11,6 @@ use crate::platform::path_ext::*;
 use crate::platform::specifier::Specifier;
 use crate::public::json_serde::JsonSerde;
 use crate::public::linked_meta::LinkedMeta;
-use crate::public::package_json::PackageJson;
 use crate::public::package_kind::PackageKind;
 
 pub fn link_npm(
@@ -21,7 +20,8 @@ pub fn link_npm(
   package: NpmPackage,
 ) -> anyhow::Result<()> {
   let package_contents = package.contents();
-  let package_lib_contents = package_contents.join("lib");
+  let package_node_modules = package_contents.join("node_modules");
+  let package_node_modules_atlaspack = package_node_modules.join("@atlaspack");
 
   // node_modules
   let node_modules = ctx.env.pwd.join("node_modules");
@@ -30,6 +30,7 @@ pub fn link_npm(
   let node_modules_bin_atlaspack = node_modules_bin.join(c::NM_BIN_NAME);
   let node_modules_super = node_modules.join("atlaspack");
   let node_modules_atlaspack = node_modules.join("@atlaspack");
+  let node_modules_atlaspack_node_modules = node_modules_atlaspack.join("node_modules");
 
   // Create the following folder structure
   //   /node_modules
@@ -67,80 +68,33 @@ pub fn link_npm(
   }
 
   // Map super package to target directory
-  for entry in fs::read_dir(&package_lib_contents)? {
+  for entry in fs::read_dir(&package_node_modules_atlaspack)? {
     let entry = entry?;
     let entry_path = entry.path();
 
     log::info!("Entry: {:?}", entry_path);
 
-    if fs::metadata(&entry_path)?.is_dir() {
-      continue;
-    }
-
-    // Skip non .js files
-    if entry_path.extension().is_some_and(|ext| ext != "js") {
+    if !fs::metadata(&entry_path)?.is_dir() {
       continue;
     }
 
     let file_stem = entry_path.try_file_stem()?;
-    if file_stem.starts_with("vendor.") {
-      continue;
-    }
-
     let node_modules_atlaspack_pkg = node_modules_atlaspack.join(&file_stem);
     log::info!(
       "Linking: {:?} -> {:?}",
       entry_path,
       node_modules_atlaspack_pkg
     );
+
     fs_ext::remove_if_exists(&node_modules_atlaspack_pkg)?;
+    fs_ext::create_dir_if_not_exists(&node_modules_atlaspack_pkg)?;
+    fs_ext::cp_dir_recursive(&entry_path, &node_modules_atlaspack_pkg)?;
+  }
 
-    fs::create_dir(&node_modules_atlaspack_pkg)?;
-    PackageJson::write_to_file(
-      &PackageJson {
-        name: Some(format!("@atlaspack/{file_stem}")),
-        version: Some(specifier.to_string()),
-        main: Some("./index.js".to_string()),
-        types: Some("./index.d.ts".to_string()),
-        r#type: Some("commonjs".to_string()),
-        private: None,
-      },
-      node_modules_atlaspack_pkg.join("package.json"),
-    )?;
-
-    // TODO: Remove this. One of our consumer packages imports this path directly.
-    // This path should not be imported by consumers and will be fixed there.
-    // In the interim, this workaround unblocks the roll out but will eventually be removed.
-    if file_stem == "runtime-js" {
-      fs::create_dir_all(node_modules_atlaspack_pkg.join("lib").join("helpers"))?;
-      fs_ext::soft_link(
-        &package_lib_contents
-          .join("runtimes")
-          .join("js")
-          .join("helpers")
-          .join("bundle-manifest.js"),
-        &node_modules_atlaspack_pkg
-          .join("lib")
-          .join("helpers")
-          .join("bundle-manifest.js"),
-      )?;
-    }
-
-    fs::write(
-      node_modules_atlaspack_pkg.join("index.js"),
-      format!("module.exports = require('atlaspack/lib/{file_stem}.js')\n"),
-    )?;
-
-    fs::write(
-      node_modules_atlaspack_pkg.join("index.d.ts"),
-      format!(
-        r#"// @ts-ignore
-export * from "atlaspack/{file_stem}";
-// @ts-ignore
-export {{ default }} from "atlaspack/{file_stem}";
-"#
-      ),
-    )?;
+  if !cmd.exclude_node_modules {
+    fs_ext::create_dir_if_not_exists(&node_modules_atlaspack_node_modules)?;
+    fs_ext::cp_dir_recursive(&package_node_modules, &node_modules_atlaspack_node_modules)?;
+    fs_ext::remove_if_exists(node_modules_atlaspack_node_modules.join("@atlaspack"))?;
   }
 
   let meta = LinkedMeta {
@@ -174,7 +128,7 @@ fn create_bin(node_modules_bin_atlaspack: &Path) -> std::io::Result<()> {
     log::info!("Creating: node_modules/.bin/atlaspack");
     fs::write(
       node_modules_bin_atlaspack,
-      "#!/usr/bin/env node\nrequire('atlaspack/lib/cli.js')\n",
+      "#!/usr/bin/env node\nrequire('@atlaspack/cli')\n",
     )?;
     fs::set_permissions(node_modules_bin_atlaspack, Permissions::from_mode(0o777))?;
   }

--- a/crates/apvm/src/context.rs
+++ b/crates/apvm/src/context.rs
@@ -12,6 +12,7 @@ pub struct Context {
   pub env: Env,
   pub paths: Paths,
   pub apvmrc: ApvmRcRef,
+  pub debug: bool,
   pub versions: Versions,
   #[serde(skip)]
   pub resolver: PackageResolver,

--- a/crates/apvm/src/main.rs
+++ b/crates/apvm/src/main.rs
@@ -80,6 +80,7 @@ fn main() -> anyhow::Result<()> {
     versions,
     apvmrc,
     env,
+    debug: log::log_enabled!(log::Level::Debug),
     paths,
     resolver,
     validator,

--- a/crates/apvm/src/platform/bin_path.rs
+++ b/crates/apvm/src/platform/bin_path.rs
@@ -36,7 +36,7 @@ pub fn release_bin_path<P: AsRef<Path>>(base: P) -> PathBuf {
 }
 
 pub fn npm_bin_path<P: AsRef<Path>>(base: P) -> PathBuf {
-  base.as_ref().join("lib").join("cli.js")
+  base.as_ref().join("static").join("cli").join("index.js")
 }
 
 pub fn unmanaged_bin_path<P: AsRef<Path>>(base: P) -> PathBuf {

--- a/crates/apvm/src/platform/constants.rs
+++ b/crates/apvm/src/platform/constants.rs
@@ -9,6 +9,9 @@ pub static NPM_API_URL: &str = "https://registry.npmjs.org/atlaspack";
 pub static RELEASE_URL: &str = "https://github.com/atlassian-labs/atlaspack/releases/download";
 pub static GITHUB_URL: &str = "https://github.com/atlassian-labs/atlaspack/archive/";
 
+// "GITHUB_RAW/${commit_hash}/${...filepath}"
+pub static GITHUB_RAW: &str = "http://raw.githubusercontent.com/atlassian-labs/atlaspack";
+
 #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
 pub static RELEASE_NAME: &str = "atlaspack-macos-arm64";
 

--- a/crates/apvm/src/platform/runtime.rs
+++ b/crates/apvm/src/platform/runtime.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
-pub fn resolve_runtime<S: AsRef<str>>(runtime: S) -> anyhow::Result<PathBuf> {
-  let runtime = if runtime.as_ref().starts_with("/") {
-    PathBuf::from(runtime.as_ref())
+pub fn resolve_executable<S: AsRef<str>>(executable: S) -> anyhow::Result<PathBuf> {
+  let runtime = if executable.as_ref().starts_with("/") {
+    PathBuf::from(executable.as_ref())
   } else {
-    which::CanonicalPath::new(runtime.as_ref())?.to_path_buf()
+    which::CanonicalPath::new(executable.as_ref())?.to_path_buf()
   };
   if !std::fs::exists(&runtime)? {
     return Err(anyhow::anyhow!("Cannot find runtime executable"));

--- a/packages/core/atlaspack/static/build-cache/index.d.ts
+++ b/packages/core/atlaspack/static/build-cache/index.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from '@atlaspack/build-cache';

--- a/packages/core/atlaspack/static/bundler/default/index.d.ts
+++ b/packages/core/atlaspack/static/bundler/default/index.d.ts
@@ -1,0 +1,2 @@
+export {default} from '@atlaspack/bundler-default';
+export * from '@atlaspack/bundler-default';

--- a/packages/core/atlaspack/static/bundler/library/index.d.ts
+++ b/packages/core/atlaspack/static/bundler/library/index.d.ts
@@ -1,0 +1,2 @@
+export {default} from '@atlaspack/bundler-library';
+export * from '@atlaspack/bundler-library';

--- a/packages/core/atlaspack/static/codeframe/index.d.ts
+++ b/packages/core/atlaspack/static/codeframe/index.d.ts
@@ -1,1 +1,2 @@
-export {};
+export {default} from '@atlaspack/codeframe';
+export * from '@atlaspack/codeframe';

--- a/packages/core/atlaspack/static/events/index.d.ts
+++ b/packages/core/atlaspack/static/events/index.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from '@atlaspack/events';

--- a/packages/core/atlaspack/static/graph/index.d.ts
+++ b/packages/core/atlaspack/static/graph/index.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from '@atlaspack/graph';

--- a/packages/core/atlaspack/static/logger/index.d.ts
+++ b/packages/core/atlaspack/static/logger/index.d.ts
@@ -1,1 +1,2 @@
-export {};
+export {default} from '@atlaspack/logger';
+export * from '@atlaspack/logger';

--- a/packages/core/atlaspack/static/markdown-ansi/index.d.ts
+++ b/packages/core/atlaspack/static/markdown-ansi/index.d.ts
@@ -1,1 +1,2 @@
-export {};
+export {default} from '@atlaspack/markdown-ansi';
+export * from '@atlaspack/markdown-ansi';

--- a/packages/core/atlaspack/static/node-resolver-core/index.d.ts
+++ b/packages/core/atlaspack/static/node-resolver-core/index.d.ts
@@ -1,1 +1,2 @@
-export {};
+export {default} from '@atlaspack/node-resolver-core';
+export * from '@atlaspack/node-resolver-core';

--- a/packages/core/atlaspack/static/utils/index.d.ts
+++ b/packages/core/atlaspack/static/utils/index.d.ts
@@ -1,1 +1,1 @@
-export {};
+export * from '@atlaspack/utils';

--- a/packages/core/conditional-import-types/index.d.ts
+++ b/packages/core/conditional-import-types/index.d.ts
@@ -41,3 +41,5 @@ declare function importCond<CondT, CondF>(
     ? ConditionalImport<CondT, CondF>
     : never
   : never;
+
+export {};


### PR DESCRIPTION
## Motivation

Enable APVM support with the existing unified `atlaspack` npm package: https://www.npmjs.com/package/atlaspack

## Changes

- APVM changes
  - Download/extract the `atlaspack` npm package
  - Link the `atlaspack` package
  - Support for resolving npm tags (like `latest` `dev`) 
- Added type re-exports to core packages in the `atlaspack` npm package 

## Notes

#### Atlaspack unmodified

The `atlaspack` package distributes Atlaspack completely unmodified so there are no consumer side changes required.

#### yarn install

APVM will download and do a `yarn install` on the `atlaspack` package. This works fine but is a bit slow (~45s). 

This can be skipped with: 

```
apvm install --skip-postinstall latest
```

#### Reuse `node_modules` at link target

If the consumer already has a version of Atlaspack installed and you want to reuse their `node_modules`, use the `--exclude-node-modules` option:

```
apvm link --exclude-node-modules 2.0.6
```

#### Optimised install times

If a project already has Atlaspack installed and you want to optimize the install times, run:

```
apvm install --skip-postinstall 2.0.6
apvm link --exclude-node-modules 2.0.6
```

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
