### PR TITLE
Allow explicit entries with target sources

### DIFF
--- a/crates/atlaspack/src/requests/target_request.rs
+++ b/crates/atlaspack/src/requests/target_request.rs
@@ -314,6 +314,10 @@ impl TargetRequest {
     &self,
     request_context: RunRequestContext,
   ) -> Result<Vec<Option<Target>>, anyhow::Error> {
+    let allow_explicit_target_entries = request_context
+      .options
+      .feature_flags
+      .bool_enabled("allowExplicitTargetEntries");
     let config = self.load_config(&request_context)?;
     let mut targets: Vec<Option<Target>> = Vec::new();
 
@@ -352,6 +356,7 @@ impl TargetRequest {
               descriptor.clone(),
               name,
               &request_context.project_root,
+              allow_explicit_target_entries,
             )?);
           }
 
@@ -375,6 +380,7 @@ impl TargetRequest {
             builtin_target_descriptor,
             builtin_target.name,
             &request_context.project_root,
+            allow_explicit_target_entries,
           )?);
         }
       }
@@ -413,6 +419,7 @@ impl TargetRequest {
         custom_target.descriptor.clone(),
         custom_target.name,
         &request_context.project_root,
+        allow_explicit_target_entries,
       )?);
     }
 
@@ -469,6 +476,40 @@ impl TargetRequest {
     Ok(targets)
   }
 
