### PR TITLE
Atlaspack flags - use ATLASPACK_BUILD_ENV instead of NODE_ENV

### DIFF
--- a/.changeset/shiny-pandas-develop.md
+++ b/.changeset/shiny-pandas-develop.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/feature-flags': minor
+---
+
+Use ATLASPACK_BUILD_ENV instead of NODE_ENV to determine if Atlaspack is being run in the context of Atlaspack tests.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test:js": "yarn test:js:unit && yarn test:integration",
     "test:js:coverage": "yarn nyc yarn test:js:unit",
     "test:js:coverage:report": "yarn nyc report --reporter=html-spa",
-    "test:js:unit": "cross-env NODE_ENV=test ATLASPACK_REGISTER_USE_SRC=true mocha --timeout 5000",
+    "test:js:unit": "cross-env NODE_ENV=test ATLASPACK_REGISTER_USE_SRC=true ATLASPACK_BUILD_ENV=test mocha --timeout 5000",
     "test:unit": "yarn test:js:unit && cargo test",
     "canary:release": "lerna publish -y --canary --preid canary --dist-tag=canary --exact --force-publish=* --no-push",
     "tag:prerelease": "lerna version --exact --force-publish=* --no-git-tag-version --no-push",

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -56,7 +56,7 @@ export const DEFAULT_FEATURE_FLAGS = {
    * - Remove "large file blob" writes
    * - Reduce size of the caches by deduplicating data
    */
-  cachePerformanceImprovements: process.env.NODE_ENV === 'test',
+  cachePerformanceImprovements: process.env.ATLASPACK_BUILD_ENV === 'test',
 
   /**
    * Deduplicates environments across cache / memory entities
@@ -124,13 +124,13 @@ export const DEFAULT_FEATURE_FLAGS = {
    * properties (e.g. `CONSTANTS['api_' + endpoint`]) would not be recognised as
    * being used, and thus not included in the bundle.
    */
-  unusedComputedPropertyFix: process.env.NODE_ENV === 'test',
+  unusedComputedPropertyFix: process.env.ATLASPACK_BUILD_ENV === 'test',
 
   /**
    * Fixes an issue where star re-exports of empty files (usually occurring in compiled typescript libraries)
    * could cause exports to undefined at runtime.
    */
-  emptyFileStarRexportFix: process.env.NODE_ENV === 'test',
+  emptyFileStarRexportFix: process.env.ATLASPACK_BUILD_ENV === 'test',
 
   /**
    * Enables the new packaging progress CLI experience
@@ -141,7 +141,7 @@ export const DEFAULT_FEATURE_FLAGS = {
    * Adds support for `webpackChunkName` comments in dynamic imports.
    * Imports with the same `webpackChunkName` will be bundled together.
    */
-  supportWebpackChunkName: process.env.NODE_ENV === 'test',
+  supportWebpackChunkName: process.env.ATLASPACK_BUILD_ENV === 'test',
 
   /**
    * Enable a change to the conditional bundling loader to use a fallback bundle loading if the expected scripts aren't found
@@ -155,12 +155,12 @@ export const DEFAULT_FEATURE_FLAGS = {
    * Enable the new incremental bundling versioning logic which determines whether
    * a full bundling pass is required based on the AssetGraph's bundlingVersion.
    */
-  incrementalBundlingVersioning: process.env.NODE_ENV === 'test',
+  incrementalBundlingVersioning: process.env.ATLASPACK_BUILD_ENV === 'test',
   /**
    * Allow for the use of `data-atlaspack-isolated` on script tags in HTML to produce
    * inline scripts that are build as "isolated" bundles.
    */
-  inlineIsolatedScripts: process.env.NODE_ENV === 'test',
+  inlineIsolatedScripts: process.env.ATLASPACK_BUILD_ENV === 'test',
 };
 
 export type FeatureFlags = typeof DEFAULT_FEATURE_FLAGS;


### PR DESCRIPTION
Use `ATLASPACK_BUILD_ENV` instead of `NODE_ENV` to determine if Atlaspack is being run in the context of Atlaspack tests.

We currently use the `ATLASPACK_BUILD_ENV` environment variable to describe the build environment context (production, development, test).

Documented here:
https://github.com/atlassian-labs/atlaspack/blob/main/docs/cli/environment-variables.md#atlaspack_build_env

When Atlaspack is running tests, we want new flags to default to true. This way, we can ensure rolling out new flags is not incompatible with existing functionality.

Note: Also added `ATLASPACK_BUILD_ENV=test` to the `test:js:unit` script.


## Checklist

- [x] There is a changeset for this change, or one is not required

