### PR TITLE
Fixes for tesseract resolver

### DIFF
--- a/packages/resolvers/tesseract/src/TesseractResolver.ts
+++ b/packages/resolvers/tesseract/src/TesseractResolver.ts
@@ -11,7 +11,7 @@ interface TesseractResolverConfig {
   browserResolvedNodeBuiltins?: Array<string>;
 
   /** Module mappings that bypass normal resolution (e.g., for SSR compatibility). */
-  preResolved?: Map<string, string>;
+  preResolved?: Record<string, string>;
 
   /** Node.js built-in aliases for Tesseract-specific implementations. */
   builtinAliases?: Record<string, string>;
@@ -37,7 +37,7 @@ const getIgnoreModules = (
   ignoreModules: Array<string>,
 ) => {
   if (env.PILLAR_LOCAL_DEVELOPMENT === 'true') {
-    ignoreModules.push('@atlassiansox/analytics-web-client');
+    return [...ignoreModules, '@atlassiansox/analytics-web-client'];
   }
 
   return ignoreModules;
@@ -91,7 +91,9 @@ export default new Resolver({
     });
     const userConfig: TesseractResolverConfig = conf?.contents || {};
 
-    const preResolved = userConfig.preResolved || new Map<string, string>();
+    const preResolved = userConfig.preResolved
+      ? new Map(Object.entries(userConfig.preResolved))
+      : new Map<string, string>();
     const builtinAliases = userConfig.builtinAliases || {};
     const serverSuffixes = userConfig.serverSuffixes || [];
     const ignoreModules = userConfig.ignoreModules || [];
@@ -129,11 +131,6 @@ export default new Resolver({
     };
   },
   resolve({dependency, specifier, config, options}) {
-    // Only resolve for Tesseract environment
-    if (!dependency.env.isTesseract()) {
-      return null;
-    }
-
     const {
       nodeResolver,
       browserResolver,
@@ -175,8 +172,12 @@ export default new Resolver({
 
     let preResolvedValue = preResolved.get(specifier);
     if (preResolvedValue) {
+      const resolvedPath =
+        preResolvedValue.startsWith('./') || preResolvedValue.startsWith('../')
+          ? require.resolve(join(options.projectRoot, preResolvedValue))
+          : require.resolve(preResolvedValue, {paths: [options.projectRoot]});
       return {
-        filePath: require.resolve(preResolvedValue),
+        filePath: resolvedPath,
         code: undefined,
         sideEffects: false,
       };
@@ -191,13 +192,29 @@ export default new Resolver({
       (options.env.STATIC_FALLBACK === 'true' &&
         STATIC_FALLBACK_MODULES.includes(specifier));
 
+    const snapvmEnv = new Proxy(dependency.env, {
+      get(target, property) {
+        if (useBrowser && property === 'isLibrary') {
+          return false;
+        }
+
+        if (typeof property === 'string') {
+          const value = target[property as keyof typeof target];
+          const ret = typeof value === 'function' ? value.bind(target) : value;
+          return ret;
+        }
+
+        return Reflect.get(target, property);
+      },
+    });
+
     const promise = useBrowser
       ? browserResolver.resolve({
           sourcePath: dependency.sourcePath,
           parent: dependency.resolveFrom,
           filename: aliasSpecifier || specifier,
           specifierType: dependency.specifierType,
-          env: dependency.env,
+          env: snapvmEnv,
           packageConditions: ['ssr', 'require'],
         })
       : nodeResolver.resolve({
@@ -205,7 +222,7 @@ export default new Resolver({
           parent: dependency.resolveFrom,
           filename: aliasSpecifier || specifier,
           specifierType: dependency.specifierType,
-          env: dependency.env,
+          env: snapvmEnv,
           packageConditions: ['ssr', 'require'],
         });
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Added fixes for tesseract resolver to successfully build

## Changes
- Removed context environment check to fix module css resolution error
- Fix preResolved map initialisation from config
- Fix analytics client library from being pushed multiple times to ignoreModules
- Add back proxy for `isLibrary` to resolve in tesseract environment

## Checklist

- [ ] Existing or new tests cover this change
- [ ] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
