### PR TITLE
Force all entry assets to be wrapped

### DIFF
--- a/.changeset/lucky-ties-retire.md
+++ b/.changeset/lucky-ties-retire.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/packager-js': patch
+---
+
+Fix the scope hoisting improvements feature by making all entry assets of a bundle
+wrapped, which means there is no top level scope.


### PR DESCRIPTION
## Motivation

We made some [changes to scope hoisting] a little while ago to allow for hoisting assets within other wrapped assets where it was safe to do so.

It looks like that process gets a bit confused when the asset can also go into the top level scope.

[changes to scope hoisting]: https://github.com/atlassian-labs/atlaspack/pull/627

## Changes

It's much simpler and a more robust if we just don't have a top level scope, and everything is a parcel require at some level. In this change, we set all entry assets of the bundle to be wrapped, and then let the subsequent children be hoisted within.

## Checklist

- [x] There is a changeset for this change, or one is not required