### PR TITLE
Add configurable async bundle merging

### DIFF
--- a/.changeset/cyan-radios-jog.md
+++ b/.changeset/cyan-radios-jog.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/feature-flags': minor
+'@atlaspack/bundler-default': minor
+'@atlaspack/utils': minor
+---
+
+Add configurable async bundle merging and redundant shared bundle removal behind a feature flag.

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -24,8 +24,10 @@
     "@atlaspack/plugin": "2.14.27",
     "@atlaspack/rust": "3.6.2",
     "@atlaspack/utils": "2.18.4",
+    "@types/sorted-array-functions": "^1.0.0",
     "nullthrows": "^1.1.1",
-    "many-keys-map": "^1.0.3"
+    "many-keys-map": "^1.0.3",
+    "sorted-array-functions": "^1.0.0"
   },
   "scripts": {
     "check-ts": "tsc --emitDeclarationOnly --rootDir src",

--- a/packages/bundlers/default/src/idealGraph.ts
+++ b/packages/bundlers/default/src/idealGraph.ts
@@ -1731,7 +1731,7 @@ export function createIdealGraph(
         let b = mergeCandidates[j];
         if (a === b) continue; // Skip self-comparison
 
-        candidates.push(getAsyncBundleMergeOverlap(a, b, maxOverfetchSize));
+        candidates.push(scoreAsyncMerge(a, b, maxOverfetchSize));
       }
     }
 
@@ -1809,11 +1809,7 @@ export function createIdealGraph(
         continue;
       }
 
