### PR TITLE
Fix linking from child directories

### DIFF
--- a/packages/core/utils/package.json
+++ b/packages/core/utils/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@atlaspack/babel-register": "2.14.4",
+    "@types/is-glob": "^4.0.1",
     "benny": "^3.7.1",
     "random-int": "^1.0.0"
   },

--- a/packages/core/utils/src/glob.ts
+++ b/packages/core/utils/src/glob.ts
@@ -1,10 +1,7 @@
-import type {FilePath, Glob} from '@atlaspack/types-internal';
-import type {FileSystem} from '@atlaspack/types-internal';
+import type {FilePath, FileSystem, Glob} from '@atlaspack/types-internal';
 
-// @ts-expect-error TS7016
 import _isGlob from 'is-glob';
-// @ts-expect-error TS2305
-import fastGlob, {FastGlobOptions} from 'fast-glob';
+import fastGlob, {Options as FastGlobOptions} from 'fast-glob';
 import micromatch, {isMatch, makeRe, type Options} from 'micromatch';
 import {normalizeSeparators} from './path';
 
@@ -42,16 +39,14 @@ export function globToRegex(glob: Glob, opts?: Options): RegExp {
 export function globSync(
   p: FilePath,
   fs: FileSystem,
-  options?: FastGlobOptions<FilePath>,
+  options?: FastGlobOptions,
 ): Array<FilePath> {
   options = {
     ...options,
     fs: {
-      // @ts-expect-error TS7006
       statSync: (p) => {
         return fs.statSync(p);
       },
-      // @ts-expect-error TS7006
       lstatSync: (p) => {
         // Our FileSystem interface doesn't have lstat support at the moment,
         // but this is fine for our purposes since we follow symlinks by default.
@@ -64,33 +59,32 @@ export function globSync(
     },
   };
 
-  // @ts-expect-error TS2322
   return fastGlob.sync(normalizeSeparators(p), options);
 }
 
 export function glob(
   p: FilePath,
   fs: FileSystem,
-  options: FastGlobOptions<FilePath>,
+  options: FastGlobOptions,
 ): Promise<Array<FilePath>> {
   options = {
     ...options,
     fs: {
-      // @ts-expect-error TS7006
       stat: async (p, cb) => {
         try {
           cb(null, await fs.stat(p));
         } catch (err: any) {
+          // @ts-expect-error TS2345
           cb(err);
         }
       },
-      // @ts-expect-error TS7006
       lstat: async (p, cb) => {
         // Our FileSystem interface doesn't have lstat support at the moment,
         // but this is fine for our purposes since we follow symlinks by default.
         try {
           cb(null, await fs.stat(p));
         } catch (err: any) {
+          // @ts-expect-error TS2345
           cb(err);
         }
       },
@@ -98,18 +92,19 @@ export function glob(
       readdir: async (p, opts, cb) => {
         if (typeof opts === 'function') {
           cb = opts;
+          // @ts-expect-error TS2322
           opts = null;
         }
 
         try {
           cb(null, await fs.readdir(p, opts));
         } catch (err: any) {
+          // @ts-expect-error TS2345
           cb(err);
         }
       },
     },
   };
 
-  // @ts-expect-error TS2322
   return fastGlob(normalizeSeparators(p), options);
 }

--- a/packages/dev/atlaspack-link/src/AtlaspackLinkConfig.ts
+++ b/packages/dev/atlaspack-link/src/AtlaspackLinkConfig.ts
@@ -88,7 +88,11 @@ export class AtlaspackLinkConfig {
     return this.nodeModulesGlobs.reduce<Array<any>>(
       (matches, pattern) => [
         ...matches,
-        ...globSync(pattern, this.fs, {cwd: this.appRoot, onlyFiles: false}),
+        ...globSync(pattern, this.fs, {
+          cwd: this.appRoot,
+          onlyFiles: false,
+          absolute: true,
+        }),
       ],
       [],
     );

--- a/yarn.lock
+++ b/yarn.lock
@@ -3891,6 +3891,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/is-glob@^4.0.1":
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/@types/is-glob/-/is-glob-4.0.4.tgz#1d60fa47ff70abc97b4d9ea45328747c488b3a50"
+  integrity sha512-3mFBtIPQ0TQetKRDe94g8YrxJZxdMillMGegyv6zRBXvq4peRRhf2wLZ/Dl53emtTsC29dQQBwYvovS20yXpiQ==
+
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"


### PR DESCRIPTION
## Motivation

I'm pretty sure this was working when I tested it the first time, but I guess not.

The glob for node_modules directories previously would resolve the new top level one, but then just return `node_modules` which got matched to the child directory for the cleanup steps.

## Changes

I've made the glob function return absolute paths, so that we know exactly which node_modules dir we're using

## Checklist

- [x] There is a changeset for this change, or one is not required

[no-changeset]: Unreleased package
