### PR TITLE
Refactor dev-server code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -180,7 +180,7 @@ dependencies = [
  "jwalk",
  "log",
  "rand",
- "reqwest",
+ "reqwest 0.12.15",
  "serde",
  "serde_json",
  "sha-1",
@@ -492,6 +492,20 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "xxhash-rust",
+]
+
+[[package]]
+name = "atlaspack_dev_server"
+version = "0.1.0"
+dependencies = [
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "warp",
 ]
 
 [[package]]
@@ -1670,6 +1684,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2053,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,6 +2105,30 @@ name = "hashbrown"
 version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+
+[[package]]
+name = "headers"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "headers-core",
+ "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http 0.2.12",
+]
 
 [[package]]
 name = "heck"
@@ -2178,6 +2244,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
@@ -2189,12 +2266,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
@@ -2205,8 +2293,8 @@ checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2224,6 +2312,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
@@ -2231,8 +2343,8 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2248,8 +2360,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
- "http",
- "hyper",
+ "http 1.1.0",
+ "hyper 1.5.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -2261,13 +2373,26 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2284,9 +2409,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -3066,6 +3191,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
 name = "minidump-common"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3195,6 +3330,24 @@ dependencies = [
  "dunce",
  "libc",
  "nasm-rs",
+]
+
+[[package]]
+name = "multer"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01acbdc23469fd8fe07ab135923371d5f5a422fbf9c522158677c8eb15bc51c2"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 0.2.12",
+ "httparse",
+ "log",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -3808,6 +3961,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4341,6 +4514,46 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
@@ -4350,12 +4563,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.1.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-rustls",
- "hyper-tls",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -4367,12 +4580,12 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -4548,6 +4761,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
@@ -4701,7 +4923,7 @@ checksum = "016958f51b96861dead7c1e02290f138411d05e94fad175c8636a835dee6e51e"
 dependencies = [
  "httpdate",
  "native-tls",
- "reqwest",
+ "reqwest 0.12.15",
  "rustls",
  "sentry-anyhow",
  "sentry-backtrace",
@@ -6061,6 +6283,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -6086,6 +6314,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -6401,6 +6650,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6443,7 +6717,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.1",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -6467,6 +6741,7 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6583,6 +6858,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror 1.0.65",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6627,6 +6921,12 @@ checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-id"
@@ -6826,6 +7126,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
+]
+
+[[package]]
+name = "warp"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378d202ff965b011c64817db11d5829506d3404edeadb61f190d111da3f231c"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "headers",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "mime",
+ "mime_guess",
+ "multer",
+ "percent-encoding",
+ "pin-project",
+ "scoped-tls",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-tungstenite",
+ "tokio-util",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -7103,6 +7432,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7117,6 +7455,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -7153,6 +7506,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7165,6 +7524,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7174,6 +7539,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7201,6 +7572,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7210,6 +7587,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7225,6 +7608,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7234,6 +7623,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7254,6 +7649,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36c1fec1a2bb5866f07c25f68c26e565c4c200aebb96d7e55710c19d3e8ac49b"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/crates/atlaspack_dev_server/Cargo.toml
+++ b/crates/atlaspack_dev_server/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "atlaspack_dev_server"
+version = "0.1.0"
+edition = "2021"
+
+[[bin]]
+name = "atlaspack_dev_server"
+path = "src/main.rs"
+
+[dependencies]
+warp = "0.3"
+tokio = { version = "1.0", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+tempfile = "3.0"
+
+[lints]
+workspace = true

--- a/crates/atlaspack_dev_server/README.md
+++ b/crates/atlaspack_dev_server/README.md
@@ -1,0 +1,75 @@
+# Atlaspack Dev Server
+
+A development server built with Warp for the Atlaspack project.
+
+## Features
+
+- **Health Check Endpoint**: `GET /health` - Returns server status
+- **API Status Endpoint**: `GET /api/status` - Returns build status and timestamp
+- **Static File Serving**: `GET /static/*` - Serves files from `./dist` directory
+- **CORS Support**: Configured to allow cross-origin requests
+- **Logging**: Built-in request logging with tracing
+
+## Usage
+
+### As a Library
+
+```rust
+use atlaspack_dev_server::{DevServer, start_dev_server};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Option 1: Use the convenience function
+    start_dev_server(Some(3000)).await?;
+    
+    // Option 2: Create a custom server
+    let server = DevServer::new("127.0.0.1".to_string(), 8080);
+    server.start().await?;
+    
+    Ok(())
+}
+```
+
+### As a Binary
+
+```bash
+# Run the dev server on port 3000
+cargo run --bin atlaspack_dev_server
+
+# Or build and run
+cargo build --release
+./target/release/atlaspack_dev_server
+```
+
+## API Endpoints
+
+- `GET /health` - Health check endpoint
+  ```json
+  {
+    "status": "ok",
+    "service": "atlaspack-dev-server"
+  }
+  ```
+
+- `GET /api/status` - Build status endpoint
+  ```json
+  {
+    "build_status": "ready",
+    "timestamp": 1234567890
+  }
+  ```
+
+- `GET /static/*` - Static file serving from `./dist` directory
+
+## Dependencies
+
+- `warp` - Web server framework
+- `tokio` - Async runtime
+- `serde` & `serde_json` - JSON serialization
+- `tracing` & `tracing-subscriber` - Logging and observability
+
+## Testing
+
+```bash
+cargo test
+```

--- a/crates/atlaspack_dev_server/src/lib.rs
+++ b/crates/atlaspack_dev_server/src/lib.rs
@@ -1,0 +1,357 @@
+use std::net::SocketAddr;
+use tracing::info;
+use warp::Filter;
+
+pub struct DevServer {
+  port: u16,
+  host: String,
+}
+
+impl DevServer {
+  pub fn new(host: String, port: u16) -> Self {
+    Self { host, port }
+  }
+
+  pub async fn start(&self) -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize tracing
+    tracing_subscriber::fmt::init();
+
+    info!(
+      "Starting Atlaspack dev server on {}:{}",
+      self.host, self.port
+    );
+
+    // Create basic routes
+    let routes = self.create_routes();
+
+    // Parse the socket address
+    let addr: SocketAddr = format!("{}:{}", self.host, self.port).parse()?;
+
+    info!("Dev server listening on http://{}", addr);
+
+    // Start the server
+    warp::serve(routes).run(addr).await;
+
+    Ok(())
+  }
+
+  // New method for testing: start server and return the actual bound address
+  pub async fn start_with_addr(&self) -> Result<SocketAddr, Box<dyn std::error::Error>> {
+    use std::net::TcpListener;
+
+    let routes = self.create_routes();
+
+    // If port is 0, find an available port
+    let addr = if self.port == 0 {
+      let listener = TcpListener::bind(format!("{}:0", self.host))?;
+      let addr = listener.local_addr()?;
+      drop(listener); // Close the listener so warp can bind to it
+      addr
+    } else {
+      format!("{}:{}", self.host, self.port).parse()?
+    };
+
+    // Start the server in the background
+    tokio::spawn(warp::serve(routes).run(addr));
+
+    // Give the server a moment to start
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    Ok(addr)
+  }
+
+  fn create_routes(
+    &self,
+  ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+    let health = warp::path("health").and(warp::get()).map(|| {
+      warp::reply::json(&serde_json::json!({
+          "status": "ok",
+          "service": "atlaspack-dev-server"
+      }))
+    });
+
+    let static_files = warp::path("static").and(warp::fs::dir("./dist"));
+
+    let api = warp::path("api").and(warp::path("status").and(warp::get()).map(|| {
+      warp::reply::json(&serde_json::json!({
+          "build_status": "ready",
+          "timestamp": std::time::SystemTime::now()
+              .duration_since(std::time::UNIX_EPOCH)
+              .unwrap()
+              .as_secs()
+      }))
+    }));
+
+    let cors = warp::cors()
+      .allow_any_origin()
+      .allow_headers(vec!["content-type"])
+      .allow_methods(vec!["GET", "POST", "PUT", "DELETE"]);
+
+    // Combine all routes
+    health
+      .or(static_files)
+      .or(api)
+      .with(cors)
+      .with(warp::log("atlaspack_dev_server"))
+  }
+}
+
+// Convenience function to start a dev server with default settings
+pub async fn start_dev_server(port: Option<u16>) -> Result<(), Box<dyn std::error::Error>> {
+  let server = DevServer::new("127.0.0.1".to_string(), port.unwrap_or(3000));
+  server.start().await
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use std::time::Duration;
+  use tempfile::TempDir;
+  use tokio::time::sleep;
+
+  async fn setup_test_server() -> (SocketAddr, TempDir) {
+    // Create a temporary directory for static files
+    let temp_dir = TempDir::new().expect("Failed to create temp dir");
+    let dist_path = temp_dir.path().join("dist");
+    std::fs::create_dir_all(&dist_path).expect("Failed to create dist dir");
+
+    // Create a test file in the dist directory
+    let test_file_path = dist_path.join("test.txt");
+    std::fs::write(&test_file_path, "Hello from static file!").expect("Failed to write test file");
+
+    // Change to the temp directory so the server can find ./dist
+    let original_dir = std::env::current_dir().expect("Failed to get current dir");
+    std::env::set_current_dir(temp_dir.path()).expect("Failed to change dir");
+
+    // Create server with port 0 to get a random available port
+    let server = DevServer::new("127.0.0.1".to_string(), 0);
+    let addr = server
+      .start_with_addr()
+      .await
+      .expect("Failed to start server");
+
+    // Give the server a moment to start
+    sleep(Duration::from_millis(100)).await;
+
+    // Restore original directory
+    std::env::set_current_dir(original_dir).expect("Failed to restore dir");
+
+    (addr, temp_dir)
+  }
+
+  #[test]
+  fn test_dev_server_creation() {
+    let server = DevServer::new("localhost".to_string(), 8080);
+    assert_eq!(server.host, "localhost");
+    assert_eq!(server.port, 8080);
+  }
+
+  #[tokio::test]
+  async fn test_health_endpoint() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    let response = client
+      .get(&format!("http://{}/health", addr))
+      .send()
+      .await
+      .expect("Failed to send request");
+
+    assert_eq!(response.status(), 200);
+
+    let json: serde_json::Value = response
+      .json()
+      .await
+      .expect("Failed to parse JSON response");
+
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["service"], "atlaspack-dev-server");
+  }
+
+  #[tokio::test]
+  async fn test_api_status_endpoint() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    let response = client
+      .get(&format!("http://{}/api/status", addr))
+      .send()
+      .await
+      .expect("Failed to send request");
+
+    assert_eq!(response.status(), 200);
+
+    let json: serde_json::Value = response
+      .json()
+      .await
+      .expect("Failed to parse JSON response");
+
+    assert_eq!(json["build_status"], "ready");
+    assert!(json["timestamp"].is_number());
+
+    // Verify timestamp is reasonable (within last minute)
+    let timestamp = json["timestamp"]
+      .as_u64()
+      .expect("Timestamp should be a number");
+    let now = std::time::SystemTime::now()
+      .duration_since(std::time::UNIX_EPOCH)
+      .unwrap()
+      .as_secs();
+    assert!(timestamp <= now);
+    assert!(timestamp > now - 60); // Within last minute
+  }
+
+  #[tokio::test]
+  async fn test_static_file_serving() {
+    let (addr, temp_dir) = setup_test_server().await;
+
+    // Change to temp directory for this test
+    let original_dir = std::env::current_dir().expect("Failed to get current dir");
+    std::env::set_current_dir(temp_dir.path()).expect("Failed to change dir");
+
+    let client = reqwest::Client::new();
+
+    let response = client
+      .get(&format!("http://{}/static/test.txt", addr))
+      .send()
+      .await
+      .expect("Failed to send request");
+
+    // Restore directory
+    std::env::set_current_dir(original_dir).expect("Failed to restore dir");
+
+    assert_eq!(response.status(), 200);
+
+    let text = response.text().await.expect("Failed to get response text");
+
+    assert_eq!(text, "Hello from static file!");
+  }
+
+  #[tokio::test]
+  async fn test_static_file_not_found() {
+    let (addr, temp_dir) = setup_test_server().await;
+
+    // Change to temp directory for this test
+    let original_dir = std::env::current_dir().expect("Failed to get current dir");
+    std::env::set_current_dir(temp_dir.path()).expect("Failed to change dir");
+
+    let client = reqwest::Client::new();
+
+    let response = client
+      .get(&format!("http://{}/static/nonexistent.txt", addr))
+      .send()
+      .await
+      .expect("Failed to send request");
+
+    // Restore directory
+    std::env::set_current_dir(original_dir).expect("Failed to restore dir");
+
+    assert_eq!(response.status(), 404);
+  }
+
+  #[tokio::test]
+  async fn test_cors_headers() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Send a request with Origin header to trigger CORS
+    let response = client
+      .get(&format!("http://{}/health", addr))
+      .header("Origin", "http://localhost:3000")
+      .send()
+      .await
+      .expect("Failed to send request");
+
+    assert_eq!(response.status(), 200);
+
+    // Check CORS headers
+    let headers = response.headers();
+    assert!(headers.contains_key("access-control-allow-origin"));
+  }
+
+  #[tokio::test]
+  async fn test_cors_preflight() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Send a preflight OPTIONS request
+    let response = client
+      .request(reqwest::Method::OPTIONS, &format!("http://{}/health", addr))
+      .header("Origin", "http://localhost:3000")
+      .header("Access-Control-Request-Method", "GET")
+      .send()
+      .await
+      .expect("Failed to send preflight request");
+
+    assert_eq!(response.status(), 200);
+
+    // Check CORS preflight headers
+    let headers = response.headers();
+    assert!(headers.contains_key("access-control-allow-origin"));
+    assert!(headers.contains_key("access-control-allow-methods"));
+    assert!(headers.contains_key("access-control-allow-headers"));
+  }
+
+  #[tokio::test]
+  async fn test_nonexistent_endpoint() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    let response = client
+      .get(&format!("http://{}/nonexistent", addr))
+      .send()
+      .await
+      .expect("Failed to send request");
+
+    assert_eq!(response.status(), 404);
+  }
+
+  #[tokio::test]
+  async fn test_multiple_concurrent_requests() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Send multiple concurrent requests
+    let mut handles = vec![];
+    for _ in 0..10 {
+      let client = client.clone();
+      let addr = addr;
+      let handle = tokio::spawn(async move {
+        client
+          .get(&format!("http://{}/health", addr))
+          .send()
+          .await
+          .expect("Failed to send request")
+      });
+      handles.push(handle);
+    }
+
+    // Wait for all requests to complete
+    for handle in handles {
+      let response = handle.await.expect("Task failed");
+      assert_eq!(response.status(), 200);
+    }
+  }
+
+  #[tokio::test]
+  async fn test_different_http_methods() {
+    let (addr, _temp_dir) = setup_test_server().await;
+    let client = reqwest::Client::new();
+
+    // Test GET (should work)
+    let response = client
+      .get(&format!("http://{}/health", addr))
+      .send()
+      .await
+      .expect("Failed to send GET request");
+    assert_eq!(response.status(), 200);
+
+    // Test POST to health endpoint (should fail - only GET allowed)
+    let response = client
+      .post(&format!("http://{}/health", addr))
+      .send()
+      .await
+      .expect("Failed to send POST request");
+    assert_eq!(response.status(), 405); // Method Not Allowed
+  }
+}

