### PR TITLE
Manual static binding exports

### DIFF
--- a/.changeset/pretty-melons-jump.md
+++ b/.changeset/pretty-melons-jump.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/packager-js': patch
+---
+
+Experimental config option to manually specify static export bindings as a performance optimisation. Requires the "exportsRebindingOptimisation" flag to be enabled.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     container:
-      image: debian:bullseye-slim
+      image: debian:bookworm-slim
     steps:
       - uses: actions/checkout@v4
       - name: Install dependencies

--- a/packages/packagers/js/src/index.ts
+++ b/packages/packagers/js/src/index.ts
@@ -16,6 +16,7 @@ import {ScopeHoistingPackager} from './ScopeHoistingPackager';
 type JSPackagerConfig = {
   parcelRequireName: string;
   unstable_asyncBundleRuntime: boolean;
+  unstable_manualStaticBindingExports: string[] | null;
 };
 
 const CONFIG_SCHEMA: SchemaEntity = {
@@ -24,6 +25,12 @@ const CONFIG_SCHEMA: SchemaEntity = {
     unstable_asyncBundleRuntime: {
       type: 'boolean',
     },
+    unstable_manualStaticBindingExports: {
+      type: 'array',
+      items: {
+        type: 'string',
+      },
+    },
   },
   additionalProperties: false,
 };
@@ -31,7 +38,10 @@ const CONFIG_SCHEMA: SchemaEntity = {
 export default new Packager({
   async loadConfig({config, options}): Promise<JSPackagerConfig> {
     let packageKey = '@atlaspack/packager-js';
-    let conf = await config.getConfigFrom(options.projectRoot + '/index', [], {
+    let conf = await config.getConfigFrom<{
+      unstable_asyncBundleRuntime?: boolean;
+      unstable_manualStaticBindingExports?: string[];
+    }>(options.projectRoot + '/index', [], {
       packageKey,
     });
 
@@ -51,7 +61,7 @@ export default new Packager({
 
     // Generate a name for the global parcelRequire function that is unique to this project.
     // This allows multiple parcel builds to coexist on the same page.
-    let packageName = await config.getConfigFrom(
+    let packageName = await config.getConfigFrom<string>(
       options.projectRoot + '/index',
       [],
       {
@@ -61,12 +71,12 @@ export default new Packager({
 
     let name = packageName?.contents ?? '';
     return {
-      // @ts-expect-error TS2345
       parcelRequireName: 'parcelRequire' + hashString(name).slice(-4),
       unstable_asyncBundleRuntime: Boolean(
-        // @ts-expect-error TS2339
         conf?.contents?.unstable_asyncBundleRuntime,
       ),
+      unstable_manualStaticBindingExports:
+        conf?.contents?.unstable_manualStaticBindingExports ?? null,
     };
   },
   async package({
@@ -100,6 +110,7 @@ export default new Packager({
             bundle,
             nullthrows(config).parcelRequireName,
             nullthrows(config).unstable_asyncBundleRuntime,
+            nullthrows(config).unstable_manualStaticBindingExports,
             logger,
           )
         : new DevPackager(


### PR DESCRIPTION
## Motivation

This change introduces a performance optimisation for the scope hoisting packager by allowing developers to manually specify static export bindings. This can help improve runtime performance in scenarios where the automatic analysis of export bindings is not implemented (CJS).

## Changes

- Added `unstable_manualStaticBindingExports` configuration option to the JS packager
- Updated the configuration schema to accept an array of strings for manual static binding exports
- Modified `ScopeHoistingPackager` to utilise the manual static binding configuration
- Improved TypeScript types and removed some type errors in the configuration loading
- Added changeset for the new feature

The new configuration option:
- Is experimental (prefixed with `unstable_`)
- Accepts an array of export names that should be treated as static bindings
- Requires the "exportsRebindingOptimisation" flag to be enabled
- Provides a manual override for performance-critical scenarios

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder
