### PR TITLE
Use source files for type checking

### DIFF
--- a/packages/bundlers/bundler-experimental/package.json
+++ b/packages/bundlers/bundler-experimental/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/bundlers/default/package.json
+++ b/packages/bundlers/default/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/DefaultBundler.js",
   "source": "./src/DefaultBundler.ts",
-  "types": "./lib/types/DefaultBundler.d.ts",
+  "types": "./src/DefaultBundler.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/bundlers/library/package.json
+++ b/packages/bundlers/library/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/LibraryBundler.js",
   "source": "./src/LibraryBundler.ts",
-  "types": "./lib/types/LibraryBundler.d.ts",
+  "types": "./src/LibraryBundler.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/compressors/brotli/package.json
+++ b/packages/compressors/brotli/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/BrotliCompressor.js",
   "source": "./src/BrotliCompressor.ts",
-  "types": "./lib/types/BrotliCompressor.d.ts",
+  "types": "./src/BrotliCompressor.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/compressors/gzip/package.json
+++ b/packages/compressors/gzip/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/GzipCompressor.js",
   "source": "./src/GzipCompressor.ts",
-  "types": "./lib/types/GzipCompressor.d.ts",
+  "types": "./src/GzipCompressor.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/compressors/raw/package.json
+++ b/packages/compressors/raw/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/RawCompressor.js",
   "source": "./src/RawCompressor.ts",
-  "types": "./lib/types/RawCompressor.d.ts",
+  "types": "./src/RawCompressor.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/build-cache/package.json
+++ b/packages/core/build-cache/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/cache/package.json
+++ b/packages/core/cache/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/cli/package.json
+++ b/packages/core/cli/package.json
@@ -16,7 +16,7 @@
   },
   "main": "./lib/bin.js",
   "source": "./src/bin.ts",
