### PR TITLE
Fix cliProgressReportingImprovements output

### DIFF
--- a/.changeset/lucky-toys-appear.md
+++ b/.changeset/lucky-toys-appear.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/reporter-cli': patch
+---
+
+Fixes the cliProgressReportingImprovements, which were previously being overwritten by the existing packaging messaging. With this fix, now only the progress messages are shown during packaging.

--- a/packages/reporters/cli/src/CLIReporter.ts
+++ b/packages/reporters/cli/src/CLIReporter.ts
@@ -122,8 +122,9 @@ export async function _report(
         getFeatureFlag('cliProgressReportingImprovements') &&
         (event.phase === 'packaging' || event.phase === 'optimizing')
       ) {
-        // If the flag is turned on, then the output is handled
-        // getProgressMessage
+        // If the flag is turned on, we ignore the old `packaging` and
+        // `optimizing` event types, and only consider `packagingAndOptimizing`
+        // events
         break;
       }
 

--- a/packages/reporters/cli/src/CLIReporter.ts
+++ b/packages/reporters/cli/src/CLIReporter.ts
@@ -118,6 +118,15 @@ export async function _report(
         seenPhasesGen.add(event.phase);
       }
 
+      if (
+        getFeatureFlag('cliProgressReportingImprovements') &&
+        (event.phase === 'packaging' || event.phase === 'optimizing')
+      ) {
+        // If the flag is turned on, then the output is handled
+        // getProgressMessage
+        break;
+      }
+
       if (!isTTY && logLevelFilter != logLevels.verbose) {
         if (event.phase == 'transforming' && !seenPhases.has('transforming')) {
           updateSpinner('Building...');
@@ -126,7 +135,6 @@ export async function _report(
         } else if (event.phase === 'packagingAndOptimizing') {
           updatePackageProgress(event.completeBundles, event.totalBundles);
         } else if (
-          !getFeatureFlag('cliProgressReportingImprovements') &&
           (event.phase == 'packaging' || event.phase == 'optimizing') &&
           !seenPhases.has('packaging') &&
           !seenPhases.has('optimizing')


### PR DESCRIPTION
## Motivation

We previously added a feature flag (#691) that enabled a new experience for the packaging output that shows packaging progress rather than the name of the current bundle.

This worked great in TTY outputs, but less so with the dynamic one, where the percentage updates would show, but would then also be overwritten by the existing bundle name messaging.

## Changes

If the feature flag is on, and it's a packaging or optimising event, we now just bail out of the loop early, and let the `packagingAndOptimising` events handle everything.

## Checklist

- [x] There is a changeset for this change, or one is not required