### PR TITLE
Fix errors when creating diagnostics with relative file paths

### DIFF
--- a/.changeset/quick-guests-return.md
+++ b/.changeset/quick-guests-return.md
@@ -1,0 +1,9 @@
+---
+'@atlaspack/utils': major
+'@atlaspack/transformer-css': patch
+'@atlaspack/transformer-js': patch
+---
+
+Fix errors when creating diagnostics with relative file paths
+
+BREAKING CHANGE: The `remapSourceLocation` API in `@atlaspack/utils` now requires the project root

--- a/packages/core/utils/src/prettyDiagnostic.ts
+++ b/packages/core/utils/src/prettyDiagnostic.ts
@@ -2,6 +2,7 @@ import type {Diagnostic} from '@atlaspack/diagnostic';
 import type {PluginOptions} from '@atlaspack/types-internal';
 
 import formatCodeFrame from '@atlaspack/codeframe';
+import logger from '@atlaspack/logger';
 import _mdAnsi from '@atlaspack/markdown-ansi';
 import _chalk from 'chalk';
 import path from 'path';
@@ -86,7 +87,15 @@ export default async function prettyDiagnostic(
       let highlights = codeFrame.codeHighlights;
       let code = codeFrame.code;
       if (code == null && options && filePath != null) {
-        code = await options.inputFS.readFile(filePath, 'utf8');
+        try {
+          code = await options.inputFS.readFile(filePath, 'utf8');
+        } catch (e) {
+          // In strange cases this can fail and hide the underlying error.
+          logger.warn({
+            origin: '@atlaspack/utils',
+            message: `Failed to read file for generating codeframe: "${filePath}"`,
+          });
+        }
       }
 
       let formattedCodeFrame = '';

--- a/packages/core/utils/src/sourcemap.ts
+++ b/packages/core/utils/src/sourcemap.ts
@@ -95,6 +95,7 @@ export async function loadSourceMap(
 export function remapSourceLocation(
   loc: SourceLocation,
   originalMap: SourceMap,
+  projectRoot: string,
 ): SourceLocation {
   let {
     filePath,
@@ -108,7 +109,11 @@ export function remapSourceLocation(
 
   if (start?.original) {
     if (start.source) {
-      filePath = start.source;
+      if (!path.isAbsolute(start.source)) {
+        filePath = path.join(projectRoot, start.source);
+      } else {
+        filePath = start.source;
+      }
     }
 
     ({line: startLine, column: startCol} = start.original);

--- a/packages/transformers/css/src/CSSTransformer.ts
+++ b/packages/transformers/css/src/CSSTransformer.ts
@@ -220,7 +220,7 @@ export default new Transformer({
       for (let dep of res.dependencies) {
         let loc = convertLoc(dep.loc);
         if (originalMap) {
-          loc = remapSourceLocation(loc, originalMap);
+          loc = remapSourceLocation(loc, originalMap, options.projectRoot);
         }
 
         // @ts-expect-error TS2339

--- a/packages/transformers/js/src/JSTransformer.ts
+++ b/packages/transformers/js/src/JSTransformer.ts
@@ -672,7 +672,11 @@ export default new Transformer({
 
       // If there is an original source map, use it to remap to the original source location.
       if (originalMap) {
-        location = remapSourceLocation(location, originalMap);
+        location = remapSourceLocation(
+          location,
+          originalMap,
+          options.projectRoot,
+        );
       }
 
       return location;


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

When errors occur in files outside the project root, it's currently possible for the diagnostic creation to break handling the file paths. This PR resolves the issue with the following changes.

- Warn instead of blowing up if the code from a code frame can not be read
- Ensure filepaths from sourcemaps are absolute before adding them to the Symbol location

## Checklist

- [ ] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