+  fn entry_matches_target_source(
+    &self,
+    target_source: &Option<SourceField>,
+    project_root: &Path,
+  ) -> bool {
+    let Some(source) = target_source else {
+      return false;
+    };
+
+    let current_entry_path = &self.entry.file_path;
+
+    // Handle both string and array sources
+    let sources = match source {
+      SourceField::Source(s) => vec![s.as_str()],
+      SourceField::Sources(sources) => sources.iter().map(|s| s.as_str()).collect(),
+    };
+
+    // Check if current entry matches any of the target sources
+    sources.iter().any(|source_str| {
+      // Resolve the target source path relative to the package directory (where package.json is)
+      // The package directory is the parent of the current entry path
+      let package_dir = current_entry_path.parent().unwrap_or(project_root);
+      let source_path = package_dir.join(source_str);
+      let target_source_path = source_path
+        .canonicalize()
+        .unwrap_or_else(|_| source_path.clone());
+      let current_entry_canonical = current_entry_path
+        .canonicalize()
+        .unwrap_or_else(|_| current_entry_path.clone());
+
+      target_source_path == current_entry_canonical
+    })
+  }
+
   fn get_default_engines_for_context(&self, context: EnvironmentContext) -> Engines {
     let defaults = self.default_target_options.engines.clone();
     if context.is_browser() {
@@ -486,12 +527,19 @@ impl TargetRequest {
     }
   }
 
-  fn skip_target(&self, target_name: &str, source: &Option<SourceField>) -> bool {
+  fn skip_target(
+    &self,
+    target_name: &str,
+    source: &Option<SourceField>,
+    allow_explicit_target_entries: bool,
+  ) -> bool {
     // We skip targets if they have a descriptor.source that does not match the current
     // exclusiveTarget. They will be handled by a separate resolvePackageTargets call from their
     // Entry point but with exclusiveTarget set.
+    // However, when allowExplicitTargetEntries is enabled, we don't skip targets with source
+    // as they will be filtered later based on the current entry.
     match self.entry.target.as_ref() {
-      None => source.is_some(),
+      None => source.is_some() && !allow_explicit_target_entries,
       Some(exclusive_target) => target_name != exclusive_target,
     }
   }
@@ -503,9 +551,21 @@ impl TargetRequest {
     target_descriptor: TargetDescriptor,
     target_name: &str,
     project_root: &Path,
+    allow_explicit_target_entries: bool,
   ) -> Result<Option<Target>, anyhow::Error> {
-    if self.skip_target(target_name, &target_descriptor.source) {
+    if self.skip_target(
+      target_name,
+      &target_descriptor.source,
+      allow_explicit_target_entries,
+    ) {
       return Ok(None);
+    }
+
+    // Additional filtering for allowExplicitTargetEntries feature
+    if allow_explicit_target_entries && target_descriptor.source.is_some() {
+      if !self.entry_matches_target_source(&target_descriptor.source, project_root) {
+        return Ok(None);
+      }
     }
 
     let mut engines = target_descriptor
@@ -788,6 +848,15 @@ mod tests {
     browserslistrc: Option<String>,
     atlaspack_options: Option<AtlaspackOptions>,
   ) -> Result<RequestResult, anyhow::Error> {
+    targets_from_config_with_entry(package_json, browserslistrc, atlaspack_options, None).await
+  }
+
+  async fn targets_from_config_with_entry(
+    package_json: String,
+    browserslistrc: Option<String>,
+    atlaspack_options: Option<AtlaspackOptions>,
+    entry_file: Option<&str>,
+  ) -> Result<RequestResult, anyhow::Error> {
     let fs = InMemoryFileSystem::default();
     let project_root = PathBuf::default();
     let package_dir = package_dir();
@@ -801,9 +870,25 @@ mod tests {
       fs.write_file(&project_root.join(".browserslistrc"), browserslistrc);
     }
 
+    // Create the entry file path based on the first entry in options or use default
+    let entry_path = if let Some(entry_file) = entry_file {
+      project_root.join(&package_dir).join(entry_file)
+    } else if let Some(ref options) = atlaspack_options {
+      if !options.entries.is_empty() {
+        project_root.join(&package_dir).join(&options.entries[0])
+      } else {
+        PathBuf::default()
+      }
+    } else {
+      PathBuf::default()
+    };
+
     let request = TargetRequest {
       default_target_options: DefaultTargetOptions::default(),
-      entry: Entry::default(),
+      entry: Entry {
+        file_path: entry_path,
+        target: None,
+      },
       env: None,
       mode: BuildMode::Development,
     };
@@ -1856,5 +1941,222 @@ mod tests {
     assert_targets("mjs", None, OutputFormat::EsModule).await;
     assert_targets("mjs", Some(ModuleFormat::CommonJS), OutputFormat::EsModule).await;
     assert_targets("mjs", Some(ModuleFormat::Module), OutputFormat::EsModule).await;
+  }
+
+  #[tokio::test(flavor = "multi_thread")]
+  async fn test_allow_explicit_target_entries_feature_flag_disabled() {
+    // When feature flag is disabled, targets with source should be skipped
+    let feature_flags = atlaspack_core::types::FeatureFlags::default();
+    // Feature flag is false by default
+
+    let mut options = AtlaspackOptions::default();
+    options.feature_flags = feature_flags;
+    options.entries = vec!["input.js".to_string()];
+
+    let targets = targets_from_config(
+      r#"{
+        "targets": {
+          "one": {
+            "source": "./input.js",
+            "distDir": "./dist/one"
+          },
+          "two": {
+            "source": "./input2.js", 
+            "distDir": "./dist/two"
+          }
+        }
+      }"#
+        .to_string(),
+      None,
+      Some(options),
+    )
+    .await;
+
+    // Should get no targets because they all have source properties and feature flag is disabled
+    if let Ok(RequestResult::Target(output)) = targets {
+      assert_eq!(
+        output.targets.len(),
+        0,
+        "Expected 0 targets when feature flag is disabled"
+      );
+    } else {
+      panic!("Expected successful target resolution");
+    }
+  }
+
+  #[tokio::test(flavor = "multi_thread")]
+  async fn test_allow_explicit_target_entries_feature_flag_enabled_single_source() {
+    // When feature flag is enabled, targets should be filtered by matching source
+    let feature_flags =
+      atlaspack_core::types::FeatureFlags::with_bool_flag("allowExplicitTargetEntries", true);
+
+    let mut options = AtlaspackOptions::default();
+    options.feature_flags = feature_flags;
+    options.entries = vec!["input.js".to_string()];
+
+    let targets = targets_from_config(
+      r#"{
+        "targets": {
+          "one": {
+            "source": "./input.js",
+            "distDir": "./dist/one"
+          },
+          "two": {
+            "source": "./input2.js", 
+            "distDir": "./dist/two"
+          }
+        }
+      }"#
+        .to_string(),
+      None,
+      Some(options),
+    )
+    .await;
+
+    if let Ok(RequestResult::Target(output)) = targets {
+      assert_eq!(
+        output.targets.len(),
+        1,
+        "Expected 1 target matching the entry"
+      );
+      assert_eq!(
+        output.targets[0].name, "one",
+        "Expected target 'one' to match input.js"
+      );
+    } else {
+      panic!("Expected successful target resolution");
+    }
+  }
+
+  #[tokio::test(flavor = "multi_thread")]
+  async fn test_allow_explicit_target_entries_feature_flag_enabled_array_source() {
+    // When feature flag is enabled with array sources, should match any source in array
+    let feature_flags =
+      atlaspack_core::types::FeatureFlags::with_bool_flag("allowExplicitTargetEntries", true);
+
+    let mut options = AtlaspackOptions::default();
+    options.feature_flags = feature_flags;
+    options.entries = vec!["input2.js".to_string()];
+
+    let targets = targets_from_config(
+      r#"{
+        "targets": {
+          "one": {
+            "source": "./input.js",
+            "distDir": "./dist/one"
+          },
+          "multi": {
+            "source": ["./input2.js", "./input3.js"], 
+            "distDir": "./dist/multi"
+          }
+        }
+      }"#
+        .to_string(),
+      None,
+      Some(options),
+    )
+    .await;
+
+    if let Ok(RequestResult::Target(output)) = targets {
+      assert_eq!(
+        output.targets.len(),
+        1,
+        "Expected 1 target matching the entry"
+      );
+      assert_eq!(
+        output.targets[0].name, "multi",
+        "Expected target 'multi' to match input2.js from array"
+      );
+    } else {
+      panic!("Expected successful target resolution");
+    }
+  }
+
+  #[tokio::test(flavor = "multi_thread")]
+  async fn test_allow_explicit_target_entries_feature_flag_enabled_no_matching_source() {
+    // When feature flag is enabled but no sources match, should get no targets
+    let feature_flags =
+      atlaspack_core::types::FeatureFlags::with_bool_flag("allowExplicitTargetEntries", true);
+
+    let mut options = AtlaspackOptions::default();
+    options.feature_flags = feature_flags;
+    options.entries = vec!["nonexistent.js".to_string()];
+
+    let targets = targets_from_config(
+      r#"{
+        "targets": {
+          "one": {
+            "source": "./input.js",
+            "distDir": "./dist/one"
+          },
+          "two": {
+            "source": "./input2.js", 
+            "distDir": "./dist/two"
+          }
+        }
+      }"#
+        .to_string(),
+      None,
+      Some(options),
+    )
+    .await;
+
+    if let Ok(RequestResult::Target(output)) = targets {
+      assert_eq!(
+        output.targets.len(),
+        0,
+        "Expected 0 targets when no sources match"
+      );
+    } else {
+      panic!("Expected successful target resolution");
+    }
+  }
+
+  #[tokio::test(flavor = "multi_thread")]
+  async fn test_allow_explicit_target_entries_feature_flag_enabled_targets_without_source() {
+    // When feature flag is enabled, targets without source should still be included
+    let feature_flags =
+      atlaspack_core::types::FeatureFlags::with_bool_flag("allowExplicitTargetEntries", true);
+
+    let mut options = AtlaspackOptions::default();
+    options.feature_flags = feature_flags;
+    options.entries = vec!["input.js".to_string()];
+
+    let targets = targets_from_config(
+      r#"{
+        "targets": {
+          "no_source": {
+            "distDir": "./dist/no_source"
+          },
+          "with_source": {
+            "source": "./input.js",
+            "distDir": "./dist/with_source"
+          }
+        }
+      }"#
+        .to_string(),
+      None,
+      Some(options),
+    )
+    .await;
+
+    if let Ok(RequestResult::Target(output)) = targets {
+      assert_eq!(
+        output.targets.len(),
+        2,
+        "Expected 2 targets: one without source, one matching source"
+      );
+      let target_names: Vec<&str> = output.targets.iter().map(|t| t.name.as_str()).collect();
+      assert!(
+        target_names.contains(&"no_source"),
+        "Expected target without source to be included"
+      );
+      assert!(
+        target_names.contains(&"with_source"),
+        "Expected target with matching source to be included"
+      );
+    } else {
+      panic!("Expected successful target resolution");
+    }
   }
 }

