### PR TITLE
Use stable names for single file output bundles

### DIFF
--- a/.changeset/popular-donuts-smell.md
+++ b/.changeset/popular-donuts-smell.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/feature-flags': patch
+'@atlaspack/bundler-default': patch
+---
+
+Adds a new feature flag `singleFileOutputStableName` - when enabled, bundles produced by the experimental single file output bundler will have stable names (i.e. no hash).

--- a/packages/bundlers/default/src/MonolithicBundler.ts
+++ b/packages/bundlers/default/src/MonolithicBundler.ts
@@ -3,6 +3,8 @@ import type {
   Dependency,
   MutableBundleGraph,
 } from '@atlaspack/types-internal';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
+
 import nullthrows from 'nullthrows';
 
 export function addJSMonolithBundle(
@@ -16,7 +18,11 @@ export function addJSMonolithBundle(
   );
 
   // Create a single bundle to hold all JS assets
-  let bundle = bundleGraph.createBundle({entryAsset, target});
+  let bundle = bundleGraph.createBundle({
+    entryAsset,
+    target,
+    needsStableName: getFeatureFlag('singleFileOutputStableName'),
+  });
 
   bundleGraph.traverse(
     (node, _, actions) => {

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -162,6 +162,11 @@ export const DEFAULT_FEATURE_FLAGS = {
    * async bundles.
    */
   removeRedundantSharedBundles: process.env.ATLASPACK_BUILD_ENV === 'test',
+
+  /**
+   * When enabled, single file output bundles have a stable name
+   */
+  singleFileOutputStableName: process.env.ATLASPACK_BUILD_ENV === 'test',
 };
 
 export type FeatureFlags = typeof DEFAULT_FEATURE_FLAGS;

--- a/packages/core/integration-tests/test/monolithic-bundler.ts
+++ b/packages/core/integration-tests/test/monolithic-bundler.ts
@@ -198,4 +198,32 @@ describe('monolithic bundler', function () {
     assert(result.output.startsWith('File text: !function('));
     assert(result.output.includes('Hello world'));
   });
+
+  it.v2('should produce a bundle with a stable name', async function () {
+    await fsFixture(overlayFS, __dirname)`
+      stable-name
+        a.js:
+          export const a = 'a';
+        yarn.lock: {}
+    `;
+
+    let bundleResult = await bundle(path.join(__dirname, 'stable-name/a.js'), {
+      defaultTargetOptions: {shouldScopeHoist: false},
+      inputFS: overlayFS,
+      mode: 'production',
+      targets: {
+        'stable-name': {
+          distDir: 'dist-stable-name',
+          __unstable_singleFileOutput: true,
+        },
+      },
+    });
+
+    const bundles = bundleResult.getBundles();
+    assert(bundles.length === 1);
+    assert(
+      bundles[0].name === 'a.js',
+      'Expected bundle name to be a.js, but it was ' + bundles[0].name,
+    );
+  });
 });


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

The default bundler will ensure any entry bundles have a stable name (i.e. with no hash in it). The "monolithic bundler" used when the `__unstable_singleFileOutput` option is enabled currently doesn't do this, so entry JS bundles will have a hash in their name.. the environment these bundles are used in does not expect this hash.

## Changes

Added a new feature flag `singleFileOutputStableName`, when enabled will set the `needsStableName` to true when creating the entry bundles.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
