### PR TITLE
Fix low hanging ts expect errors 1/n

### DIFF
--- a/.changeset/four-frogs-mix.md
+++ b/.changeset/four-frogs-mix.md
@@ -1,0 +1,11 @@
+---
+'@atlaspack/watcher-watchman-js': patch
+'@atlaspack/transformer-typescript-tsc': patch
+'@atlaspack/transformer-webextension': patch
+'@atlaspack/transformer-webmanifest': patch
+'@atlaspack/runtime-service-worker': patch
+'@atlaspack/runtime-webextension': patch
+'@atlaspack/transformer-yaml': patch
+---
+
+Type fixes

--- a/packages/runtimes/service-worker/package.json
+++ b/packages/runtimes/service-worker/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@atlaspack/plugin": "2.14.27",
     "@atlaspack/utils": "2.18.4",
+    "@atlaspack/types": "2.15.17",
     "nullthrows": "^1.1.1"
   },
   "type": "commonjs",

--- a/packages/runtimes/service-worker/src/ServiceWorkerRuntime.ts
+++ b/packages/runtimes/service-worker/src/ServiceWorkerRuntime.ts
@@ -1,5 +1,6 @@
 import {Runtime} from '@atlaspack/plugin';
 import {urlJoin} from '@atlaspack/utils';