-  "types": "./lib/types/bin.d.ts",
+  "types": "./src/bin.ts",
   "scripts": {
     "check-ts": "tsc --emitDeclarationOnly --rootDir src",
     "build:lib": "gulp build --gulpfile ../../../gulpfile.js --cwd ."

--- a/packages/core/codeframe/package.json
+++ b/packages/core/codeframe/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./lib/codeframe.js",
   "source": "./src/codeframe.ts",
-  "types": "./lib/types/codeframe.d.ts",
+  "types": "./src/codeframe.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/core/package.json
+++ b/packages/core/core/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/diagnostic/package.json
+++ b/packages/core/diagnostic/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/diagnostic.js",
   "source": "./src/diagnostic.ts",
-  "types": "./lib/types/diagnostic.d.ts",
+  "types": "./src/diagnostic.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/eslint-plugin/package.json
+++ b/packages/core/eslint-plugin/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"

--- a/packages/core/feature-flags/package.json
+++ b/packages/core/feature-flags/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "check-ts": "tsc --emitDeclarationOnly --rootDir src",
     "build:lib": "gulp build --gulpfile ../../../gulpfile.js --cwd ."

--- a/packages/core/fs/package.json
+++ b/packages/core/fs/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/graph/package.json
+++ b/packages/core/graph/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/logger/package.json
+++ b/packages/core/logger/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/Logger.js",
   "source": "./src/Logger.ts",
-  "types": "./lib/types/Logger.d.ts",
+  "types": "./src/Logger.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/markdown-ansi/package.json
+++ b/packages/core/markdown-ansi/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/markdown-ansi.js",
   "source": "./src/markdown-ansi.ts",
-  "types": "./lib/types/markdown-ansi.d.ts",
+  "types": "./src/markdown-ansi.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/package-manager/package.json
+++ b/packages/core/package-manager/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/plugin/package.json
+++ b/packages/core/plugin/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/PluginAPI.js",
   "source": "./src/PluginAPI.ts",
-  "types": "./lib/types/PluginAPI.d.ts",
+  "types": "./src/PluginAPI.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/profiler/package.json
+++ b/packages/core/profiler/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/register/package.json
+++ b/packages/core/register/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/register.js",
   "source": "./src/register.ts",
-  "types": "./lib/types/register.d.ts",
+  "types": "./src/register.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/test-utils/package.json
+++ b/packages/core/test-utils/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./lib/utils.js",
   "source": "./src/utils.ts",
-  "types": "./lib/types/utils.d.ts",
+  "types": "./src/utils.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/types-internal/package.json
+++ b/packages/core/types-internal/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"

--- a/packages/core/types/package.json
+++ b/packages/core/types/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/atlassian-labs/atlaspack.git"

--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/core/workers/package.json
+++ b/packages/core/workers/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/dev/atlaspack-link/package.json
+++ b/packages/dev/atlaspack-link/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "dependencies": {
     "@babel/core": "^7.22.11",
     "@atlaspack/babel-register": "2.14.3",

--- a/packages/dev/bundle-stats-cli/package.json
+++ b/packages/dev/bundle-stats-cli/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/cli.js",
   "source": "./src/cli.ts",
-  "types": "./lib/types/cli.d.ts",
+  "types": "./src/cli.ts",
   "bin": {
     "atlaspack-bundle-stats": "bin/bundle-stats.js"
   },

--- a/packages/namers/default/package.json
+++ b/packages/namers/default/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/DefaultNamer.js",
   "source": "./src/DefaultNamer.ts",
-  "types": "./lib/types/DefaultNamer.d.ts",
+  "types": "./src/DefaultNamer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/blob-url/package.json
+++ b/packages/optimizers/blob-url/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/BlobURLOptimizer.js",
   "source": "./src/BlobURLOptimizer.ts",
-  "types": "./lib/types/BlobURLOptimizer.d.ts",
+  "types": "./src/BlobURLOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/css/package.json
+++ b/packages/optimizers/css/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/CSSOptimizer.js",
   "source": "./src/CSSOptimizer.ts",
-  "types": "./lib/types/CSSOptimizer.d.ts",
+  "types": "./src/CSSOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/cssnano/package.json
+++ b/packages/optimizers/cssnano/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/CSSNanoOptimizer.js",
   "source": "./src/CSSNanoOptimizer.ts",
-  "types": "./lib/types/CSSNanoOptimizer.d.ts",
+  "types": "./src/CSSNanoOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/data-url/package.json
+++ b/packages/optimizers/data-url/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/DataURLOptimizer.js",
   "source": "./src/DataURLOptimizer.ts",
-  "types": "./lib/types/DataURLOptimizer.d.ts",
+  "types": "./src/DataURLOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/htmlnano/package.json
+++ b/packages/optimizers/htmlnano/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/HTMLNanoOptimizer.js",
   "source": "./src/HTMLNanoOptimizer.ts",
-  "types": "./lib/types/HTMLNanoOptimizer.d.ts",
+  "types": "./src/HTMLNanoOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/image/package.json
+++ b/packages/optimizers/image/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "./lib/ImageOptimizer.js",
   "source": "./src/ImageOptimizer.ts",
-  "types": "./lib/types/ImageOptimizer.d.ts",
+  "types": "./src/ImageOptimizer.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/optimizers/inline-requires/package.json
+++ b/packages/optimizers/inline-requires/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/InlineRequires.js",
   "source": "./src/InlineRequires.ts",
-  "types": "./lib/types/InlineRequires.d.ts",
+  "types": "./src/InlineRequires.ts",
   "engines": {
     "node": ">= 14.0.0"
   },

--- a/packages/optimizers/svgo/package.json
+++ b/packages/optimizers/svgo/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SVGOOptimizer.js",
   "source": "./src/SVGOOptimizer.ts",
-  "types": "./lib/types/SVGOOptimizer.d.ts",
+  "types": "./src/SVGOOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/swc/package.json
+++ b/packages/optimizers/swc/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SwcOptimizer.js",
   "source": "./src/SwcOptimizer.ts",
-  "types": "./lib/types/SwcOptimizer.d.ts",
+  "types": "./src/SwcOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/optimizers/terser/package.json
+++ b/packages/optimizers/terser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TerserOptimizer.js",
   "source": "./src/TerserOptimizer.ts",
-  "types": "./lib/types/TerserOptimizer.d.ts",
+  "types": "./src/TerserOptimizer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/css/package.json
+++ b/packages/packagers/css/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/CSSPackager.js",
   "source": "./src/CSSPackager.ts",
-  "types": "./lib/types/CSSPackager.d.ts",
+  "types": "./src/CSSPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/html/package.json
+++ b/packages/packagers/html/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/HTMLPackager.js",
   "source": "./src/HTMLPackager.ts",
-  "types": "./lib/types/HTMLPackager.d.ts",
+  "types": "./src/HTMLPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/js/package.json
+++ b/packages/packagers/js/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/raw-url/package.json
+++ b/packages/packagers/raw-url/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/RawUrlPackager.js",
   "source": "./src/RawUrlPackager.ts",
-  "types": "./lib/types/RawUrlPackager.d.ts",
+  "types": "./src/RawUrlPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/raw/package.json
+++ b/packages/packagers/raw/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/RawPackager.js",
   "source": "./src/RawPackager.ts",
-  "types": "./lib/types/RawPackager.d.ts",
+  "types": "./src/RawPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/svg/package.json
+++ b/packages/packagers/svg/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SVGPackager.js",
   "source": "./src/SVGPackager.ts",
-  "types": "./lib/types/SVGPackager.d.ts",
+  "types": "./src/SVGPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/ts/package.json
+++ b/packages/packagers/ts/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TSPackager.js",
   "source": "./src/TSPackager.ts",
-  "types": "./lib/types/TSPackager.d.ts",
+  "types": "./src/TSPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/packagers/wasm/package.json
+++ b/packages/packagers/wasm/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/WasmPackager.js",
   "source": "./src/WasmPackager.ts",
-  "types": "./lib/types/WasmPackager.d.ts",
+  "types": "./src/WasmPackager.ts",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/packages/packagers/webextension/package.json
+++ b/packages/packagers/webextension/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/WebExtensionPackager.js",
   "source": "./src/WebExtensionPackager.ts",
-  "types": "./lib/types/WebExtensionPackager.d.ts",
+  "types": "./src/WebExtensionPackager.ts",
   "engines": {
     "node": ">=16.0.0"
   },

--- a/packages/packagers/xml/package.json
+++ b/packages/packagers/xml/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/XMLPackager.js",
   "source": "./src/XMLPackager.ts",
-  "types": "./lib/types/XMLPackager.d.ts",
+  "types": "./src/XMLPackager.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/build-metrics/package.json
+++ b/packages/reporters/build-metrics/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/BuildMetricsReporter.js",
   "source": "./src/BuildMetricsReporter.ts",
-  "types": "./lib/types/BuildMetricsReporter.d.ts",
+  "types": "./src/BuildMetricsReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/bundle-analyzer/package.json
+++ b/packages/reporters/bundle-analyzer/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/BundleAnalyzerReporter.js",
   "source": "./src/BundleAnalyzerReporter.ts",
-  "types": "./lib/types/BundleAnalyzerReporter.d.ts",
+  "types": "./src/BundleAnalyzerReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/bundle-buddy/package.json
+++ b/packages/reporters/bundle-buddy/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/BundleBuddyReporter.js",
   "source": "./src/BundleBuddyReporter.ts",
-  "types": "./lib/types/BundleBuddyReporter.d.ts",
+  "types": "./src/BundleBuddyReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/bundle-stats/package.json
+++ b/packages/reporters/bundle-stats/package.json
@@ -6,7 +6,7 @@
   },
   "main": "./lib/BundleStatsReporter.js",
   "source": "./src/BundleStatsReporter.ts",
-  "types": "./lib/types/BundleStatsReporter.d.ts",
+  "types": "./src/BundleStatsReporter.ts",
   "bin": {
     "atlaspack-bundle-stats": "bin.js"
   },

--- a/packages/reporters/cli/package.json
+++ b/packages/reporters/cli/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/CLIReporter.js",
   "source": "./src/CLIReporter.ts",
-  "types": "./lib/types/CLIReporter.d.ts",
+  "types": "./src/CLIReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/conditional-manifest/package.json
+++ b/packages/reporters/conditional-manifest/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/ConditionalManifestReporter.js",
   "source": "./src/ConditionalManifestReporter.ts",
-  "types": "./lib/types/ConditionalManifestReporter.d.ts",
+  "types": "./src/ConditionalManifestReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/dev-server-sw/package.json
+++ b/packages/reporters/dev-server-sw/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./lib/ServerReporter.js",
   "source": "./src/ServerReporter.ts",
-  "types": "./lib/types/ServerReporter.d.ts",
+  "types": "./src/ServerReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/dev-server/package.json
+++ b/packages/reporters/dev-server/package.json
@@ -13,7 +13,7 @@
   },
   "main": "./lib/ServerReporter.js",
   "source": "./src/ServerReporter.ts",
