### PR TITLE
Fix Atlaspack link when using against source files

### DIFF
--- a/.changeset/sixty-bananas-poke.md
+++ b/.changeset/sixty-bananas-poke.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/package-manager': patch
+---
+
+Fix using Atlaspack linked with source files


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Changes

Ever since moving to TypeScript, Atlaspack link has not worked against source files directly. This PR re-enables that workflow when `ATLASPACK_REGISTER_USE_SRC=true` is set while still allowing external TS plugins to be compiled at runtime if needed. 

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
