### PR TITLE
Fix incorrect output with skipped assets with scope hoisting improvements

### DIFF
--- a/.changeset/eleven-avocados-end.md
+++ b/.changeset/eleven-avocados-end.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/packager-js': patch
+---
+
+Fix incorrect output with skipped assets with scope hoisting improvements


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

This PR resolves an issue where the new partial scope hoisting (`applyScopeHoistingImprovement` and `applyScopeHoistingImprovementV2`) could introduce nested `parcelRegister` calls within a `parcelRegister` which is invalid. This can happen when a skipped asset (an asset where only it's dependencies are added to the bundle) has wrapped dependencies. This is very niche and most builds likely will not run into it.

The fix here is add `parcelRequire` calls to the wrapped assets instead of attempting to inline them.

I was unable to replicate this in a test as I'm not sure how best to recreate all the edge cases in a single test and would like to  fast track the fix. I have validated it against the internal reproduction. 

## Checklist

- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