-      let candidate = getAsyncBundleMergeOverlap(
-        currentA,
-        currentB,
-        maxOverfetchSize,
-      );
+      let candidate = scoreAsyncMerge(currentA, currentB, maxOverfetchSize);
 
       if (candidate.overfetchSize <= maxOverfetchSize && candidate.score > 0) {
         sortedArray.add(candidates, candidate, sortByScore);
@@ -1876,7 +1872,7 @@ export function createIdealGraph(
     score: number;
     bundleIds: number[];
   }
-  function getAsyncBundleMergeOverlap(
+  function scoreAsyncMerge(
     bundleAId: NodeId,
     bundleBId: NodeId,
     maxOverfetchSize: number,
@@ -1887,20 +1883,12 @@ export function createIdealGraph(
     let overlapSize = 0;
     let overfetchSize = 0;
 
-    let removedBundleSharedBundlesA = new Set<NodeId>();
-    let removedBundleSharedBundlesB = new Set<NodeId>();
-
     for (let bundleId of new Set([...bundleGroupA, ...bundleGroupB])) {
       let bundle = getBundle(bundleId);
 
       if (bundleGroupA.has(bundleId) && bundleGroupB.has(bundleId)) {
         overlapSize += bundle.size;
       } else {
-        if (bundleGroupB.has(bundleId)) {
-          removedBundleSharedBundlesB.add(bundleId);
-        } else if (bundleGroupA.has(bundleId)) {
-          removedBundleSharedBundlesA.add(bundleId);
-        }
         overfetchSize += bundle.size;
       }
     }

--- a/packages/bundlers/default/src/idealGraph.ts
+++ b/packages/bundlers/default/src/idealGraph.ts
@@ -1717,6 +1717,7 @@ export function createIdealGraph(
       if (
         bundleRootBundle.type === 'js' &&
         bundleRootBundle.bundleBehavior !== 'inline' &&
+        bundleRootBundle.bundleBehavior !== 'inlineIsolated' &&
         bundleRootBundle.size <= bundleSize &&
         !isIgnored(bundleRootBundle)
       ) {

--- a/packages/bundlers/default/src/idealGraph.ts
+++ b/packages/bundlers/default/src/idealGraph.ts
@@ -1284,15 +1284,14 @@ export function createIdealGraph(
     }
   }
 
+  // Step merge async bundles that meet the configured params
   if (config.asyncBundleMerge) {
-    // Step merge async bundles that meet the overlap threshold
     mergeAsyncBundles(config.asyncBundleMerge);
   }
 
+  // Step merge shared bundles that meet the configured params
   if (config.sharedBundleMerge && config.sharedBundleMerge.length > 0) {
-    // Step merge shared bundles that meet the overlap threshold
-    // This step is skipped by default as the threshold defaults to 1
-    mergeOverlapBundles(config.sharedBundleMerge);
+    mergeSharedBundles(config.sharedBundleMerge);
   }
 
   // Step Merge Share Bundles: Merge any shared bundles under the minimum bundle size back into
@@ -1621,7 +1620,7 @@ export function createIdealGraph(
     bundleGraph.removeNode(bundleToRemoveId);
   }
 
-  function mergeOverlapBundles(mergeConfig: SharedBundleMergeCandidates) {
+  function mergeSharedBundles(mergeConfig: SharedBundleMergeCandidates) {
     // Find all shared bundles
     let sharedBundles = new Set<NodeId>();
     bundleGraph.traverse((nodeId) => {

--- a/packages/bundlers/default/src/stats.ts
+++ b/packages/bundlers/default/src/stats.ts
@@ -1,0 +1,97 @@
+import {relative} from 'path';
+import {NodeId} from '@atlaspack/graph';
+import {DefaultMap, debugTools} from '@atlaspack/utils';
+
+import {Bundle} from './idealGraph';
+
+interface MergedBundle {
+  id: NodeId;
+  reason: string;
+}
+
+export class Stats {
+  projectRoot: string;
+  merges: DefaultMap<NodeId, MergedBundle[]> = new DefaultMap(() => []);
+
+  constructor(projectRoot: string) {
+    this.projectRoot = projectRoot;
+  }
+
+  trackMerge(bundleToKeep: NodeId, bundleToRemove: NodeId, reason: string) {
+    if (!debugTools['bundle-stats']) {
+      return;
+    }
+
+    this.merges
+      .get(bundleToKeep)
+      .push(...this.merges.get(bundleToRemove), {id: bundleToRemove, reason});
+    this.merges.delete(bundleToRemove);
+  }
+
+  getBundleLabel(bundle: Bundle): string {
+    if (bundle.manualSharedBundle) {
+      return bundle.manualSharedBundle;
+    }
+
+    if (bundle.mainEntryAsset) {
+      let relativePath = relative(
+        this.projectRoot,
+        bundle.mainEntryAsset.filePath,
+      );
+
+      if (relativePath.length > 100) {
+        relativePath =
+          relativePath.slice(0, 50) + '...' + relativePath.slice(-50);
+      }
+
+      return relativePath;
+    }
+
+    return `shared`;
+  }
+
+  report(getBundle: (bundleId: NodeId) => Bundle | null | undefined): void {
+    if (!debugTools['bundle-stats']) {
+      return;
+    }
+
+    type MergeResult = Record<string, string | number>;
+    let mergeResults: Array<MergeResult> = [];
+
+    let totals: Record<string, string | number> = {
+      label: 'Totals',
+      merges: 0,
+    };
+
+    for (let [bundleId, mergedBundles] of this.merges) {
+      let bundle = getBundle(bundleId);
+      if (!bundle) {
+        continue;
+      }
+
+      let result: MergeResult = {
+        label: this.getBundleLabel(bundle),
+        size: bundle.size,
+        merges: mergedBundles.length,
+      };
+
+      for (let merged of mergedBundles) {
+        result[merged.reason] = ((result[merged.reason] as number) || 0) + 1;
+        totals[merged.reason] = ((totals[merged.reason] as number) || 0) + 1;
+      }
+
+      (totals.merges as number) += mergedBundles.length;
+      mergeResults.push(result);
+    }
+
+    mergeResults.sort((a, b) => {
+      // Sort by bundle size descending
+      return (b.size as number) - (a.size as number);
+    });
+
+    mergeResults.push(totals);
+
+    // eslint-disable-next-line no-console
+    console.table(mergeResults);
+  }
+}

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -156,6 +156,12 @@ export const DEFAULT_FEATURE_FLAGS = {
    * a full bundling pass is required based on the AssetGraph's bundlingVersion.
    */
   incrementalBundlingVersioning: process.env.ATLASPACK_BUILD_ENV === 'test',
+
+  /**
+   * Remove redundant shared bundles that are no longer required after merging
+   * async bundles.
+   */
+  removeRedundantSharedBundles: process.env.ATLASPACK_BUILD_ENV === 'test',
 };
 
 export type FeatureFlags = typeof DEFAULT_FEATURE_FLAGS;

--- a/packages/core/integration-tests/test/bundler.ts
+++ b/packages/core/integration-tests/test/bundler.ts
@@ -2891,7 +2891,7 @@ describe('bundler', function () {
 
   it('should ignore configured bundles from async merge', async () => {
     await fsFixture(overlayFS, __dirname)`
-      merge-async-bundles
+      merge-async-bundles-ignore
         index.js:
           import('./async-1.js');
           import('./async-2.js');
@@ -2920,7 +2920,7 @@ describe('bundler', function () {
     `;
 
     const b = await bundle(
-      [path.join(__dirname, 'merge-async-bundles/index.js')],
+      [path.join(__dirname, 'merge-async-bundles-ignore/index.js')],
       {
         inputFS: overlayFS,
       },

--- a/packages/core/integration-tests/test/bundler.ts
+++ b/packages/core/integration-tests/test/bundler.ts
@@ -2789,10 +2789,14 @@ describe('bundler', function () {
     async () => {
       await fsFixture(overlayFS, __dirname)`
       merge-webpack-chunk-name
+        index.html:
+          <script type="module" src="./index.js"></script>
         index.js:
-          import(/* webpackChunkName: "shared" */ './async-1.js');
-          import(/* webpackChunkName: "shared" */ './async-2.js');
-          import(/* webpackChunkName: "shared-two" */ './async-3.js');
+          sideEffectNoop(Promise.all([
+            import(/* webpackChunkName: "shared" */ './async-1.js'),
+            import(/* webpackChunkName: "shared" */ './async-2.js'),
+            import(/* webpackChunkName: "shared-two" */ './async-3.js')
+          ]));
 
         async-1.js:
           export const async1 = 'async1';
@@ -2805,7 +2809,7 @@ describe('bundler', function () {
     `;
 
       const b = await bundle(
-        [path.join(__dirname, 'merge-webpack-chunk-name/index.js')],
+        [path.join(__dirname, 'merge-webpack-chunk-name/index.html')],
         {
           inputFS: overlayFS,
           featureFlags: {
@@ -2815,6 +2819,7 @@ describe('bundler', function () {
       );
 
       assertBundles(b, [
+        {assets: ['index.html']},
         {
           assets: [
             'index.js',
@@ -2838,10 +2843,15 @@ describe('bundler', function () {
   it('should merge small async bundles together when configured', async () => {
     await fsFixture(overlayFS, __dirname)`
       merge-async-bundles
+        index.html:
+          <script type="module" src="./index.js"></script>
+
         index.js:
-          import('./async-1.js');
-          import('./async-2.js');
-          import('./async-3.js');
+          sideEffectNoop(Promise.all([
+            import('./async-1.js'),
+            import('./async-2.js'),
+            import('./async-3.js')
+          ]));
 
         async-1.js:
           export const async1 = 'async1';
@@ -2865,19 +2875,17 @@ describe('bundler', function () {
     `;
 
     const b = await bundle(
-      [path.join(__dirname, 'merge-async-bundles/index.js')],
+      [path.join(__dirname, 'merge-async-bundles/index.html')],
       {
         inputFS: overlayFS,
       },
     );
 
     assertBundles(b, [
+      {assets: ['index.html']},
       {
         assets: [
           'index.js',
-          'bundle-url.js',
-          'cacheLoader.js',
-          'js-loader.js',
           'async-1.js',
           'async-2.js',
           'async-3.js',
@@ -2892,10 +2900,15 @@ describe('bundler', function () {
   it('should ignore configured bundles from async merge', async () => {
     await fsFixture(overlayFS, __dirname)`
       merge-async-bundles-ignore
+        index.html:
+          <script type="module" src="./index.js"></script>
+
         index.js:
-          import('./async-1.js');
-          import('./async-2.js');
-          import('./async-3.js');
+          sideEffectNoop(Promise.all([
+            import('./async-1.js'),
+            import('./async-2.js'),
+            import('./async-3.js')
+          ]));
 
         async-1.js:
           export const async1 = 'async1';
@@ -2920,13 +2933,14 @@ describe('bundler', function () {
     `;
 
     const b = await bundle(
-      [path.join(__dirname, 'merge-async-bundles-ignore/index.js')],
+      [path.join(__dirname, 'merge-async-bundles-ignore/index.html')],
       {
         inputFS: overlayFS,
       },
     );
 
     assertBundles(b, [
+      {assets: ['index.html']},
       {
         assets: ['index.js', 'bundle-url.js', 'cacheLoader.js', 'js-loader.js'],
       },

--- a/packages/core/utils/src/debug-tools.ts
+++ b/packages/core/utils/src/debug-tools.ts
@@ -12,11 +12,13 @@
 type DebugTools = {
   ['asset-file-names-in-output']: boolean;
   ['simple-cli-reporter']: boolean;
+  ['bundle-stats']: boolean;
 };
 
 export let debugTools: DebugTools = {
   'asset-file-names-in-output': false,
   'simple-cli-reporter': false,
+  'bundle-stats': false,
 };
 
 const envVarValue = process.env.ATLASPACK_DEBUG_TOOLS ?? '';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4316,6 +4316,11 @@
   resolved "https://registry.yarnpkg.com/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz#5fd3592ff10c1e9695d377020c033116cc2889f2"
   integrity sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==
 
+"@types/sorted-array-functions@^1.0.0":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/sorted-array-functions/-/sorted-array-functions-1.3.3.tgz#c7e9902b4677dfd0693e4658d85a3ccb35b6e091"
+  integrity sha512-Znd+o08cWzYInbmSyoeK7D1aet3zFj346zuL0QWAnKVg3Sp57azvCzbxBfnxjDPNyHqOhzvK79K9sEV97BX5iQ==
+
 "@types/stack-utils@^2.0.0":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
@@ -16200,6 +16205,11 @@ sort-keys@^2.0.0:
   integrity sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=
   dependencies:
     is-plain-obj "^1.0.0"
+
+sorted-array-functions@^1.0.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/sorted-array-functions/-/sorted-array-functions-1.3.0.tgz#8605695563294dffb2c9796d602bd8459f7a0dd5"
+  integrity sha512-2sqgzeFlid6N4Z2fUQ1cvFmTOLRi/sEDzSQ0OKYchqgoPmQBVyM3959qYx3fpS6Esef80KjmpgPeEr028dP3OA==
 
 source-map-js@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This PR introduces 3 related things:
- Configurable async bundle merging for reducing total network requests
- Removal of redundant shared bundles when merging async bundles together 
- A new debug tool for outputting a report from the bundler results 

# Async bundle merging 

This PR adds a new bundler feature that attempts to reduce the amount of small async bundles in the output by merging them together. This is achieved by scoring all the candidates for how well they match and merging the best candidates until they meet the max overfetch size or no more good candidates are available. 

To enable the feature you can provide a new bundle config `asyncBundleMerge` with the following settings.

```
"@atlaspack/bundler-default": {
    "asyncBundleMerge": {
        "bundleSize": 5000,
        "maxOverfetchSize": 50000,
        "ignore": ["assets-to-never-merge/**"]
    }
}
```

| Name | Description | Required |
| - | - | - | 
| `bundleSize` | The max threshold for determining which bundles to merge. e.g. Merge all bundles smaller than 5000 bytes | true |
| `maxOverfetchSize` | The maximum amount of potentially overfetched bytes to introduced by a merged bundle | true |
| `ignore` | An array of file path globs to ignore from merging | false |

# Redundant shared bundle merging

When merging async bundles together (via webpack chunk names or the new configurable merging), it's possible to encounter a situation where two shared bundles now have identical source bundles, which means they will be loaded together in all cases. This means it's a free network request to claim back with essentially zero trade-off. This feature is currently flagged behind `removeRedundantSharedBundles`.

# Bundle stats debug tool

I've added a new [debug tool](https://github.com/atlassian-labs/atlaspack/pull/659) for outputting a report from the bundling algorithm. We can add to this over time, but right now it outputs all the merged bundles, how many times they were merged and for which reason (async merge, webpack chunk name, shared bundle merge, etc). 

<img width="2068" height="549" alt="image" src="https://github.com/user-attachments/assets/52e6b83e-4cf3-4ffa-8c13-b9bbe5637d2a" />


## Checklist

- [x] Existing or new tests cover this change
- [ ] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
