### PR TITLE
Just log a warning rather than throwing if an unknown debug tool is passed in

### DIFF
--- a/.changeset/fluffy-rocks-buy.md
+++ b/.changeset/fluffy-rocks-buy.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/utils': patch
+---
+
+Passing in an unknown debug tool will now just warn, rather than blowing up the build.

--- a/packages/core/utils/src/debug-tools.ts
+++ b/packages/core/utils/src/debug-tools.ts
@@ -36,8 +36,9 @@ for (let tool of envVarValue.split(',')) {
   } else if (tool === '') {
     continue;
   } else {
-    throw new Error(
-      `Invalid debug tool option: ${tool}. Valid options are: ${Object.keys(
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Unknown debug tool option: ${tool}. Valid options are: ${Object.keys(
         debugTools,
       ).join(', ')}`,
     );


### PR DESCRIPTION
## Motivation

Throwing is a bit aggressive here, it doesn't need to tank the build.

## Changes

If an unknown debug tool is encountered then it will just log a warning instead now.

## Checklist

- [x] There is a changeset for this change, or one is not required