-  "types": "./lib/types/ServerReporter.d.ts",
+  "types": "./src/ServerReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/json/package.json
+++ b/packages/reporters/json/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/JSONReporter.js",
   "source": "./src/JSONReporter.ts",
-  "types": "./lib/types/JSONReporter.d.ts",
+  "types": "./src/JSONReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/lsp-reporter/package.json
+++ b/packages/reporters/lsp-reporter/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/LspReporter.js",
   "source": "./src/LspReporter.ts",
-  "types": "./lib/types/LspReporter.d.ts",
+  "types": "./src/LspReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/sourcemap-visualiser/package.json
+++ b/packages/reporters/sourcemap-visualiser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SourceMapVisualiser.js",
   "source": "./src/SourceMapVisualiser.ts",
-  "types": "./lib/types/SourceMapVisualiser.d.ts",
+  "types": "./src/SourceMapVisualiser.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/reporters/tracer/package.json
+++ b/packages/reporters/tracer/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TracerReporter.js",
   "source": "./src/TracerReporter.ts",
-  "types": "./lib/types/TracerReporter.d.ts",
+  "types": "./src/TracerReporter.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/resolvers/default/package.json
+++ b/packages/resolvers/default/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/DefaultResolver.js",
   "source": "./src/DefaultResolver.ts",
