### PR TITLE
Add support for isolating inline scripts

### DIFF
--- a/.changeset/short-needles-dream.md
+++ b/.changeset/short-needles-dream.md
@@ -1,0 +1,13 @@
+---
+'@atlaspack/feature-flags': minor
+'@atlaspack/transformer-html': minor
+'@atlaspack/bundler-default': minor
+'@atlaspack/packager-js': minor
+'@atlaspack/utils': minor
+'@atlaspack/core': minor
+'@atlaspack/runtime-js': minor
+'@atlaspack/rust': minor
+'@atlaspack/types-internal': minor
+---
+
+Implement "inline isolated" scripts

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -541,6 +541,7 @@ mod tests {
       &project_root,
       false,
       None,
+      Some(BundleBehavior::Inline),
     );
 
     assert_eq!(

--- a/crates/atlaspack_core/src/types/asset.rs
+++ b/crates/atlaspack_core/src/types/asset.rs
@@ -328,6 +328,7 @@ impl Asset {
     project_root: &Path,
     side_effects: bool,
     unique_key: Option<String>,
+    bundle_behavior: Option<BundleBehavior>,
   ) -> Self {
     let id = create_asset_id(CreateAssetIdParams {
       code: None,
@@ -344,7 +345,7 @@ impl Asset {
       .any(|p| p.file_name() == Some(OsStr::new("node_modules")));
 
     Self {
-      bundle_behavior: Some(BundleBehavior::Inline),
+      bundle_behavior,
       code,
       env,
       file_path,

--- a/crates/atlaspack_core/src/types/bundle.rs
+++ b/crates/atlaspack_core/src/types/bundle.rs
@@ -80,6 +80,9 @@ pub enum BundleBehavior {
 
   /// The asset will be isolated from its parents in a separate bundle, and shared assets will be duplicated
   Isolated,
+
+  /// An Inline asset that is also isolated
+  InlineIsolated,
 }
 
 pub type MaybeBundleBehavior = Option<BundleBehavior>;

--- a/crates/atlaspack_plugin_transformer_html/src/html_dependencies_visitor.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/html_dependencies_visitor.rs
@@ -152,7 +152,7 @@ impl DomVisitor for HtmlDependenciesVisitor {
           };
           let mut inline_bundle_behavior = None;
           let dependency = Dependency {
-            bundle_behavior: if self.context.enabled_inline_isolated
+            bundle_behavior: if self.context.enable_inline_isolated
               && src_attr.is_none()
               && attrs.get(isolated_attr).is_some()
             {

--- a/crates/atlaspack_plugin_transformer_html/src/html_dependencies_visitor.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/html_dependencies_visitor.rs
@@ -146,8 +146,21 @@ impl DomVisitor for HtmlDependenciesVisitor {
             ..*self.context.env.clone()
           });
 
+          let isolated_attr = ExpandedName {
+            ns: &ns!(),
+            local: &LocalName::from("data-atlaspack-isolated"),
+          };
+          let mut inline_bundle_behavior = None;
           let dependency = Dependency {
-            bundle_behavior: if src_attr.is_none() {
+            bundle_behavior: if self.context.enabled_inline_isolated
+              && src_attr.is_none()
+              && attrs.get(isolated_attr).is_some()
+            {
+              attrs.delete(isolated_attr);
+              inline_bundle_behavior = Some(BundleBehavior::InlineIsolated);
+              Some(BundleBehavior::InlineIsolated)
+            } else if src_attr.is_none() {
+              inline_bundle_behavior = Some(BundleBehavior::Inline);
               Some(BundleBehavior::Inline)
             } else if source_type == SourceType::Script
               && attrs.get(expanded_name!("", "async")).is_some()
@@ -172,7 +185,6 @@ impl DomVisitor for HtmlDependenciesVisitor {
             },
             ..Default::default()
           };
-
           let dependency_id = dependency.id();
           self.dependencies.push(dependency);
 
@@ -214,6 +226,7 @@ impl DomVisitor for HtmlDependenciesVisitor {
                 &self.context.project_root,
                 self.context.side_effects,
                 Some(specifier),
+                inline_bundle_behavior,
               ),
               dependencies: Vec::new(),
             });
@@ -258,6 +271,7 @@ impl DomVisitor for HtmlDependenciesVisitor {
               &self.context.project_root,
               self.context.side_effects,
               Some(specifier),
+              Some(BundleBehavior::Inline),
             ),
             dependencies: Vec::new(),
           });

--- a/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
@@ -29,7 +29,10 @@ impl AtlaspackHtmlTransformerPlugin {
   pub fn new(ctx: &PluginContext) -> Self {
     AtlaspackHtmlTransformerPlugin {
       project_root: ctx.options.project_root.clone(),
-      enable_inline_isolated: ctx.options.feature_flags.bool_enabled("inlineIsolated"),
+      enable_inline_isolated: ctx
+        .options
+        .feature_flags
+        .bool_enabled("inlineIsolatedScripts"),
     }
   }
 }

--- a/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
@@ -22,12 +22,14 @@ use crate::html_dependencies_visitor::HtmlDependenciesVisitor;
 #[derive(Debug)]
 pub struct AtlaspackHtmlTransformerPlugin {
   project_root: PathBuf,
+  enabled_inline_isolated: bool,
 }
 
 impl AtlaspackHtmlTransformerPlugin {
   pub fn new(ctx: &PluginContext) -> Self {
     AtlaspackHtmlTransformerPlugin {
       project_root: ctx.options.project_root.clone(),
+      enabled_inline_isolated: ctx.options.feature_flags.bool_enabled("inlineIsolated"),
     }
   }
 }
@@ -49,6 +51,7 @@ impl TransformerPlugin for AtlaspackHtmlTransformerPlugin {
       side_effects: input.side_effects,
       source_asset_id: input.id.clone(),
       source_path: Some(input.file_path.clone()),
+      enabled_inline_isolated: self.enabled_inline_isolated,
     };
 
     let HtmlTransformation {
@@ -96,6 +99,7 @@ pub struct HTMLTransformationContext {
   pub side_effects: bool,
   pub source_asset_id: AssetId,
   pub source_path: Option<PathBuf>,
+  pub enabled_inline_isolated: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -274,6 +278,76 @@ mod test {
   }
 
   #[test]
+  fn transforms_inline_isolated_script_tag() {
+    let script = String::from(
+      "
+        const main = () => {
+          console.log('test');
+        }
+      ",
+    )
+    .trim()
+    .to_string();
+
+    let bytes = html_body(&format!(
+      r#"
+        <script type="text/javascript" data-atlaspack-isolated>{script}</script>
+      "#,
+    ));
+
+    let mut dom = parse_html(bytes.as_bytes()).unwrap();
+    let context = transformation_context();
+
+    let transformation = run_html_transformations(context.clone(), &mut dom);
+    let html = String::from_utf8(serialize_html(dom).unwrap()).unwrap();
+
+    assert_eq!(
+      &normalize_html(&html),
+      &normalize_html(&html_body(&format!(
+        r#"
+          <script data-parcel-key="16f87d7beed96467">{script}</script>
+        "#
+      )))
+    );
+
+    let env = Arc::new(Environment {
+      source_type: SourceType::Script,
+      ..Environment::default()
+    });
+
+    assert_eq!(
+      transformation,
+      HtmlTransformation {
+        dependencies: vec![Dependency {
+          bundle_behavior: Some(BundleBehavior::InlineIsolated),
+          env: env.clone(),
+          source_asset_id: Some(String::from("test")),
+          source_asset_type: Some(FileType::Html),
+          source_path: Some(PathBuf::from("main.html")),
+          specifier: String::from("16f87d7beed96467"),
+          ..Dependency::default()
+        }],
+        discovered_assets: vec![AssetWithDependencies {
+          asset: Asset {
+            bundle_behavior: Some(BundleBehavior::InlineIsolated),
+            code: Code::from(script),
+            env: env.clone(),
+            file_path: PathBuf::from("main.html"),
+            file_type: FileType::Js,
+            id: String::from("b0deada2a458cc5f"),
+            is_bundle_splittable: true,
+            is_source: true,
+            meta: JSONObject::from_iter([(String::from("type"), "tag".into())]),
+            unique_key: Some(String::from("16f87d7beed96467")),
+            ..Asset::default()
+          },
+          dependencies: Vec::new()
+        }],
+      }
+    );
+  }
+
+  #[test]
   fn transforms_inline_style_tag() {
     let bytes = html_body(
       "
@@ -356,6 +430,8 @@ mod test {
     Arc::get_mut(&mut context.env).unwrap().should_scope_hoist = false;
     context.source_path = Some(PathBuf::from("main.html"));
     context.source_asset_id = String::from("test");
+    // Remove this when cleaning up feature flag
+    context.enabled_inline_isolated = true;
 
     context
   }

--- a/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_html/src/html_transformer.rs
@@ -22,14 +22,14 @@ use crate::html_dependencies_visitor::HtmlDependenciesVisitor;
 #[derive(Debug)]
 pub struct AtlaspackHtmlTransformerPlugin {
   project_root: PathBuf,
-  enabled_inline_isolated: bool,
+  enable_inline_isolated: bool,
 }
 
 impl AtlaspackHtmlTransformerPlugin {
   pub fn new(ctx: &PluginContext) -> Self {
     AtlaspackHtmlTransformerPlugin {
       project_root: ctx.options.project_root.clone(),
-      enabled_inline_isolated: ctx.options.feature_flags.bool_enabled("inlineIsolated"),
+      enable_inline_isolated: ctx.options.feature_flags.bool_enabled("inlineIsolated"),
     }
   }
 }
@@ -51,7 +51,7 @@ impl TransformerPlugin for AtlaspackHtmlTransformerPlugin {
       side_effects: input.side_effects,
       source_asset_id: input.id.clone(),
       source_path: Some(input.file_path.clone()),
-      enabled_inline_isolated: self.enabled_inline_isolated,
+      enable_inline_isolated: self.enable_inline_isolated,
     };
 
     let HtmlTransformation {
@@ -99,7 +99,7 @@ pub struct HTMLTransformationContext {
   pub side_effects: bool,
   pub source_asset_id: AssetId,
   pub source_path: Option<PathBuf>,
-  pub enabled_inline_isolated: bool,
+  pub enable_inline_isolated: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -431,7 +431,7 @@ mod test {
     context.source_path = Some(PathBuf::from("main.html"));
     context.source_asset_id = String::from("test");
     // Remove this when cleaning up feature flag
-    context.enabled_inline_isolated = true;
+    context.enable_inline_isolated = true;
 
     context
   }

--- a/crates/node-bindings/src/atlaspack/dependency.rs
+++ b/crates/node-bindings/src/atlaspack/dependency.rs
@@ -17,6 +17,7 @@ enum JSBundleBehavior {
 enum BundleBehaviorStr {
   Inline,
   Isolated,
+  InlineIsolated,
 }
 
 impl From<JSBundleBehavior> for BundleBehavior {
@@ -24,6 +25,7 @@ impl From<JSBundleBehavior> for BundleBehavior {
     match value {
       JSBundleBehavior::String(BundleBehaviorStr::Inline) => BundleBehavior::Inline,
       JSBundleBehavior::String(BundleBehaviorStr::Isolated) => BundleBehavior::Isolated,
+      JSBundleBehavior::String(BundleBehaviorStr::InlineIsolated) => BundleBehavior::InlineIsolated,
       JSBundleBehavior::Int(value) => value,
     }
   }

--- a/packages/bundlers/default/src/MonolithicBundler.ts
+++ b/packages/bundlers/default/src/MonolithicBundler.ts
@@ -38,9 +38,12 @@ export function addJSMonolithBundle(
       let assets = bundleGraph.getDependencyAssets(dependency);
 
       for (const asset of assets) {
-        if (asset.bundleBehavior === 'isolated') {
+        if (
+          asset.bundleBehavior === 'isolated' ||
+          asset.bundleBehavior === 'inlineIsolated'
+        ) {
           throw new Error(
-            'Isolated assets are not supported for single file output builds',
+            `${asset.bundleBehavior === 'isolated' ? 'Isolated' : 'Inline isolated'} assets are not supported for single file output builds`,
           );
         }
 

--- a/packages/bundlers/default/src/bundleMerge.ts
+++ b/packages/bundlers/default/src/bundleMerge.ts
@@ -12,8 +12,13 @@ function getBundlesForBundleGroup(
 ): number {
   let count = 0;
   bundleGraph.traverse((nodeId) => {
-    // @ts-expect-error TS2339
-    if (bundleGraph.getNode(nodeId)?.bundleBehavior !== 'inline') {
+    const node = bundleGraph.getNode(nodeId);
+    if (
+      node &&
+      node !== 'root' &&
+      node.bundleBehavior !== 'inline' &&
+      node.bundleBehavior !== 'inlineIsolated'
+    ) {
       count++;
     }
   }, bundleGroupId);

--- a/packages/bundlers/default/src/bundleMerge.ts
+++ b/packages/bundlers/default/src/bundleMerge.ts
@@ -15,9 +15,9 @@ function getBundlesForBundleGroup(
     const node = bundleGraph.getNode(nodeId);
     if (
       node &&
-      node !== 'root' &&
-      node.bundleBehavior !== 'inline' &&
-      node.bundleBehavior !== 'inlineIsolated'
+      (node === 'root' ||
+        (node.bundleBehavior !== 'inline' &&
+          node.bundleBehavior !== 'inlineIsolated'))
     ) {
       count++;
     }

--- a/packages/bundlers/default/src/idealGraph.ts
+++ b/packages/bundlers/default/src/idealGraph.ts
@@ -1313,11 +1313,12 @@ export function createIdealGraph(
       let numBundlesContributingToPRL = bundleIdsInGroup.reduce((count, b) => {
         let bundle = nullthrows(bundleGraph.getNode(b));
         invariant(bundle !== 'root');
-        // @ts-expect-error TS2365
         return (
           count +
-          (bundle.bundleBehavior !== 'inline' &&
-            bundle.bundleBehavior !== 'inlineIsolated')
+          Number(
+            bundle.bundleBehavior !== 'inline' &&
+              bundle.bundleBehavior !== 'inlineIsolated',
+          )
         );
       }, 0);
 

--- a/packages/core/core/src/Atlaspack.ts
+++ b/packages/core/core/src/Atlaspack.ts
@@ -199,6 +199,7 @@ export default class Atlaspack {
         fs: inputFS && new FileSystemV3(inputFS),
         defaultTargetOptions: resolvedOptions.defaultTargetOptions,
         lmdb,
+        featureFlags: resolvedOptions.featureFlags,
       });
       this.#disposable.add(() => {
         rustAtlaspack.end();

--- a/packages/core/core/src/BundleGraph.ts
+++ b/packages/core/core/src/BundleGraph.ts
@@ -1455,7 +1455,8 @@ export default class BundleGraph {
       ISOLATED_ENVS.has(fromEnvironmentId(bundle.env).context) ||
       !bundle.isSplittable ||
       bundle.bundleBehavior === BundleBehavior.isolated ||
-      bundle.bundleBehavior === BundleBehavior.inline
+      bundle.bundleBehavior === BundleBehavior.inline ||
+      bundle.bundleBehavior === BundleBehavior.inlineIsolated
     ) {
       return false;
     }
@@ -1472,6 +1473,7 @@ export default class BundleGraph {
             b.id !== bundle.id &&
             b.bundleBehavior !== BundleBehavior.isolated &&
             b.bundleBehavior !== BundleBehavior.inline &&
+            b.bundleBehavior !== BundleBehavior.inlineIsolated &&
             this.bundleHasAsset(b, asset),
         )
       ) {
@@ -1490,7 +1492,8 @@ export default class BundleGraph {
         if (
           bundleNode.type !== 'bundle' ||
           bundleNode.value.bundleBehavior === BundleBehavior.isolated ||
-          bundleNode.value.bundleBehavior === BundleBehavior.inline
+          bundleNode.value.bundleBehavior === BundleBehavior.inline ||
+          bundleNode.value.bundleBehavior === BundleBehavior.inlineIsolated
         ) {
           return false;
         }
@@ -1522,6 +1525,7 @@ export default class BundleGraph {
                     b.id !== bundle.id &&
                     b.bundleBehavior !== BundleBehavior.isolated &&
                     b.bundleBehavior !== BundleBehavior.inline &&
+                    b.bundleBehavior !== BundleBehavior.inlineIsolated &&
                     this.bundleHasAsset(b, asset),
                 )
               ) {
@@ -1664,7 +1668,8 @@ export default class BundleGraph {
     this.traverseBundles((bundle) => {
       if (
         opts?.includeInline ||
-        bundle.bundleBehavior !== BundleBehavior.inline
+        (bundle.bundleBehavior !== BundleBehavior.inline &&
+          bundle.bundleBehavior !== BundleBehavior.inlineIsolated)
       ) {
         bundles.push(bundle);
       }
@@ -1748,7 +1753,8 @@ export default class BundleGraph {
       let bundle = bundleNode.value;
       if (
         opts?.includeInline ||
-        bundle.bundleBehavior !== BundleBehavior.inline
+        (bundle.bundleBehavior !== BundleBehavior.inline &&
+          bundle.bundleBehavior !== BundleBehavior.inlineIsolated)
       ) {
         bundles.add(bundle);
       }
@@ -1786,7 +1792,8 @@ export default class BundleGraph {
 
         if (
           includeInline ||
-          node.value.bundleBehavior !== BundleBehavior.inline
+          (node.value.bundleBehavior !== BundleBehavior.inline &&
+            node.value.bundleBehavior !== BundleBehavior.inlineIsolated)
         ) {
           referencedBundles.add(node.value);
         }
@@ -2161,7 +2168,10 @@ export default class BundleGraph {
         includeInline: true,
       });
       for (let referenced of referencedBundles) {
-        if (referenced.bundleBehavior === BundleBehavior.inline) {
+        if (
+          referenced.bundleBehavior === BundleBehavior.inline ||
+          referenced.bundleBehavior === BundleBehavior.inlineIsolated
+        ) {
           bundles.push(referenced);
           addReferencedBundles(referenced);
         }
@@ -2171,7 +2181,10 @@ export default class BundleGraph {
     addReferencedBundles(bundle);
 
     this.traverseBundles((childBundle, _, traversal) => {
-      if (childBundle.bundleBehavior === BundleBehavior.inline) {
+      if (
+        childBundle.bundleBehavior === BundleBehavior.inline ||
+        childBundle.bundleBehavior === BundleBehavior.inlineIsolated
+      ) {
         bundles.push(childBundle);
       } else if (childBundle.id !== bundle.id) {
         traversal.skipChildren();

--- a/packages/core/core/src/PackagerRunner.ts
+++ b/packages/core/core/src/PackagerRunner.ts
@@ -377,7 +377,12 @@ export default class PackagerRunner {
     bundle: NamedBundle,
     map?: SourceMap | null,
   ): Async<string | null | undefined> {
-    if (map && bundle.env.sourceMap && bundle.bundleBehavior !== 'inline') {
+    if (
+      map &&
+      bundle.env.sourceMap &&
+      bundle.bundleBehavior !== 'inline' &&
+      bundle.bundleBehavior !== 'inlineIsolated'
+    ) {
       if (bundle.env.sourceMap && bundle.env.sourceMap.inline) {
         return this.generateSourceMap(bundleToInternalBundle(bundle), map);
       } else {
@@ -427,7 +432,10 @@ export default class PackagerRunner {
           bundle: BundleType,
           bundleGraph: BundleGraphType<NamedBundleType>,
         ) => {
-          if (bundle.bundleBehavior !== 'inline') {
+          if (
+            bundle.bundleBehavior !== 'inline' &&
+            bundle.bundleBehavior !== 'inlineIsolated'
+          ) {
             throw new Error(
               'Bundle is not inline and unable to retrieve contents',
             );

--- a/packages/core/core/src/atlaspack-v3/worker/compat/bitflags.ts
+++ b/packages/core/core/src/atlaspack-v3/worker/compat/bitflags.ts
@@ -62,6 +62,7 @@ export const bundleBehaviorMap: BitFlags<BundleBehavior, number> = new BitFlags(
   {
     inline: 0,
     isolated: 1,
+    inlineIsolated: 2,
   },
 );
 

--- a/packages/core/core/src/requests/WriteBundlesRequest.ts
+++ b/packages/core/core/src/requests/WriteBundlesRequest.ts
@@ -86,8 +86,12 @@ async function run({input, api, farm, options}) {
     includeInline: getFeatureFlag('inlineBundlesSourceMapFixes'),
   });
   const bundles = allBundles
-    // @ts-expect-error TS7006
-    .filter((bundle) => bundle.bundleBehavior !== 'inline')
+    .filter(
+      // @ts-expect-error TS7006
+      (bundle) =>
+        bundle.bundleBehavior !== 'inline' &&
+        bundle.bundleBehavior !== 'inline-isolated',
+    )
     // @ts-expect-error TS7006
     .filter((bundle) => {
       // Do not package and write placeholder bundles to disk. We just

--- a/packages/core/core/src/types.ts
+++ b/packages/core/core/src/types.ts
@@ -179,6 +179,7 @@ export type Dependency = {
 export const BundleBehavior = {
   inline: 0,
   isolated: 1,
+  inlineIsolated: 2,
 } as const;
 
 // @ts-expect-error TS2322

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -145,6 +145,12 @@ export type FeatureFlags = {
    * a full bundling pass is required based on the AssetGraph's bundlingVersion.
    */
   incrementalBundlingVersioning: boolean;
+
+  /**
+   * Allow for the use of `data-atlaspack-isolated` on script tags in HTML to produce
+   * inline scripts that are build as "isolated" bundles.
+   */
+  inlineIsolatedScripts: boolean;
 };
 
 export type ConsistencyCheckFeatureFlagValue =
@@ -186,6 +192,7 @@ export const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
   condbDevFallbackDev: false,
   condbDevFallbackProd: false,
   incrementalBundlingVersioning: process.env.NODE_ENV === 'test',
+  inlineIsolatedScripts: process.env.NODE_ENV === 'test',
 };
 
 let featureFlagValues: FeatureFlags = {...DEFAULT_FEATURE_FLAGS};

--- a/packages/core/integration-tests/test/html.ts
+++ b/packages/core/integration-tests/test/html.ts
@@ -3272,9 +3272,6 @@ describe('html', function () {
       inputFS: overlayFS,
       outputFS: overlayFS,
       mode: 'production',
-      featureFlags: {
-        inlineIsolatedScripts: true,
-      },
     });
     const outdir = outputFS.readdirSync(distDir);
     // We expect to only produce HTML files
@@ -3282,5 +3279,14 @@ describe('html', function () {
       outdir.every((f) => f.endsWith('.html')),
       `Expected only HTML files: ${outdir.join(', ')}`,
     );
+    outdir
+      .filter((f) => f.endsWith('.html'))
+      .forEach((f) => {
+        const html = outputFS.readFileSync(path.join(distDir, f), 'utf8');
+        assert(
+          !html.includes('data-atlaspack-isolated'),
+          `Expected data-atlaspack-isolated to be stripped from ${f}`,
+        );
+      });
   });
 });

--- a/packages/core/integration-tests/test/html.ts
+++ b/packages/core/integration-tests/test/html.ts
@@ -3240,14 +3240,16 @@ describe('html', function () {
     await fsFixture(overlayFS, dir)`
       yarn.lock: {}
 
-      shared.js: 
-        // Something meaty to trigger a separate bundle
-        import {createHash } from 'crypto';
+      package.json:
+        {
+          "@atlaspack/bundler-default": {
+            "minBundleSize": 0
+          }
+        }
 
+      shared.js: 
         export function shared(a) {
-          const h = createHash('sha256');
-          h.update(a);
-          return h.digest('hex');
+          return "This is some shared stuff " + a;
         }
 
       index.html:
@@ -3270,6 +3272,9 @@ describe('html', function () {
       inputFS: overlayFS,
       outputFS: overlayFS,
       mode: 'production',
+      featureFlags: {
+        inlineIsolatedScripts: true,
+      },
     });
     const outdir = outputFS.readdirSync(distDir);
     // We expect to only produce HTML files

--- a/packages/core/integration-tests/test/html.ts
+++ b/packages/core/integration-tests/test/html.ts
@@ -3236,8 +3236,8 @@ describe('html', function () {
 
   it('should support isolated inline scripts', async function () {
     const dir = path.join(__dirname, 'html-inline-isolated');
-    await inputFS.mkdirp(dir);
-    await fsFixture(inputFS, dir)`
+    await overlayFS.mkdirp(dir);
+    await fsFixture(overlayFS, dir)`
       yarn.lock: {}
 
       shared.js: 
@@ -3267,8 +3267,8 @@ describe('html', function () {
       path.join(dir, 'index2.html'),
     ];
     const b = await bundle(entries, {
-      inputFS,
-      outputFS,
+      inputFS: overlayFS,
+      outputFS: overlayFS,
       mode: 'production',
     });
     const outdir = outputFS.readdirSync(distDir);

--- a/packages/core/types-internal/src/index.ts
+++ b/packages/core/types-internal/src/index.ts
@@ -749,7 +749,7 @@ export type ASTGenerator = {
   version: Semver;
 };
 
-export type BundleBehavior = 'inline' | 'isolated';
+export type BundleBehavior = 'inline' | 'isolated' | 'inlineIsolated';
 
 export type AtlaspackTransformOptions = {
   filePath: FilePath;

--- a/packages/core/utils/src/replaceBundleReferences.ts
+++ b/packages/core/utils/src/replaceBundleReferences.ts
@@ -74,7 +74,10 @@ export function replaceURLReferences({
       continue;
     }
 
-    if (resolved.bundleBehavior === 'inline') {
+    if (
+      resolved.bundleBehavior === 'inline' ||
+      resolved.bundleBehavior === 'inlineIsolated'
+    ) {
       // If a bundle is inline, it should be replaced with inline contents,
       // not a URL.
       continue;
@@ -140,7 +143,10 @@ export async function replaceInlineReferences({
 
   for (let dependency of dependencies) {
     let entryBundle = bundleGraph.getReferencedBundle(dependency, bundle);
-    if (entryBundle?.bundleBehavior !== 'inline') {
+    if (
+      entryBundle?.bundleBehavior !== 'inline' &&
+      entryBundle?.bundleBehavior !== 'inlineIsolated'
+    ) {
       continue;
     }
 

--- a/packages/packagers/js/src/DevPackager.ts
+++ b/packages/packagers/js/src/DevPackager.ts
@@ -272,7 +272,8 @@ export class DevPackager {
     return (
       !this.bundleGraph.hasParentBundleOfType(this.bundle, 'js') ||
       this.bundle.env.isIsolated() ||
-      this.bundle.bundleBehavior === 'isolated'
+      this.bundle.bundleBehavior === 'isolated' ||
+      this.bundle.bundleBehavior === 'inlineIsolated'
     );
   }
 }

--- a/packages/packagers/js/src/ScopeHoistingPackager.ts
+++ b/packages/packagers/js/src/ScopeHoistingPackager.ts
@@ -131,7 +131,8 @@ export class ScopeHoistingPackager {
     this.isAsyncBundle =
       this.bundleGraph.hasParentBundleOfType(this.bundle, 'js') &&
       !this.bundle.env.isIsolated() &&
-      this.bundle.bundleBehavior !== 'isolated';
+      this.bundle.bundleBehavior !== 'isolated' &&
+      this.bundle.bundleBehavior !== 'inlineIsolated';
 
     this.globalNames = GLOBALS_BY_CONTEXT[bundle.env.context];
   }
@@ -323,6 +324,7 @@ export class ScopeHoistingPackager {
       this.useAsyncBundleRuntime &&
       bundle.type === 'js' &&
       bundle.bundleBehavior !== 'inline' &&
+      bundle.bundleBehavior !== 'inlineIsolated' &&
       bundle.env.outputFormat === 'esmodule' &&
       !bundle.env.isIsolated() &&
       bundle.bundleBehavior !== 'isolated' &&
@@ -1651,6 +1653,7 @@ ${code}
           .some((g) => this.bundleGraph.isEntryBundleGroup(g)) ||
         this.bundle.env.isIsolated() ||
         this.bundle.bundleBehavior === 'isolated' ||
+        this.bundle.bundleBehavior === 'inlineIsolated' ||
         // Conditional deps may be loaded before entrypoints on the server
         this.hasConditionalDependency();
 

--- a/packages/runtimes/js/src/JSRuntime.ts
+++ b/packages/runtimes/js/src/JSRuntime.ts
@@ -183,7 +183,10 @@ export default new Runtime({
           dependency,
           bundle,
         );
-        if (referencedBundle?.bundleBehavior === 'inline') {
+        if (
+          referencedBundle?.bundleBehavior === 'inline' ||
+          referencedBundle?.bundleBehavior === 'inlineIsolated'
+        ) {
           assets.push({
             filePath: path.join(
               __dirname,
@@ -286,7 +289,10 @@ export default new Runtime({
         dependency,
         bundle,
       );
-      if (referencedBundle?.bundleBehavior === 'inline') {
+      if (
+        referencedBundle?.bundleBehavior === 'inline' ||
+        referencedBundle?.bundleBehavior === 'inlineIsolated'
+      ) {
         assets.push({
           filePath: path.join(__dirname, `/bundles/${referencedBundle.id}.js`),
           code: `module.exports = ${JSON.stringify(dependency.id)};`,
@@ -325,7 +331,11 @@ export default new Runtime({
 
       // Skip URL runtimes for library builds. This is handled in packaging so that
       // the url is inlined and statically analyzable.
-      if (bundle.env.isLibrary && mainBundle.bundleBehavior !== 'isolated') {
+      if (
+        bundle.env.isLibrary &&
+        mainBundle.bundleBehavior !== 'isolated' &&
+        mainBundle.bundleBehavior !== 'inlineIsolated'
+      ) {
         continue;
       }
 
@@ -382,7 +392,11 @@ export default new Runtime({
       shouldUseRuntimeManifest(bundle, options) &&
       bundleGraph
         .getChildBundles(bundle)
-        .some((b) => b.bundleBehavior !== 'inline') &&
+        .some(
+          (b) =>
+            b.bundleBehavior !== 'inline' &&
+            b.bundleBehavior !== 'inlineIsolated',
+        ) &&
       isNewContext(bundle, bundleGraph)
     ) {
       assets.push({
@@ -891,7 +905,10 @@ function getRegisterCode(
   // @ts-expect-error TS2304
   let mappings: Array<FilePath | string> = [];
   bundleGraph.traverseBundles((bundle, _, actions) => {
-    if (bundle.bundleBehavior === 'inline') {
+    if (
+      bundle.bundleBehavior === 'inline' ||
+      bundle.bundleBehavior === 'inlineIsolated'
+    ) {
       return;
     }
 
@@ -982,6 +999,7 @@ function shouldUseRuntimeManifest(
   return (
     !env.isLibrary &&
     bundle.bundleBehavior !== 'inline' &&
+    bundle.bundleBehavior !== 'inlineIsolated' &&
     env.isBrowser() &&
     options.mode === 'production'
   );

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@atlaspack/diagnostic": "2.14.2",
+    "@atlaspack/feature-flags": "2.20.1",
     "@atlaspack/plugin": "2.14.22",
     "@atlaspack/rust": "3.4.2",
     "nullthrows": "^1.1.1",

--- a/packages/transformers/html/src/inline.ts
+++ b/packages/transformers/html/src/inline.ts
@@ -1,9 +1,15 @@
-import type {AST, MutableAsset, TransformerResult} from '@atlaspack/types';
+import type {
+  AST,
+  BundleBehavior,
+  MutableAsset,
+  TransformerResult,
+} from '@atlaspack/types';
 import {hashString} from '@atlaspack/rust';
 // @ts-expect-error TS2724
 import type {PostHTMLNode} from 'posthtml';
 
 import PostHTML from 'posthtml';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 const SCRIPT_TYPES = {
   'application/javascript': 'js',
@@ -120,6 +126,14 @@ export default function extractInlineAssets(
           delete node.attrs.type;
         }
 
+        let bundleBehavior: BundleBehavior = 'inline';
+        if (
+          getFeatureFlag('inlineIsolatedScripts') &&
+          typeof node.attrs['data-atlaspack-isolated'] !== 'undefined'
+        ) {
+          bundleBehavior = 'inlineIsolated';
+        }
+
         // insert parcelId to allow us to retrieve node during packaging
         node.attrs['data-parcel-key'] = parcelKey;
         asset.setAST(ast); // mark dirty
@@ -133,7 +147,7 @@ export default function extractInlineAssets(
           type,
           content: value,
           uniqueKey: parcelKey,
-          bundleBehavior: 'inline',
+          bundleBehavior,
           // @ts-expect-error TS2322
           env,
           meta: {

--- a/packages/transformers/html/src/inline.ts
+++ b/packages/transformers/html/src/inline.ts
@@ -132,6 +132,7 @@ export default function extractInlineAssets(
           typeof node.attrs['data-atlaspack-isolated'] !== 'undefined'
         ) {
           bundleBehavior = 'inlineIsolated';
+          delete node.attrs['data-atlaspack-isolated'];
         }
 
         // insert parcelId to allow us to retrieve node during packaging

--- a/packages/transformers/html/test/HTMLTransformer.test.ts
+++ b/packages/transformers/html/test/HTMLTransformer.test.ts
@@ -351,4 +351,25 @@ describe('HTMLTransformer', () => {
       },
     ]);
   });
+
+  it('transforms simple inline script with data-atlaspack-isolated', async () => {
+    const code = `
+<html>
+  <body>
+    <script data-atlaspack-isolated>console.log('blah'); require('path');</script>
+  </body>
+</html>
+    `;
+    const {transformResult, inputAsset} = await runTestTransform(code);
+    assert(transformResult.includes(inputAsset));
+    const assets = normalizeAssets(transformResult);
+    assert.deepEqual(assets[1], {
+      type: 'js',
+      content: "console.log('blah'); require('path');",
+      uniqueKey: 'a8a37984d2e520b9',
+      bundleBehavior: 'inlineIsolated',
+      env: null,
+      meta: null,
+    });
+  });
 });


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

In some use cases we want to bundle multiple HTML entries with inline scripts that depend on shared code, however we don't want Atlaspack to produce a shared bundle - we want to keep all the bundled code within the inline script.

Essentially we want the inline script to also be isolated, something that is not previously supported by Atlaspack.

## Changes

Implement a new attribute to tell Atlaspack that an inline script should be isolated: `<script data-atlaspack-isolated>`. With this attribute, the script will use a new bundle behaviour called `inlineIsolated` which is a combination of both inline and isolated.

The majority of the change is adding conditions for this new `bundleBehavior` everywhere there's a check for `inline` or `isolated` to ensure the new `bundleBehavior` is both.

There is a new feature flag `inlineIsolatedScripts` which enables parsing the new attribute in the HTML transformer (both in JS and Rust) and setting the new `bundleBehavior` on the dependency, however there is no feature flag checks elsewhere in the code - the new `bundleBehavior` will only ever be set by the HTML transformers behind gated code, so I believe this is a safe approach.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder (TODO)

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
