### PR TITLE
allow additional ignore modules via conditional env variable

### DIFF
--- a/packages/resolvers/tesseract/src/TesseractResolver.ts
+++ b/packages/resolvers/tesseract/src/TesseractResolver.ts
@@ -36,10 +36,12 @@ const getIgnoreModules = (
   env: typeof process.env,
   ignoreModules: Array<string>,
 ) => {
-  if (env.PILLAR_LOCAL_DEVELOPMENT === 'true') {
-    return [...ignoreModules, '@atlassiansox/analytics-web-client'];
+  if (env.SSR_IGNORE_MODULES) {
+    const additionalIgnoreModules = env.SSR_IGNORE_MODULES.split(',')
+      .map((module) => module.trim())
+      .filter((module) => module.length > 0);
+    return [...ignoreModules, ...additionalIgnoreModules];
   }
-
   return ignoreModules;
 };
 


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Allow additional modules to be ignored using `SSR_IGNORE_MODULES` env variable.

## Changes

Modifies getIgnoreModules within `@atlaspack/resolver-tesseract` to remove hardcoded condition to ignore analytics client module, and parses new env variable `SSR_IGNORE_MODULES` for additional modules to be ignored

## Checklist

- [ ] Existing or new tests cover this change
- [ ] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
