### PR TITLE
Preserve unstableSingleFileOutput in CSS asset env

### DIFF
--- a/.changeset/angry-papayas-hammer.md
+++ b/.changeset/angry-papayas-hammer.md
@@ -1,0 +1,6 @@
+---
+'@atlaspack/feature-flags': patch
+'@atlaspack/transformer-css': patch
+---
+
+Add new feature flag `preserveUnstableSingleFileOutputInCss` which when enabled will ensure the `unstableSingleFileOutput` property on the asset environment is preserved when transforming CSS.

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -194,6 +194,12 @@ export const DEFAULT_FEATURE_FLAGS = {
    * When enabled, allows custom per-target "env" properties to be used in transformers.
    */
   customEnvInTargets: process.env.ATLASPACK_BUILD_ENV === 'test',
+
+  /**
+   * When enabled, ensures the `unstableSingleFileOutput` environment property is preserved during CSS transformation
+   */
+  preserveUnstableSingleFileOutputInCss:
+    process.env.ATLASPACK_BUILD_ENV === 'test',
 };
 
 export type FeatureFlags = typeof DEFAULT_FEATURE_FLAGS;

--- a/packages/core/integration-tests/test/integration/css/env-test-transformer.js
+++ b/packages/core/integration-tests/test/integration/css/env-test-transformer.js
@@ -1,0 +1,9 @@
+const {Transformer} = require('@atlaspack/plugin');
+module.exports = new Transformer({
+  transform: async ({asset, options}) => {
+    if (asset.env.unstableSingleFileOutput === false) {
+      throw new Error('unstableSingleFileOutput should be true');
+    }
+    return [asset];
+  },
+});

--- a/packages/transformers/css/package.json
+++ b/packages/transformers/css/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@atlaspack/diagnostic": "2.14.3",
     "@atlaspack/plugin": "2.14.29",
+    "@atlaspack/feature-flags": "2.24.1",
     "@parcel/source-map": "^2.1.1",
     "@atlaspack/types": "2.15.19",
     "@atlaspack/utils": "2.19.1",

--- a/packages/transformers/css/src/CSSTransformer.ts
+++ b/packages/transformers/css/src/CSSTransformer.ts
@@ -14,6 +14,7 @@ import * as native from 'lightningcss';
 import browserslist from 'browserslist';
 import nullthrows from 'nullthrows';
 import ThrowableDiagnostic, {errorToDiagnostic} from '@atlaspack/diagnostic';
+import {getFeatureFlag} from '@atlaspack/feature-flags';
 
 const {transform, transformStyleAttribute, browserslistToTargets} = native;
 
@@ -63,6 +64,11 @@ export default new Transformer({
       shouldOptimize: asset.env.shouldOptimize,
       shouldScopeHoist: asset.env.shouldScopeHoist,
       sourceMap: asset.env.sourceMap,
+      unstableSingleFileOutput: getFeatureFlag(
+        'preserveUnstableSingleFileOutputInCss',
+      )
+        ? asset.env.unstableSingleFileOutput
+        : undefined,
     });
 
     let [code, originalMap] = await Promise.all([


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

In a transformer that touches CSS files after the default CSS transform, we require access to the `asset.env.unstableSingleFileOutput` property, however this property is not preserved when the CSS transformer normalises the asset environment.

## Changes

Add a new feature flag `preserveUnstableSingleFileOutputInCss` which when enabled will copy the `unstableSingleFileOutput` property to the new environment for the CSS asset.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
