### PR TITLE
Key lookups by Asset reference instead of id string in ScopeHoistingPackager

### DIFF
--- a/.changeset/eight-singers-give.md
+++ b/.changeset/eight-singers-give.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/packager-js': patch
+---
+
+Minor refactor of the internals of the scope hoisting packager. Some of the internal objects are now keyed on Assets rather than string asset IDs.

--- a/packages/packagers/js/src/ESMOutputFormat.ts
+++ b/packages/packagers/js/src/ESMOutputFormat.ts
@@ -83,7 +83,7 @@ export class ESMOutputFormat implements OutputFormat {
       local,
       exportAs,
     } of this.packager.exportedSymbols.values()) {
-      if (this.packager.wrappedAssets.has(asset.id)) {
+      if (this.packager.wrappedAssets.has(asset)) {
         let obj = `parcelRequire("${this.packager.bundleGraph.getAssetPublicId(
           asset,
         )}")`;

--- a/packages/packagers/js/src/ScopeHoistingPackager.ts
+++ b/packages/packagers/js/src/ScopeHoistingPackager.ts
@@ -111,7 +111,7 @@ export class ScopeHoistingPackager {
   topLevelNames: Map<string, number> = new Map();
   seenAssets: Set<Asset> = new Set();
   wrappedAssets: Set<Asset> = new Set();
-  hoistedRequires: Map<string, Map<string, string>> = new Map();
+  hoistedRequires: Map<Dependency, Map<Asset, string>> = new Map();
   seenHoistedRequires: Set<string> = new Set();
   needsPrelude: boolean = false;
   usedHelpers: Set<string> = new Set();
@@ -1257,14 +1257,14 @@ ${code}
       (!this.bundle.hasAsset(resolvedAsset) ||
         !this.shouldSkipAsset(resolvedAsset))
     ) {
-      let hoisted = this.hoistedRequires.get(dep.id);
+      let hoisted = this.hoistedRequires.get(dep);
       if (!hoisted) {
         hoisted = new Map();
-        this.hoistedRequires.set(dep.id, hoisted);
+        this.hoistedRequires.set(dep, hoisted);
       }
 
       hoisted.set(
-        resolvedAsset.id,
+        resolvedAsset,
         `var $${publicId} = parcelRequire(${JSON.stringify(publicId)});`,
       );
     }
@@ -1349,7 +1349,7 @@ ${code}
       return ['', 0];
     }
 
-    let hoisted = this.hoistedRequires.get(dep.id);
+    let hoisted = this.hoistedRequires.get(dep);
     let res = '';
     let lineCount = 0;
     let isWrapped = this.isWrapped(resolved, parentAsset);
@@ -1361,7 +1361,7 @@ ${code}
     if (
       isWrapped &&
       !dep.meta.shouldWrap &&
-      (!hoisted || hoisted.keys().next().value !== resolved.id) &&
+      (!hoisted || hoisted.keys().next().value !== resolved) &&
       !this.bundleGraph.isDependencySkipped(dep) &&
       !this.shouldSkipAsset(resolved)
     ) {

--- a/packages/packagers/js/src/ScopeHoistingPackager.ts
+++ b/packages/packagers/js/src/ScopeHoistingPackager.ts
@@ -92,7 +92,7 @@ export class ScopeHoistingPackager {
   globalNames: ReadonlySet<string>;
   // @ts-expect-error TS2564
   assetOutputs: Map<
-    string,
+    Asset,
     {
       code: string;
       map: Buffer | null | undefined;
@@ -109,8 +109,8 @@ export class ScopeHoistingPackager {
   > = new Map();
   externals: Map<string, Map<string, string>> = new Map();
   topLevelNames: Map<string, number> = new Map();
-  seenAssets: Set<string> = new Set();
-  wrappedAssets: Set<string> = new Set();
+  seenAssets: Set<Asset> = new Set();
+  wrappedAssets: Set<Asset> = new Set();
   hoistedRequires: Map<string, Map<string, string>> = new Map();
   seenHoistedRequires: Set<string> = new Set();
   needsPrelude: boolean = false;
@@ -197,7 +197,7 @@ export class ScopeHoistingPackager {
     ) {
       // Write out all constant modules used by this bundle
       for (let asset of constantAssets) {
-        if (!this.seenAssets.has(asset.id)) {
+        if (!this.seenAssets.has(asset)) {
           processAsset(asset);
         }
       }
@@ -206,7 +206,7 @@ export class ScopeHoistingPackager {
     // Hoist wrapped asset to the top of the bundle to ensure that they are registered
     // before they are used.
     for (let asset of wrappedAssets) {
-      if (!this.seenAssets.has(asset.id)) {
+      if (!this.seenAssets.has(asset)) {
         processAsset(asset);
       }
     }
@@ -214,7 +214,7 @@ export class ScopeHoistingPackager {
     // Add each asset that is directly connected to the bundle. Dependencies will be handled
     // by replacing `import` statements in the code.
     this.bundle.traverseAssets((asset, _, actions) => {
-      if (this.seenAssets.has(asset.id)) {
+      if (this.seenAssets.has(asset)) {
         actions.skipChildren();
         return;
       }
@@ -255,7 +255,7 @@ export class ScopeHoistingPackager {
 
     // If any of the entry assets are wrapped, call parcelRequire so they are executed.
     for (let entry of entries) {
-      if (this.wrappedAssets.has(entry.id) && !this.isScriptEntry(entry)) {
+      if (this.wrappedAssets.has(entry) && !this.isScriptEntry(entry)) {
         let parcelRequire = `parcelRequire(${JSON.stringify(
           this.bundleGraph.getAssetPublicId(entry),
         )});\n`;
@@ -299,9 +299,7 @@ export class ScopeHoistingPackager {
       lineCount++;
 
       let mainEntry = nullthrows(this.bundle.getMainEntry());
-      let {code, map: mapBuffer} = nullthrows(
-        this.assetOutputs.get(mainEntry.id),
-      );
+      let {code, map: mapBuffer} = nullthrows(this.assetOutputs.get(mainEntry));
       let map;
       if (mapBuffer) {
         map = new SourceMap(this.options.projectRoot, mapBuffer);
@@ -403,7 +401,10 @@ export class ScopeHoistingPackager {
     wrapped: Array<Asset>;
     constant: Array<Asset>;
   }> {
-    let queue = new PromiseQueue({maxConcurrent: 32});
+    type QueueItem = [Asset, {code: string; map: Buffer | undefined | null}];
+    let queue = new PromiseQueue<QueueItem>({
+      maxConcurrent: 32,
+    });
     let wrapped: Array<Asset> = [];
     let constant: Array<Asset> = [];
 
@@ -414,7 +415,7 @@ export class ScopeHoistingPackager {
           this.bundle.env.sourceMap ? asset.getMapBuffer() : null,
         ]);
 
-        return [asset.id, {code, map}];
+        return [asset, {code, map}];
       });
 
       if (
@@ -432,7 +433,7 @@ export class ScopeHoistingPackager {
             .getIncomingDependencies(asset)
             .some((dep) => dep.priority === 'lazy')
         ) {
-          this.wrappedAssets.add(asset.id);
+          this.wrappedAssets.add(asset);
           wrapped.push(asset);
         } else if (
           (getFeatureFlag('inlineConstOptimisationFix') ||
@@ -453,8 +454,8 @@ export class ScopeHoistingPackager {
       if (!getFeatureFlag('applyScopeHoistingImprovementV2')) {
         // Make all entry assets wrapped, to avoid any top level hoisting
         for (let entryAsset of this.bundle.getEntryAssets()) {
-          if (!this.wrappedAssets.has(entryAsset.id)) {
-            this.wrappedAssets.add(entryAsset.id);
+          if (!this.wrappedAssets.has(entryAsset)) {
+            this.wrappedAssets.add(entryAsset);
             wrapped.push(entryAsset);
           }
         }
@@ -466,7 +467,7 @@ export class ScopeHoistingPackager {
         // The main entry needs to be check to find assets that would have gone in
         // the top level scope
         let mainEntry = this.bundle.getMainEntry();
-        if (mainEntry && !this.wrappedAssets.has(mainEntry.id)) {
+        if (mainEntry && !this.wrappedAssets.has(mainEntry)) {
           moduleGroupParents.unshift(mainEntry);
         }
       }
@@ -477,7 +478,7 @@ export class ScopeHoistingPackager {
             return;
           }
 
-          if (this.wrappedAssets.has(asset.id)) {
+          if (this.wrappedAssets.has(asset)) {
             actions.skipChildren();
             return;
           }
@@ -487,7 +488,7 @@ export class ScopeHoistingPackager {
             (assignedAssets.has(asset) || this.isReExported(asset))
           ) {
             wrapped.push(asset);
-            this.wrappedAssets.add(asset.id);
+            this.wrappedAssets.add(asset);
 
             // This also needs to be added to the traversal so that we iterate
             // it during this check.
@@ -507,20 +508,19 @@ export class ScopeHoistingPackager {
             return;
           }
 
-          if (this.wrappedAssets.has(asset.id)) {
+          if (this.wrappedAssets.has(asset)) {
             actions.skipChildren();
             return;
           }
 
           if (!asset.meta.isConstantModule) {
-            this.wrappedAssets.add(asset.id);
+            this.wrappedAssets.add(asset);
             wrapped.push(asset);
           }
         }, wrappedAssetRoot);
       }
     }
 
-    // @ts-expect-error TS2769
     this.assetOutputs = new Map(await queue.run());
     return {wrapped, constant};
   }
@@ -555,7 +555,7 @@ export class ScopeHoistingPackager {
 
     // TODO: handle ESM exports of wrapped entry assets...
     let entry = this.bundle.getMainEntry();
-    if (entry && !this.wrappedAssets.has(entry.id)) {
+    if (entry && !this.wrappedAssets.has(entry)) {
       let hasNamespace = entry.symbols.hasExportSymbol('*');
 
       for (let {
@@ -637,10 +637,10 @@ export class ScopeHoistingPackager {
   }
 
   visitAsset(asset: Asset): [string, SourceMap | null | undefined, number] {
-    invariant(!this.seenAssets.has(asset.id), 'Already visited asset');
-    this.seenAssets.add(asset.id);
+    invariant(!this.seenAssets.has(asset), 'Already visited asset');
+    this.seenAssets.add(asset);
 
-    let {code, map} = nullthrows(this.assetOutputs.get(asset.id));
+    let {code, map} = nullthrows(this.assetOutputs.get(asset));
     return this.buildAsset(asset, code, map);
   }
 
@@ -653,7 +653,7 @@ export class ScopeHoistingPackager {
     code: string,
     map?: Buffer | null,
   ): [string, SourceMap | null | undefined, number] {
-    let shouldWrap = this.wrappedAssets.has(asset.id);
+    let shouldWrap = this.wrappedAssets.has(asset);
     let deps = this.bundleGraph.getDependencies(asset);
 
     let sourceMap =
@@ -680,10 +680,7 @@ export class ScopeHoistingPackager {
           continue;
         }
 
-        if (
-          this.bundle.hasAsset(resolved) &&
-          !this.seenAssets.has(resolved.id)
-        ) {
+        if (this.bundle.hasAsset(resolved) && !this.seenAssets.has(resolved)) {
           let [code, map, lines] = this.visitAsset(resolved);
           depCode += code + '\n';
           if (sourceMap && map) {
@@ -785,7 +782,7 @@ export class ScopeHoistingPackager {
 
                 if (
                   this.bundle.hasAsset(resolved) &&
-                  !this.seenAssets.has(resolved.id)
+                  !this.seenAssets.has(resolved)
                 ) {
                   // If this asset is wrapped, we need to hoist the code for the dependency
                   // outside our parcelRequire.register wrapper. This is safe because all
@@ -794,7 +791,7 @@ export class ScopeHoistingPackager {
                   if (this.useBothScopeHoistingImprovements) {
                     if (
                       !resolved.meta.isConstantModule &&
-                      !this.wrappedAssets.has(resolved.id)
+                      !this.wrappedAssets.has(resolved)
                     ) {
                       let [depCode, depMap, depLines] =
                         this.visitAsset(resolved);
@@ -1020,7 +1017,7 @@ ${code}
     // If this asset is wrapped, we need to replace the exports namespace with `module.exports`,
     // which will be provided to us by the wrapper.
     if (
-      this.wrappedAssets.has(asset.id) ||
+      this.wrappedAssets.has(asset) ||
       (this.bundle.env.outputFormat === 'commonjs' &&
         asset === this.bundle.getMainEntry())
     ) {
@@ -1210,7 +1207,7 @@ ${code}
     }
     return (
       (!this.bundle.hasAsset(resolved) && !this.externalAssets.has(resolved)) ||
-      (this.wrappedAssets.has(resolved.id) && resolved !== parentAsset)
+      (this.wrappedAssets.has(resolved) && resolved !== parentAsset)
     );
   }
 
@@ -1309,7 +1306,7 @@ ${code}
       // Resolve to the namespace object if requested or this is a CJS default interop reqiure.
       if (
         parentAsset === resolvedAsset &&
-        this.wrappedAssets.has(resolvedAsset.id)
+        this.wrappedAssets.has(resolvedAsset)
       ) {
         // Directly use module.exports for wrapped assets importing themselves.
         return 'module.exports';
@@ -1406,7 +1403,7 @@ ${code}
     let prependLineCount = 0;
     let append = '';
 
-    let shouldWrap = this.wrappedAssets.has(asset.id);
+    let shouldWrap = this.wrappedAssets.has(asset);
     let usedSymbols = nullthrows(this.bundleGraph.getUsedSymbols(asset));
     let assetId = asset.meta.id;
     invariant(typeof assetId === 'string');


### PR DESCRIPTION
## Motivation

Most of the Maps and Sets that we have in the codebase are keyed on object references rather than id strings, but for some reason there are a bunch in the scope hoisting packager.

In theory this should be more efficient, as a reference takes up less space than a string, but this is really just about consistency.

## Changes

The `assetOutputs`, `seenAssets`, and `wrappedAssets` Map/Sets have been migrated to use an `Asset` as their key.

I was also able to remove a ts-expect-error by typing the queue.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