--- a/crates/atlaspack_core/src/types/feature_flags.rs
+++ b/crates/atlaspack_core/src/types/feature_flags.rs
@@ -35,4 +35,12 @@ impl FeatureFlags {
     };
     v == matches.as_ref()
   }
+
+  /// Create a new FeatureFlags instance with a single boolean flag set
+  /// This is primarily intended for testing
+  pub fn with_bool_flag(key: impl Into<String>, value: bool) -> Self {
+    let mut flags = HashMap::new();
+    flags.insert(key.into(), FeatureFlagValue::Bool(value));
+    FeatureFlags(flags)
+  }
 }

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -178,6 +178,13 @@ export const DEFAULT_FEATURE_FLAGS = {
    * be at the top level of the bundle.
    */
   applyScopeHoistingImprovementV2: false,
+
+  /**
+   * When enabled, if both explicit entries and explicit targets are specified,
+   * the source properties of those targets are used as filters against the base entries.
+   * This allows building only specific entries for specific targets.
+   */
+  allowExplicitTargetEntries: false,
 };
 
 export type FeatureFlags = typeof DEFAULT_FEATURE_FLAGS;

--- a/packages/core/integration-tests/test/targets.ts
+++ b/packages/core/integration-tests/test/targets.ts
@@ -1,0 +1,96 @@
+import {Bundle} from '@atlaspack/types';
+import {fsFixture, overlayFS, bundle} from '@atlaspack/test-utils';
+import assert from 'assert';
+import path from 'path';
+
+describe('targets', () => {
+  it('should support overriding env in targets', async () => {
+    const targetDir = path.join(__dirname, 'targets');
+    await overlayFS.mkdirp(targetDir);
+    await fsFixture(overlayFS, targetDir)`
+        env-transformer.js:
+          const { Transformer } = require('@atlaspack/plugin');
+          module.exports = new Transformer({ 
+            transform: async ({ asset, options }) => {
+            console.log("transforming", asset.filePath, "with env", options.env.MY_ENV)
+              const code = await asset.getCode();
+              const newCode = code.replace('MY_ENV', options.env.MY_ENV);
+              asset.setCode(newCode);
+              return [asset];
+            }
+          });
+
+        .parcelrc:
+          {
+            "extends": "@atlaspack/config-default"
+          }
+          
+        common.js:
+          export const common = 'MY_ENV';
+
+        input.js:
+          import {common} from './common.js';
+          console.log(common, 'from input');
+
+        input2.js:
+          import {common} from './common.js';
+          console.log(common, 'from input2');
+
+        input3.js:
+          import {common} from './common.js';
+          console.log(common, 'from input3');
+
+        yarn.lock: {}
+        `;
+
+    const b = await bundle(
+      [
+        path.join(targetDir, './input.js'),
+        path.join(targetDir, './input2.js'),
+        path.join(targetDir, './input3.js'),
+      ],
+      {
+        inputFS: overlayFS,
+        targets: {
+          one: {
+            source: './input.js',
+            context: 'browser',
+            distDir: './dist/one',
+            engines: {
+              browsers: ['last 1 Chrome version'],
+            },
+          },
+          two: {
+            source: ['./input2.js', './input3.js'],
+            context: 'browser',
+            distDir: './dist/two',
+            engines: {
+              browsers: ['last 1 Firefox version'],
+            },
+          },
+        },
+        featureFlags: {
+          allowExplicitTargetEntries: true,
+        },
+      },
+    );
+
+    const bundles = b.getBundles();
+    // The feature flag should filter entries per target, so we should get 3 bundles:
+    // - target "one" only for input.js
+    // - target "two" only for input2.js and input3.js
+    assert(bundles.length === 3, 'Expected 3 bundles, got ' + bundles.length);
+
+    const bundlesByTarget: Record<string, Bundle> = {};
+    for (const bundle of bundles) {
+      bundlesByTarget[bundle.target.name] = bundle;
+    }
+
+    ['one', 'two'].forEach((target) => {
+      const bundle = bundlesByTarget[target];
+      assert(bundle, `Bundle for target ${target} not found`);
+      // For now, just check that the bundle exists
+      // TODO: Add proper bundle content checking when options are working correctly
+    });
+  });
+});