-  "types": "./lib/types/DefaultResolver.d.ts",
+  "types": "./src/DefaultResolver.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/resolvers/glob/package.json
+++ b/packages/resolvers/glob/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/GlobResolver.js",
   "source": "./src/GlobResolver.ts",
-  "types": "./lib/types/GlobResolver.d.ts",
+  "types": "./src/GlobResolver.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/resolvers/repl-runtimes/package.json
+++ b/packages/resolvers/repl-runtimes/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/atlassian-labs/atlaspack.git"
   },
   "source": "./src/REPLRuntimesResolver.ts",
-  "types": "./lib/types/REPLRuntimesResolver.d.ts",
+  "types": "./src/REPLRuntimesResolver.ts",
   "dependencies": {
     "@atlaspack/plugin": "2.14.29",
     "nullthrows": "^1.1.1"

--- a/packages/resolvers/tesseract/package.json
+++ b/packages/resolvers/tesseract/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TesseractResolver.js",
   "source": "./src/TesseractResolver.ts",
-  "types": "./lib/types/TesseractResolver.d.ts",
+  "types": "./src/TesseractResolver.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/runtimes/hmr/package.json
+++ b/packages/runtimes/hmr/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/HMRRuntime.js",
   "source": "./src/HMRRuntime.ts",
-  "types": "./lib/types/HMRRuntime.d.ts",
+  "types": "./src/HMRRuntime.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/runtimes/js/package.json
+++ b/packages/runtimes/js/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/JSRuntime.js",
   "source": "./src/JSRuntime.ts",
-  "types": "./lib/types/JSRuntime.d.ts",
+  "types": "./src/JSRuntime.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/runtimes/react-refresh/package.json
+++ b/packages/runtimes/react-refresh/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/ReactRefreshRuntime.js",
   "source": "./src/ReactRefreshRuntime.ts",
-  "types": "./lib/types/ReactRefreshRuntime.d.ts",
+  "types": "./src/ReactRefreshRuntime.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/runtimes/service-worker/package.json
+++ b/packages/runtimes/service-worker/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/ServiceWorkerRuntime.js",
   "source": "./src/ServiceWorkerRuntime.ts",
-  "types": "./lib/types/ServiceWorkerRuntime.d.ts",
+  "types": "./src/ServiceWorkerRuntime.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/runtimes/webextension/package.json
+++ b/packages/runtimes/webextension/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/WebExtensionRuntime.js",
   "source": "./src/WebExtensionRuntime.ts",
-  "types": "./lib/types/WebExtensionRuntime.d.ts",
+  "types": "./src/WebExtensionRuntime.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/babel/package.json
+++ b/packages/transformers/babel/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/BabelTransformer.js",
   "source": "./src/BabelTransformer.ts",
-  "types": "./lib/types/BabelTransformer.d.ts",
+  "types": "./src/BabelTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/CSSTransformer.js",
   "source": "./src/CSSTransformer.ts",
-  "types": "./lib/types/CSSTransformer.d.ts",
+  "types": "./src/CSSTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/glsl/package.json
+++ b/packages/transformers/glsl/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/GLSLTransformer.js",
   "source": "./src/GLSLTransformer.ts",
-  "types": "./lib/types/GLSLTransformer.d.ts",
+  "types": "./src/GLSLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/graphql/package.json
+++ b/packages/transformers/graphql/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/GraphQLTransformer.js",
   "source": "./src/GraphQLTransformer.ts",
-  "types": "./lib/types/GraphQLTransformer.d.ts",
+  "types": "./src/GraphQLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/html/package.json
+++ b/packages/transformers/html/package.json
@@ -16,7 +16,7 @@
   },
   "main": "./lib/HTMLTransformer.js",
   "source": "./src/HTMLTransformer.ts",
