### PR TITLE
Type WriteBundlesRequest properly

### DIFF
--- a/.changeset/wet-comics-perform.md
+++ b/.changeset/wet-comics-perform.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': patch
+---
+
+Fixes a small error with inline bundle packaging resulting from an incorrect comparison.

--- a/packages/core/core/src/requests/WriteBundlesRequest.ts
+++ b/packages/core/core/src/requests/WriteBundlesRequest.ts
@@ -4,7 +4,7 @@ import {getFeatureFlag} from '@atlaspack/feature-flags';
 import type {SharedReference} from '@atlaspack/workers';
 import type {StaticRunOpts} from '../RequestTracker';
 import {requestTypes} from '../RequestTracker';
-import type {PackagedBundleInfo} from '../types';
+import {BundleBehavior, type PackagedBundleInfo} from '../types';
 import type BundleGraph from '../BundleGraph';
 import type {BundleInfo} from '../PackagerRunner';
 import {report} from '../ReporterRunner';
@@ -66,8 +66,9 @@ export default function createWriteBundlesRequest(
   };
 }
 
-// @ts-expect-error TS7031
-async function run({input, api, farm, options}) {
+type WriteBundlesRequestRunArgs = Parameters<WriteBundlesRequest['run']>[0];
+
+async function run({input, api, farm, options}: WriteBundlesRequestRunArgs) {
   let {bundleGraph, optionsRef} = input;
   let {ref, dispose} = await farm.createSharedReference(bundleGraph);
 
@@ -87,12 +88,10 @@ async function run({input, api, farm, options}) {
   });
   const bundles = allBundles
     .filter(
-      // @ts-expect-error TS7006
       (bundle) =>
-        bundle.bundleBehavior !== 'inline' &&
-        bundle.bundleBehavior !== 'inline-isolated',
+        bundle.bundleBehavior !== BundleBehavior.inline &&
+        bundle.bundleBehavior !== BundleBehavior.inlineIsolated,
     )
-    // @ts-expect-error TS7006
     .filter((bundle) => {
       // Do not package and write placeholder bundles to disk. We just
       // need to update the name so other bundles can reference it.
@@ -119,7 +118,6 @@ async function run({input, api, farm, options}) {
     });
 
   let cachedBundles = new Set(
-    // @ts-expect-error TS7006
     bundles.filter((b) => api.canSkipSubrequest(bundleGraph.getHash(b))),
   );
 
@@ -133,7 +131,6 @@ async function run({input, api, farm, options}) {
     reportPackagingProgress(completeBundles, bundles.length);
 
     await Promise.all(
-      // @ts-expect-error TS7006
       bundles.map(async (bundle) => {
         let request = createPackageRequest({
           bundle,
@@ -185,7 +182,6 @@ async function run({input, api, farm, options}) {
     );
     assignComplexNameHashes(hashRefToNameHash, bundles, bundleInfoMap, options);
     await Promise.all(
-      // @ts-expect-error TS7006
       bundles.map((bundle) => {
         let promise =
           writeEarlyPromises[bundle.id] ??

--- a/packages/core/core/src/requests/WriteBundlesRequest.ts
+++ b/packages/core/core/src/requests/WriteBundlesRequest.ts
@@ -66,9 +66,12 @@ export default function createWriteBundlesRequest(
   };
 }
 
-type WriteBundlesRequestRunArgs = Parameters<WriteBundlesRequest['run']>[0];
-
-async function run({input, api, farm, options}: WriteBundlesRequestRunArgs) {
+async function run({
+  input,
+  api,
+  farm,
+  options,
+}: RunInput<WriteBundlesRequestResult>) {
   let {bundleGraph, optionsRef} = input;
   let {ref, dispose} = await farm.createSharedReference(bundleGraph);
 


### PR DESCRIPTION
## Motivation

I was doing some experimenting in WriteBundlesRequest today, and decided to have a crack at cleaning up the types while I was there.

In doing so, I found a piece of code that I don't think has been doing anything. In the filter step, `bundle.bundleBehavior` is actually a number, so the string comparisons will always be false.

## Changes

I've removed all ts-expect-error comments from this file and made the required typings explicit enough to pass.

## Checklist

- [x] There is a changeset for this change, or one is not required