--- a/packages/core/integration-tests/test/targets.ts
+++ b/packages/core/integration-tests/test/targets.ts
@@ -4,27 +4,10 @@ import assert from 'assert';
 import path from 'path';
 
 describe('targets', () => {
-  it('should support overriding env in targets', async () => {
+  it('should support building targets with custom entries with a top level entry array', async () => {
     const targetDir = path.join(__dirname, 'targets');
     await overlayFS.mkdirp(targetDir);
     await fsFixture(overlayFS, targetDir)`
-        env-transformer.js:
-          const { Transformer } = require('@atlaspack/plugin');
-          module.exports = new Transformer({ 
-            transform: async ({ asset, options }) => {
-            console.log("transforming", asset.filePath, "with env", options.env.MY_ENV)
-              const code = await asset.getCode();
-              const newCode = code.replace('MY_ENV', options.env.MY_ENV);
-              asset.setCode(newCode);
-              return [asset];
-            }
-          });
-
-        .parcelrc:
-          {
-            "extends": "@atlaspack/config-default"
-          }
-          
         common.js:
           export const common = 'MY_ENV';
 
@@ -55,7 +38,7 @@ describe('targets', () => {
           one: {
             source: './input.js',
             context: 'browser',
-            distDir: './dist/one',
+            distDir: './dist',
             engines: {
               browsers: ['last 1 Chrome version'],
             },
@@ -63,7 +46,7 @@ describe('targets', () => {
           two: {
             source: ['./input2.js', './input3.js'],
             context: 'browser',
-            distDir: './dist/two',
+            distDir: './dist',
             engines: {
               browsers: ['last 1 Firefox version'],
             },
@@ -89,8 +72,6 @@ describe('targets', () => {
     ['one', 'two'].forEach((target) => {
       const bundle = bundlesByTarget[target];
       assert(bundle, `Bundle for target ${target} not found`);
-      // For now, just check that the bundle exists
-      // TODO: Add proper bundle content checking when options are working correctly
     });
   });
 });


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

You can't currently provide custom targets as Atlaspack options which have their own `source` properties without pointing to a package as the "entry" that also contains those sources.

## Changes

Adds a new feature flag `allowExplicitTargetEntries` that when enabled will allow you to specify a list of entries, and also custom targets that use a subset of those entries in different targets - one bundle will be produced per target even if there are fewer targets than entries.

Example: TODO

## Checklist

- [ ] Existing or new tests cover this change
- [ ] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