--- a/crates/atlaspack_dev_server/src/main.rs
+++ b/crates/atlaspack_dev_server/src/main.rs
@@ -1,0 +1,11 @@
+use atlaspack_dev_server::start_dev_server;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+  println!("Starting Atlaspack Dev Server...");
+
+  // Start the dev server on port 3000
+  start_dev_server(Some(3000)).await?;
+
+  Ok(())
+}

--- a/packages/reporters/dev-server/src/Server.ts
+++ b/packages/reporters/dev-server/src/Server.ts
@@ -1,12 +1,6 @@
 // @ts-expect-error TS2307
 import type {DevServerOptions, Request, Response} from './types.js.flow';
-import type {
-  BuildSuccessEvent,
-  BundleGraph,
-  FilePath,
-  PluginOptions,
-  PackagedBundle,
-} from '@atlaspack/types';
+import type {FilePath, PluginOptions} from '@atlaspack/types';
 import type {Diagnostic} from '@atlaspack/diagnostic';
 import type {FileSystem} from '@atlaspack/fs';
 import type {HTTPServer, FormattedCodeFrame} from '@atlaspack/utils';
@@ -20,7 +14,6 @@ import {
   resolveConfig,
   readConfig,
   prettyDiagnostic,
-  relativePath,
 } from '@atlaspack/utils';
 import serverErrors from './serverErrors';
 import fs from 'fs';