-  "types": "./lib/types/HTMLTransformer.d.ts",
+  "types": "./src/HTMLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/image/package.json
+++ b/packages/transformers/image/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/ImageTransformer.js",
   "source": "./src/ImageTransformer.ts",
-  "types": "./lib/types/ImageTransformer.d.ts",
+  "types": "./src/ImageTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/inline-string/package.json
+++ b/packages/transformers/inline-string/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/InlineStringTransformer.js",
   "source": "./src/InlineStringTransformer.ts",
-  "types": "./lib/types/InlineStringTransformer.d.ts",
+  "types": "./src/InlineStringTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/inline/package.json
+++ b/packages/transformers/inline/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/InlineTransformer.js",
   "source": "./src/InlineTransformer.ts",
-  "types": "./lib/types/InlineTransformer.d.ts",
+  "types": "./src/InlineTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/js/package.json
+++ b/packages/transformers/js/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/JSTransformer.js",
   "source": "./src/JSTransformer.ts",
-  "types": "./lib/types/JSTransformer.d.ts",
+  "types": "./src/JSTransformer.ts",
   "scripts": {
     "test": "mocha",
     "check-ts": "tsc --emitDeclarationOnly --rootDir src",

--- a/packages/transformers/json/package.json
+++ b/packages/transformers/json/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/JSONTransformer.js",
   "source": "./src/JSONTransformer.ts",
-  "types": "./lib/types/JSONTransformer.d.ts",
+  "types": "./src/JSONTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/jsonld/package.json
+++ b/packages/transformers/jsonld/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/JSONLDTransformer.js",
   "source": "./src/JSONLDTransformer.ts",
-  "types": "./lib/types/JSONLDTransformer.d.ts",
+  "types": "./src/JSONLDTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/less/package.json
+++ b/packages/transformers/less/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/LessTransformer.js",
   "source": "./src/LessTransformer.ts",
-  "types": "./lib/types/LessTransformer.d.ts",
+  "types": "./src/LessTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/mdx/package.json
+++ b/packages/transformers/mdx/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/MDXTransformer.js",
   "source": "./src/MDXTransformer.ts",
-  "types": "./lib/types/MDXTransformer.d.ts",
+  "types": "./src/MDXTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/postcss/package.json
+++ b/packages/transformers/postcss/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/PostCSSTransformer.js",
   "source": "./src/PostCSSTransformer.ts",
-  "types": "./lib/types/PostCSSTransformer.d.ts",
+  "types": "./src/PostCSSTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/posthtml/package.json
+++ b/packages/transformers/posthtml/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/PostHTMLTransformer.js",
   "source": "./src/PostHTMLTransformer.ts",
-  "types": "./lib/types/PostHTMLTransformer.d.ts",
+  "types": "./src/PostHTMLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/pug/package.json
+++ b/packages/transformers/pug/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/PugTransformer.js",
   "source": "./src/PugTransformer.ts",
-  "types": "./lib/types/PugTransformer.d.ts",
+  "types": "./src/PugTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/raw/package.json
+++ b/packages/transformers/raw/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/RawTransformer.js",
   "source": "./src/RawTransformer.ts",
-  "types": "./lib/types/RawTransformer.d.ts",
+  "types": "./src/RawTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/react-refresh-wrap/package.json
+++ b/packages/transformers/react-refresh-wrap/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/ReactRefreshWrapTransformer.js",
   "source": "./src/ReactRefreshWrapTransformer.ts",
-  "types": "./lib/types/ReactRefreshWrapTransformer.d.ts",
+  "types": "./src/ReactRefreshWrapTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/sass/package.json
+++ b/packages/transformers/sass/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SassTransformer.js",
   "source": "./src/SassTransformer.ts",
-  "types": "./lib/types/SassTransformer.d.ts",
+  "types": "./src/SassTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/svg-react/package.json
+++ b/packages/transformers/svg-react/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SvgReactTransformer.js",
   "source": "./src/SvgReactTransformer.ts",
-  "types": "./lib/types/SvgReactTransformer.d.ts",
+  "types": "./src/SvgReactTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/svg/package.json
+++ b/packages/transformers/svg/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/SVGTransformer.js",
   "source": "./src/SVGTransformer.ts",
-  "types": "./lib/types/SVGTransformer.d.ts",
+  "types": "./src/SVGTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/toml/package.json
+++ b/packages/transformers/toml/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TOMLTransformer.js",
   "source": "./src/TOMLTransformer.ts",
-  "types": "./lib/types/TOMLTransformer.d.ts",
+  "types": "./src/TOMLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/typescript-tsc/package.json
+++ b/packages/transformers/typescript-tsc/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TSCTransformer.js",
   "source": "./src/TSCTransformer.ts",
-  "types": "./lib/types/TSCTransformer.d.ts",
+  "types": "./src/TSCTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/typescript-types/package.json
+++ b/packages/transformers/typescript-types/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TSTypesTransformer.js",
   "source": "./src/TSTypesTransformer.ts",
-  "types": "./lib/types/TSTypesTransformer.d.ts",
+  "types": "./src/TSTypesTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/webextension/package.json
+++ b/packages/transformers/webextension/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/WebExtensionTransformer.js",
   "source": "./src/WebExtensionTransformer.ts",
-  "types": "./lib/types/WebExtensionTransformer.d.ts",
+  "types": "./src/WebExtensionTransformer.ts",
   "engines": {},
   "dependencies": {
     "@mischnic/json-sourcemap": "^0.1.0",

--- a/packages/transformers/webmanifest/package.json
+++ b/packages/transformers/webmanifest/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/WebManifestTransformer.js",
   "source": "./src/WebManifestTransformer.ts",
-  "types": "./lib/types/WebManifestTransformer.d.ts",
+  "types": "./src/WebManifestTransformer.ts",
   "engines": {},
   "dependencies": {
     "@mischnic/json-sourcemap": "^0.1.0",

--- a/packages/transformers/worklet/package.json
+++ b/packages/transformers/worklet/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/WorkletTransformer.js",
   "source": "./src/WorkletTransformer.ts",
-  "types": "./lib/types/WorkletTransformer.d.ts",
+  "types": "./src/WorkletTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/xml/package.json
+++ b/packages/transformers/xml/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/XMLTransformer.js",
   "source": "./src/XMLTransformer.ts",
-  "types": "./lib/types/XMLTransformer.d.ts",
+  "types": "./src/XMLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/transformers/yaml/package.json
+++ b/packages/transformers/yaml/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/YAMLTransformer.js",
   "source": "./src/YAMLTransformer.ts",
-  "types": "./lib/types/YAMLTransformer.d.ts",
+  "types": "./src/YAMLTransformer.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/utils/atlaspack-lsp-protocol/package.json
+++ b/packages/utils/atlaspack-lsp-protocol/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "scripts": {
     "watch": "tsc -watch -p ./",
     "check-ts": "tsc --emitDeclarationOnly --rootDir src",

--- a/packages/utils/atlaspack-lsp/package.json
+++ b/packages/utils/atlaspack-lsp/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/LspServer.js",
   "source": "./src/LspServer.ts",
-  "types": "./lib/types/LspServer.d.ts",
+  "types": "./src/LspServer.ts",
   "scripts": {
     "watch": "tsc -watch -p ./",
     "lint": "eslint src --ext ts",

--- a/packages/utils/atlaspack-watcher-watchman-js/package.json
+++ b/packages/utils/atlaspack-watcher-watchman-js/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/babel-plugin-transform-contextual-imports/package.json
+++ b/packages/utils/babel-plugin-transform-contextual-imports/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/utils/create-react-app/package.json
+++ b/packages/utils/create-react-app/package.json
@@ -11,7 +11,7 @@
     "directory": "packages/utils/create-react-app"
   },
   "source": "./src/bin.ts",
-  "types": "./lib/types/bin.d.ts",
+  "types": "./src/bin.ts",
   "files": [
     "templates",
     "lib",

--- a/packages/utils/domain-sharding/package.json
+++ b/packages/utils/domain-sharding/package.json
@@ -4,7 +4,7 @@
   "license": "(MIT OR Apache-2.0)",
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/utils/events/package.json
+++ b/packages/utils/events/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/utils/node-resolver-core/package.json
+++ b/packages/utils/node-resolver-core/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/utils/ts-utils/package.json
+++ b/packages/utils/ts-utils/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/index.js",
   "source": "./src/index.ts",
-  "types": "./lib/types/index.d.ts",
+  "types": "./src/index.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/validators/eslint/package.json
+++ b/packages/validators/eslint/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/EslintValidator.js",
   "source": "./src/EslintValidator.ts",
-  "types": "./lib/types/EslintValidator.d.ts",
+  "types": "./src/EslintValidator.ts",
   "engines": {
     "node": ">= 16.0.0"
   },

--- a/packages/validators/typescript/package.json
+++ b/packages/validators/typescript/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./lib/TypeScriptValidator.js",
   "source": "./src/TypeScriptValidator.ts",
-  "types": "./lib/types/TypeScriptValidator.d.ts",
+  "types": "./src/TypeScriptValidator.ts",
   "engines": {
     "node": ">= 16.0.0"
   },


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

This PR goes back to type checking against source files (changed previously in #739) which seems to be a better experience locally.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: This makes no difference to the published output as we rewrite the types to point to lib before publishing. 