+import type {Asset} from '@atlaspack/types';
 
 export default new Runtime({
   apply({bundle, bundleGraph}) {
@@ -7,7 +8,7 @@ export default new Runtime({
       return [];
     }
 
-    let asset = bundle.traverse((node, _, actions) => {
+    let asset = bundle.traverse<Asset>((node, _, actions) => {
       if (
         node.type === 'dependency' &&
         node.value.specifier === '@atlaspack/service-worker' &&
@@ -39,7 +40,6 @@ _register(manifest, version);
 
     return [
       {
-        // @ts-expect-error TS2339
         filePath: asset.filePath,
         code,
         isEntry: true,

--- a/packages/runtimes/webextension/package.json
+++ b/packages/runtimes/webextension/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@atlaspack/plugin": "2.14.27",
     "@atlaspack/utils": "2.18.4",
+    "@atlaspack/types": "2.15.17",
     "nullthrows": "^1.1.1"
   },
   "type": "commonjs",

--- a/packages/runtimes/webextension/src/WebExtensionRuntime.ts
+++ b/packages/runtimes/webextension/src/WebExtensionRuntime.ts
@@ -1,5 +1,6 @@
 import {Runtime} from '@atlaspack/plugin';
 import {replaceURLReferences} from '@atlaspack/utils';
+import type {Dependency} from '@atlaspack/types';
 import nullthrows from 'nullthrows';
 import fs from 'fs';
 import path from 'path';
@@ -40,7 +41,6 @@ export default new Runtime({
         nullthrows(
           entry
             ?.getDependencies()
-            // @ts-expect-error TS2304
             .find((dep: Dependency) => dep.id === insertDep),
         ),
         nullthrows(manifest),

--- a/packages/transformers/typescript-tsc/src/TSCTransformer.ts
+++ b/packages/transformers/typescript-tsc/src/TSCTransformer.ts
@@ -44,7 +44,7 @@ export default new Transformer({
       let map = new SourceMap(options.projectRoot);
       map.addVLQMap(JSON.parse(sourceMapText));
       if (originalMap) {
-        // @ts-expect-error TS2345
+        // @ts-expect-error TS2345 - the types are wrong, `extends` accepts a `SourceMap` or a `Buffer`
         map.extends(originalMap);
       }
       asset.setMap(map);

--- a/packages/transformers/webextension/src/WebExtensionTransformer.ts
+++ b/packages/transformers/webextension/src/WebExtensionTransformer.ts
@@ -51,7 +51,7 @@ async function collectDependencies(
   delete program.$schema;
   if (program.default_locale) {
     const locales = path.join(assetDir, '_locales');
-    let err = !(await fs.exists(locales))
+    let err: 'key' | 'value' | null = !(await fs.exists(locales))
       ? 'key'
       : !(await fs.exists(
             path.join(locales, program.default_locale, 'messages.json'),
@@ -69,7 +69,6 @@ async function collectDependencies(
                 filePath,
                 codeHighlights: [
                   {
-                    // @ts-expect-error TS2345
                     ...getJSONHighlightLocation(ptrs['/default_locale'], err),
                     message: md`Localization ${
                       err == 'value'

--- a/packages/transformers/webmanifest/src/WebManifestTransformer.ts
+++ b/packages/transformers/webmanifest/src/WebManifestTransformer.ts
@@ -14,8 +14,7 @@ const RESOURCES_SCHEMA = {
     properties: {
       src: {
         type: 'string',
-        // @ts-expect-error TS7006
-        __validate: (s) => {
+        __validate: (s: string) => {
           if (s.length === 0) {
             return 'Must not be empty';
           }

--- a/packages/transformers/yaml/package.json
+++ b/packages/transformers/yaml/package.json
@@ -17,7 +17,8 @@
   },
   "dependencies": {
     "@atlaspack/plugin": "2.14.27",
-    "js-yaml": "^3.10.0"
+    "js-yaml": "^3.10.0",
+    "@types/js-yaml": "^3.10.0"
   },
   "type": "commonjs",
   "scripts": {

--- a/packages/transformers/yaml/src/YAMLTransformer.ts
+++ b/packages/transformers/yaml/src/YAMLTransformer.ts
@@ -1,5 +1,4 @@
 import {Transformer} from '@atlaspack/plugin';
-// @ts-expect-error TS7016
 import yaml from 'js-yaml';
 
 export default new Transformer({

--- a/packages/utils/atlaspack-watcher-watchman-js/package.json
+++ b/packages/utils/atlaspack-watcher-watchman-js/package.json
@@ -12,7 +12,8 @@
     "@atlaspack/logger": "2.14.19",
     "@atlaspack/utils": "2.18.4",
     "@parcel/watcher": "^2.4.1",
-    "fb-watchman": "^2.0.2"
+    "fb-watchman": "^2.0.2",
+    "@types/fb-watchman": "^2.0.2"
   },
   "type": "commonjs",
   "scripts": {

--- a/packages/utils/atlaspack-watcher-watchman-js/src/wrapper.ts
+++ b/packages/utils/atlaspack-watcher-watchman-js/src/wrapper.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 import * as path from 'path';
-// @ts-expect-error TS7016
+
 import * as watchman from 'fb-watchman';
 import {isGlob} from '@atlaspack/utils';
 import logger from '@atlaspack/logger';

--- a/packages/utils/atlaspack-watcher-watchman-js/src/wrapper.ts
+++ b/packages/utils/atlaspack-watcher-watchman-js/src/wrapper.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-
 import * as watchman from 'fb-watchman';
 import {isGlob} from '@atlaspack/utils';
 import logger from '@atlaspack/logger';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4168,6 +4168,11 @@
   resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.7.tgz#226a9e31680835a6188e887f3988e60c04d3f6a3"
   integrity sha512-aLkWa0C0vO5b4Sr798E26QgOkss68Un0bLjs7u9qxzPT5CG+8DuNTffWES58YzJs3hrVAOs1wonycqEBqNJubA==
 
+"@types/js-yaml@^3.10.0":
+  version "3.12.10"
+  resolved "https://registry.yarnpkg.com/@types/js-yaml/-/js-yaml-3.12.10.tgz#4d80d0c7dfc570eb4f0be280cb2d67789f977ba5"
+  integrity sha512-/Mtaq/wf+HxXpvhzFYzrzCqNRcA958sW++7JOFC8nPrZcvfi/TrzOaaGbvt27ltJB2NQbHVAg5a1wUCsyMH7NA==
+
 "@types/json-schema@^7.0.9":
   version "7.0.12"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.12.tgz#d70faba7039d5fca54c83c7dbab41051d2b6f6cb"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4097,6 +4097,13 @@
   resolved "https://registry.yarnpkg.com/@types/ejs/-/ejs-3.1.5.tgz#49d738257cc73bafe45c13cb8ff240683b4d5117"
   integrity sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg==
 
+"@types/fb-watchman@^2.0.2":
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/@types/fb-watchman/-/fb-watchman-2.0.5.tgz#4dcdcf978ecb985fff9c22df98a6e68702792aca"
+  integrity sha512-TSPpgMo7bmDpdEL/SwpvYDXv+/y/m0LpBmBpU1jZcef2wpQ+rjgSdrOy+cLG4wBRQKMlQ0CQ/l11afqopLkpaA==
+  dependencies:
+    "@types/node" "*"
+
 "@types/fresh@^0.5.3":
   version "0.5.3"
   resolved "https://registry.yarnpkg.com/@types/fresh/-/fresh-0.5.3.tgz#a5f79a6b61b72e6d4eba153bb9033495c40d12d6"
@@ -16486,7 +16493,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16511,15 +16518,6 @@ string-width@^1.0.1, string-width@^1.0.2:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -16608,7 +16606,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16628,13 +16626,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -18266,7 +18257,7 @@ workerpool@6.1.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
   integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18287,15 +18278,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Fixes a few low hanging `@ts-expect-errors` (identified by a quick script to show packages ordered by how many ts-expect-errors, and starting from the bottom).

## Changes

Removed `@ts-expect-error` annotation, fixed `@ts-expect-error`.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