@@ -36,6 +29,7 @@ import {URL, URLSearchParams} from 'url';
 import launchEditor from 'launch-editor';
 // @ts-expect-error TS7016
 import fresh from 'fresh';
+import {ServerDataProvider} from './ServerDataProvider';
 
 export function setHeaders(res: Response) {
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -75,11 +69,7 @@ export default class Server {
   middleware: Array<(req: Request, res: Response) => boolean>;
   options: DevServerOptions;
   rootPath: string;
-  bundleGraph: BundleGraph<PackagedBundle> | null;
-  requestBundle:
-    | ((bundle: PackagedBundle) => Promise<BuildSuccessEvent>)
-    | null
-    | undefined;
+  dataProvider: ServerDataProvider;
   errors: Array<{
     message: string;
     stack: string | null | undefined;
@@ -89,7 +79,7 @@ export default class Server {
   }> | null;
   stopServer: (() => Promise<void>) | null | undefined;
 
-  constructor(options: DevServerOptions) {
+  constructor(options: DevServerOptions, dataProvider: ServerDataProvider) {
     this.options = options;
     try {
       this.rootPath = new URL(options.publicUrl).pathname;
@@ -98,9 +88,8 @@ export default class Server {
     }
     this.pending = true;
     this.pendingRequests = [];
+    this.dataProvider = dataProvider;
     this.middleware = [];
-    this.bundleGraph = null;
-    this.requestBundle = null;
     this.errors = null;
   }
 
@@ -108,12 +97,7 @@ export default class Server {
     this.pending = true;
   }
 
-  buildSuccess(
-    bundleGraph: BundleGraph<PackagedBundle>,
-    requestBundle: (bundle: PackagedBundle) => Promise<BuildSuccessEvent>,
-  ) {
-    this.bundleGraph = bundleGraph;
-    this.requestBundle = requestBundle;
+  buildSuccess() {
     this.errors = null;
     this.pending = false;
 
@@ -193,72 +177,59 @@ export default class Server {
   }
 
   sendIndex(req: Request, res: Response) {
-    if (this.bundleGraph) {
-      // If the main asset is an HTML file, serve it
-      let htmlBundleFilePaths = this.bundleGraph
-        .getBundles()
-        .filter((bundle) => path.posix.extname(bundle.name) === '.html')
-        .map((bundle) => {
-          return `/${relativePath(
-            this.options.distDir,
-            bundle.filePath,
-            false,
-          )}`;
-        });
+    // If the main asset is an HTML file, serve it
+    let htmlBundleFilePaths = this.dataProvider.getHTMLBundleFilePaths();
 
-      let indexFilePath = null;
-      let {pathname: reqURL} = url.parse(req.originalUrl || req.url);
+    let indexFilePath = null;
+    let {pathname: reqURL} = url.parse(req.originalUrl || req.url);
 
-      if (!reqURL) {
-        reqURL = '/';
-      }
+    if (!reqURL) {
+      reqURL = '/';
+    }
 
-      if (htmlBundleFilePaths.length === 1) {
-        indexFilePath = htmlBundleFilePaths[0];
-      } else {
-        let bestMatch = null;
-        for (let bundle of htmlBundleFilePaths) {
-          let bundleDir = path.posix.dirname(bundle);
-          let bundleDirSubdir = bundleDir === '/' ? bundleDir : bundleDir + '/';
-          let withoutExtension = path.posix.basename(
-            bundle,
-            path.posix.extname(bundle),
-          );
-          let isIndex = withoutExtension === 'index';
+    if (htmlBundleFilePaths.length === 1) {
+      indexFilePath = htmlBundleFilePaths[0];
+    } else {
+      let bestMatch = null;
+      for (let bundle of htmlBundleFilePaths) {
+        let bundleDir = path.posix.dirname(bundle);
+        let bundleDirSubdir = bundleDir === '/' ? bundleDir : bundleDir + '/';
+        let withoutExtension = path.posix.basename(
+          bundle,
+          path.posix.extname(bundle),
+        );
+        let isIndex = withoutExtension === 'index';
 
-          let matchesIsIndex = null;
+        let matchesIsIndex = null;
+        if (
+          isIndex &&
+          (reqURL.startsWith(bundleDirSubdir) || reqURL === bundleDir)
+        ) {
+          // bundle is /bar/index.html and (/bar or something inside of /bar/** was requested was requested)
+          matchesIsIndex = true;
+        } else if (reqURL == path.posix.join(bundleDir, withoutExtension)) {
+          // bundle is /bar/foo.html and /bar/foo was requested
+          matchesIsIndex = false;
+        }
+        if (matchesIsIndex != null) {
+          let depth = bundle.match(SLASH_REGEX)?.length ?? 0;
           if (
-            isIndex &&
-            (reqURL.startsWith(bundleDirSubdir) || reqURL === bundleDir)
+            bestMatch == null ||
+            // This one is more specific (deeper)
+            bestMatch.depth < depth ||
+            // This one is just as deep, but the bundle name matches and not just index.html
+            (bestMatch.depth === depth && bestMatch.isIndex)
           ) {
-            // bundle is /bar/index.html and (/bar or something inside of /bar/** was requested was requested)
-            matchesIsIndex = true;
-          } else if (reqURL == path.posix.join(bundleDir, withoutExtension)) {
-            // bundle is /bar/foo.html and /bar/foo was requested
-            matchesIsIndex = false;
-          }
-          if (matchesIsIndex != null) {
-            let depth = bundle.match(SLASH_REGEX)?.length ?? 0;
-            if (
-              bestMatch == null ||
-              // This one is more specific (deeper)
-              bestMatch.depth < depth ||
-              // This one is just as deep, but the bundle name matches and not just index.html
-              (bestMatch.depth === depth && bestMatch.isIndex)
-            ) {
-              bestMatch = {bundle, depth, isIndex: matchesIsIndex};
-            }
+            bestMatch = {bundle, depth, isIndex: matchesIsIndex};
           }
         }
-        indexFilePath = bestMatch?.['bundle'] ?? htmlBundleFilePaths[0];
       }
+      indexFilePath = bestMatch?.['bundle'] ?? htmlBundleFilePaths[0];
+    }
 
-      if (indexFilePath) {
-        req.url = indexFilePath;
-        this.serveBundle(req, res, () => this.send404(req, res));
-      } else {
-        this.send404(req, res);
-      }
+    if (indexFilePath) {
+      req.url = indexFilePath;
+      this.serveBundle(req, res, () => this.send404(req, res));
     } else {
       this.send404(req, res);
     }
@@ -269,37 +240,20 @@ export default class Server {
     res: Response,
     next: NextFunction,
   ): Promise<void> {
-    let bundleGraph = this.bundleGraph;
-    if (bundleGraph) {
-      let {pathname} = url.parse(req.url);
-      if (!pathname) {
-        this.send500(req, res);
-        return;
-      }
+    const {pathname} = url.parse(req.url);
 
-      let requestedPath = path.normalize(pathname.slice(1));
-      let bundle = bundleGraph
-        .getBundles()
-        .find(
-          (b) =>
-            path.relative(this.options.distDir, b.filePath) === requestedPath,
-        );
-      if (!bundle) {
-        this.serveDist(req, res, next);
-        return;
-      }
+    if (!pathname) {
+      this.send500(req, res);
+      return;
+    }
 
-      invariant(this.requestBundle != null);
-      try {
-        await this.requestBundle(bundle);
-      } catch (err: any) {
-        this.send500(req, res);
-        return;
-      }
+    const requestedPath = path.normalize(pathname.slice(1));
 
-      this.serveDist(req, res, next);
-    } else {
-      this.send404(req, res);
+    try {
+      await this.dataProvider.requestBundle(requestedPath);
+      await this.serveDist(req, res, next);
+    } catch (err: unknown) {
+      this.send500(req, res);
     }
   }
 

--- a/packages/reporters/dev-server/src/ServerDataProvider.ts
+++ b/packages/reporters/dev-server/src/ServerDataProvider.ts
@@ -1,0 +1,7 @@
+/**
+ * API the dev-server requires from the main application.
+ */
+export interface ServerDataProvider {
+  getHTMLBundleFilePaths(): string[];
+  requestBundle(requestedPath: string): Promise<'requested' | 'not-found'>;
+}

--- a/packages/reporters/dev-server/src/StaticServerDataProvider.ts
+++ b/packages/reporters/dev-server/src/StaticServerDataProvider.ts
@@ -1,0 +1,61 @@
+import type {
+  BundleGraph,
+  PackagedBundle,
+  BuildSuccessEvent,
+} from '@atlaspack/types';
+import path from 'path';
+
+import {ServerDataProvider} from './ServerDataProvider';
+
+/**
+ * An implementation of ServerDataProvider provides data from a direct `bundleGraph`
+ * and `requestBundle` function.
+ */
+export class StaticServerDataProvider implements ServerDataProvider {
+  distDir: string;
+  bundleGraph: BundleGraph<PackagedBundle> | null = null;
+  requestBundleFn:
+    | ((bundle: PackagedBundle) => Promise<BuildSuccessEvent>)
+    | null = null;
+
+  constructor(distDir: string) {
+    this.distDir = distDir;
+  }
+
+  getHTMLBundleFilePaths(): string[] {
+    return (
+      this.bundleGraph
+        ?.getBundles()
+        .filter((b) => path.posix.extname(b.name) === '.html')
+        .map((b) => path.relative(this.distDir, b.filePath)) ?? []
+    );
+  }
+
+  async requestBundle(
+    requestedPath: string,
+  ): Promise<'requested' | 'not-found'> {
+    const bundle = this.bundleGraph
+      ?.getBundles()
+      .find((b) => path.relative(this.distDir, b.filePath) === requestedPath);
+
+    if (!bundle) {
+      return 'not-found';
+    }
+
+    if (!this.requestBundleFn) {
+      return 'not-found';
+    }
+
+    await this.requestBundleFn(bundle);
+
+    return 'requested';
+  }
+
+  update(
+    bundleGraph: BundleGraph<PackagedBundle>,
+    requestBundleFn: (bundle: PackagedBundle) => Promise<BuildSuccessEvent>,
+  ) {
+    this.bundleGraph = bundleGraph;
+    this.requestBundleFn = requestBundleFn;
+  }
+}


### PR DESCRIPTION
This diff moves some dev-server code around so that the interface between the
dev-server and bundler data is more clearly determined.

This will help with refactoring the dev-server in rust / using multi-threading
which will come in a second diff.

[no-changeset] no change in behaviour

Test Plan: Run e2e tests
