### PR TITLE
Add linting to ts refs script

### DIFF
--- a/packages/bundlers/bundler-experimental/tsconfig.json
+++ b/packages/bundlers/bundler-experimental/tsconfig.json
@@ -1,5 +1,39 @@
 {
   "extends": "../../../tsconfig.base.json",
   "include": ["src"],
-  "composite": true
+  "compilerOptions": {
+    "composite": true
+  },
+  "references": [
+    {
+      "path": "../../core/core/tsconfig.json"
+    },
+    {
+      "path": "../../core/diagnostic/tsconfig.json"
+    },
+    {
+      "path": "../../core/feature-flags/tsconfig.json"
+    },
+    {
+      "path": "../../core/fs/tsconfig.json"
+    },
+    {
+      "path": "../../core/graph/tsconfig.json"
+    },
+    {
+      "path": "../../core/logger/tsconfig.json"
+    },
+    {
+      "path": "../../core/plugin/tsconfig.json"
+    },
+    {
+      "path": "../../core/rust/tsconfig.json"
+    },
+    {
+      "path": "../../core/types/tsconfig.json"
+    },
+    {
+      "path": "../../core/utils/tsconfig.json"
+    }
+  ]
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.0.3",
   "devDependencies": {
+    "@ast-grep/napi": "^0.39.5",
     "@swc/plugin-transform-imports": "^8.0.4",
     "flowgen": "^1.21.0",
     "glob": "^7.1.6",

--- a/scripts/update-ts-references.mjs
+++ b/scripts/update-ts-references.mjs
@@ -6,7 +6,7 @@ import url from 'node:url';
 import path from 'node:path';
 import glob from 'glob';
 import pkg from 'json5';
-import { parse as astParse } from '@ast-grep/napi';
+import {parse as astParse} from '@ast-grep/napi';
 
 const {parse} = pkg;
 
@@ -44,7 +44,7 @@ function checkForPackageJsonImports(packagePath) {
     // Get all TypeScript/JavaScript files in src directory recursively
     const sourceFiles = glob.sync('**/*.{ts,tsx,js,jsx}', {
       cwd: srcPath,
-      absolute: true
+      absolute: true,
     });
 
     for (const filePath of sourceFiles) {
@@ -54,7 +54,8 @@ function checkForPackageJsonImports(packagePath) {
 
         // Determine language for ast-grep based on file extension
         const ext = path.extname(filePath);
-        const language = ext === '.ts' || ext === '.tsx' ? 'typescript' : 'javascript';
+        const language =
+          ext === '.ts' || ext === '.tsx' ? 'typescript' : 'javascript';
 
         // Parse the file into an AST
         const ast = astParse(language, content);
@@ -84,8 +85,10 @@ function checkForPackageJsonImports(packagePath) {
                 // Remove quotes and check if it's a relative import of package.json
                 const cleanPath = importPath.replace(/['"]/g, '');
                 // Only match relative imports to own package.json (starts with ./ or ../)
-                if ((cleanPath.startsWith('./') || cleanPath.startsWith('../')) &&
-                    cleanPath.endsWith('/package.json')) {
+                if (
+                  (cleanPath.startsWith('./') || cleanPath.startsWith('../')) &&
+                  cleanPath.endsWith('/package.json')
+                ) {
                   return true;
                 }
               }
@@ -155,7 +158,10 @@ function getAllPackages(frozen = false) {
       const relativeTsconfigPath = path.relative(__root, tsconfigPath);
 
       // Calculate expected extends path relative to package directory
-      const expectedExtends = path.relative(packagePath, path.join(__root, 'tsconfig.base.json'));
+      const expectedExtends = path.relative(
+        packagePath,
+        path.join(__root, 'tsconfig.base.json'),
+      );
 
       let tsconfigChanged = false;
 
@@ -199,7 +205,10 @@ function getAllPackages(frozen = false) {
 
       // Assertion 3: Check if source code imports package.json, and if so, validate it's in include array
       const hasPackageJsonImport = checkForPackageJsonImports(packagePath);
-      if (hasPackageJsonImport && (!tsconfig.include || !tsconfig.include.includes('./package.json'))) {
+      if (
+        hasPackageJsonImport &&
+        (!tsconfig.include || !tsconfig.include.includes('./package.json'))
+      ) {
         if (frozen) {
           console.error(
             `❌ ${relativeTsconfigPath}: Source code imports package.json but "./package.json" is missing from "include" array. Got: ${JSON.stringify(tsconfig.include || [])}`,
@@ -245,7 +254,7 @@ function getAllPackages(frozen = false) {
     }
   }
 
-  return { packages, validationErrors, validationFixes };
+  return {packages, validationErrors, validationFixes};
 }
 
 /**
@@ -389,7 +398,7 @@ function main() {
 
   console.log('🔍 Scanning for TypeScript packages...');
 
-  const { packages, validationErrors, validationFixes } = getAllPackages(frozen);
+  const {packages, validationErrors, validationFixes} = getAllPackages(frozen);
   console.log(
     `Found ${packages.size} TypeScript packages with composite: true`,
   );

--- a/scripts/update-ts-references.mjs
+++ b/scripts/update-ts-references.mjs
@@ -178,11 +178,23 @@ function getAllPackages(frozen = false) {
 
       // Assertion 2: Should include compilerOptions.composite: true
       if (!tsconfig.compilerOptions?.composite) {
-        console.error(
-          `❌ ${relativeTsconfigPath}: Expected "compilerOptions.composite": true, but got: ${tsconfig.compilerOptions?.composite || 'undefined'}`,
-        );
-        validationErrors++;
-        continue;
+        if (frozen) {
+          console.error(
+            `❌ ${relativeTsconfigPath}: Expected "compilerOptions.composite": true, but got: ${tsconfig.compilerOptions?.composite || 'undefined'}`,
+          );
+          validationErrors++;
+          continue;
+        } else {
+          console.log(
+            `🔧 ${relativeTsconfigPath}: Adding "compilerOptions.composite": true`,
+          );
+          if (!tsconfig.compilerOptions) {
+            tsconfig.compilerOptions = {};
+          }
+          tsconfig.compilerOptions.composite = true;
+          tsconfigChanged = true;
+          validationFixes++;
+        }
       }
 
       // Assertion 3: Check if source code imports package.json, and if so, validate it's in include array

--- a/scripts/update-ts-references.mjs
+++ b/scripts/update-ts-references.mjs
@@ -6,6 +6,8 @@ import url from 'node:url';
 import path from 'node:path';
 import glob from 'glob';
 import pkg from 'json5';
+import { parse as astParse } from '@ast-grep/napi';
+
 const {parse} = pkg;
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
@@ -17,19 +19,102 @@ const IGNORED_PATTERNS = [
   'node-resolver-core/test/fixture',
   'test/fixtures',
   'examples',
+  'example',
   'integration-tests',
   'workers/test/integration',
   'fixtures',
   'fixture',
   'template',
   'lib',
+  'packages/dev/atlaspack-inspector',
 ];
+
+/**
+ * Check if a package's source code imports its package.json file using AST analysis
+ */
+function checkForPackageJsonImports(packagePath) {
+  const srcPath = path.join(packagePath, 'src');
+
+  // Check if src directory exists
+  if (!fs.existsSync(srcPath)) {
+    return false;
+  }
+
+  try {
+    // Get all TypeScript/JavaScript files in src directory recursively
+    const sourceFiles = glob.sync('**/*.{ts,tsx,js,jsx}', {
+      cwd: srcPath,
+      absolute: true
+    });
+
+    for (const filePath of sourceFiles) {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        if (!content.includes('package.json')) continue;
+
+        // Determine language for ast-grep based on file extension
+        const ext = path.extname(filePath);
+        const language = ext === '.ts' || ext === '.tsx' ? 'typescript' : 'javascript';
+
+        // Parse the file into an AST
+        const ast = astParse(language, content);
+        const root = ast.root();
+
+        // Define patterns to match different types of package.json imports
+        const patterns = [
+          // ES6 import statements - default imports
+          'import $IDENTIFIER from $STRING',
+          // ES6 import statements - named imports
+          'import { $$$NAMES } from $STRING',
+          // ES6 import statements - namespace imports
+          'import * as $IDENTIFIER from $STRING',
+          // CommonJS require statements
+          'require($STRING)',
+        ];
+
+        // Check each pattern
+        for (const pattern of patterns) {
+          const matches = root.findAll(pattern);
+          for (const match of matches) {
+            try {
+              // Get the import/require path
+              const stringNodes = match.findAll('$STRING');
+              for (const stringNode of stringNodes) {
+                const importPath = stringNode.text();
+                // Remove quotes and check if it's a relative import of package.json
+                const cleanPath = importPath.replace(/['"]/g, '');
+                // Only match relative imports to own package.json (starts with ./ or ../)
+                if ((cleanPath.startsWith('./') || cleanPath.startsWith('../')) &&
+                    cleanPath.endsWith('/package.json')) {
+                  return true;
+                }
+              }
+            } catch {
+              // Continue checking other matches if this one fails
+              continue;
+            }
+          }
+        }
+      } catch {
+        // Skip files that can't be parsed, but don't fail the whole process
+        continue;
+      }
+    }
+  } catch {
+    // If we can't scan the directory, assume no imports
+    return false;
+  }
+
+  return false;
+}
 
 /**
  * Get all package information from the monorepo
  */
-function getAllPackages() {
+function getAllPackages(frozen = false) {
   const packages = new Map();
+  let validationErrors = 0;
+  let validationFixes = 0;
 
   for (const packageJsonPathRel of glob.sync('packages/**/*/package.json', {
     cwd: __root,
@@ -66,12 +151,68 @@ function getAllPackages() {
         );
       }
 
-      // Only include packages with composite: true
+      // Validate tsconfig assertions
+      const relativeTsconfigPath = path.relative(__root, tsconfigPath);
+
+      // Calculate expected extends path relative to package directory
+      const expectedExtends = path.relative(packagePath, path.join(__root, 'tsconfig.base.json'));
+
+      let tsconfigChanged = false;
+
+      // Assertion 1: Should extend tsconfig.base.json from the root
+      if (!tsconfig.extends || tsconfig.extends !== expectedExtends) {
+        if (frozen) {
+          console.error(
+            `❌ ${relativeTsconfigPath}: Expected "extends": "${expectedExtends}", but got: "${tsconfig.extends || 'undefined'}"`,
+          );
+          validationErrors++;
+        } else {
+          console.log(
+            `🔧 ${relativeTsconfigPath}: Fixing "extends" path from "${tsconfig.extends || 'undefined'}" to "${expectedExtends}"`,
+          );
+          tsconfig.extends = expectedExtends;
+          tsconfigChanged = true;
+          validationFixes++;
+        }
+      }
+
+      // Assertion 2: Should include compilerOptions.composite: true
       if (!tsconfig.compilerOptions?.composite) {
+        console.error(
+          `❌ ${relativeTsconfigPath}: Expected "compilerOptions.composite": true, but got: ${tsconfig.compilerOptions?.composite || 'undefined'}`,
+        );
+        validationErrors++;
         continue;
       }
 
-      const relativeTsconfigPath = path.relative(__root, tsconfigPath);
+      // Assertion 3: Check if source code imports package.json, and if so, validate it's in include array
+      const hasPackageJsonImport = checkForPackageJsonImports(packagePath);
+      if (hasPackageJsonImport && (!tsconfig.include || !tsconfig.include.includes('./package.json'))) {
+        if (frozen) {
+          console.error(
+            `❌ ${relativeTsconfigPath}: Source code imports package.json but "./package.json" is missing from "include" array. Got: ${JSON.stringify(tsconfig.include || [])}`,
+          );
+          validationErrors++;
+        } else {
+          console.log(
+            `🔧 ${relativeTsconfigPath}: Adding "./package.json" to include array (source code imports package.json)`,
+          );
+          if (!tsconfig.include) {
+            tsconfig.include = [];
+          }
+          tsconfig.include.push('./package.json');
+          tsconfigChanged = true;
+          validationFixes++;
+        }
+      }
+
+      // Write the updated tsconfig if changes were made
+      if (tsconfigChanged) {
+        fs.writeFileSync(
+          tsconfigPath,
+          JSON.stringify(tsconfig, null, 2) + '\n',
+        );
+      }
 
       packages.set(pkg.name, {
         name: pkg.name,
@@ -92,7 +233,7 @@ function getAllPackages() {
     }
   }
 
-  return packages;
+  return { packages, validationErrors, validationFixes };
 }
 
 /**
@@ -236,10 +377,16 @@ function main() {
 
   console.log('🔍 Scanning for TypeScript packages...');
 
-  const packages = getAllPackages();
+  const { packages, validationErrors, validationFixes } = getAllPackages(frozen);
   console.log(
     `Found ${packages.size} TypeScript packages with composite: true`,
   );
+
+  if (validationFixes > 0) {
+    console.log(
+      `🔧 Fixed ${validationFixes} validation issue${validationFixes === 1 ? '' : 's'}`,
+    );
+  }
 
   console.log('\n📝 Updating individual package references...');
   const packageUpdates = updateTsConfigReferences(packages, frozen);
@@ -254,10 +401,22 @@ function main() {
   console.log(
     `  - tsconfig.paths.json ${rootUpdated ? 'updated' : 'unchanged'}`,
   );
-
-  if (frozen && (packageUpdates > 0 || rootUpdated)) {
+  if (validationFixes > 0) {
     console.log(
-      '\n❌ Exiting with error. Rerun without --frozen to update references.',
+      `  - Fixed ${validationFixes} validation issue${validationFixes === 1 ? '' : 's'}`,
+    );
+  }
+
+  if (frozen && (packageUpdates > 0 || rootUpdated || validationFixes > 0)) {
+    console.log(
+      '\n❌ Exiting with error. Rerun without --frozen to update references and fix validation issues.',
+    );
+    process.exitCode = 1;
+  }
+
+  if (validationErrors > 0) {
+    console.log(
+      `\n❌ Found ${validationErrors} validation error${validationErrors === 1 ? '' : 's'}. Please fix the issues above.`,
     );
     process.exitCode = 1;
   }

--- a/tsconfig.paths.json
+++ b/tsconfig.paths.json
@@ -366,6 +366,9 @@
     },
     {
       "path": "./packages/validators/typescript/tsconfig.json"
+    },
+    {
+      "path": "./packages/bundlers/bundler-experimental/tsconfig.json"
     }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,6 +68,66 @@
     "@csstools/css-tokenizer" "^3.0.3"
     lru-cache "^10.4.3"
 
+"@ast-grep/napi-darwin-arm64@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-darwin-arm64/-/napi-darwin-arm64-0.39.5.tgz#73826167721673cda7f558036443b8b2981bc121"
+  integrity sha512-UqIUjowAcXTJ00R5+bIi+2nQStzbpBeFEsXe0G1hXZVsWytaa69W4/Ewnr84IdeIo7IcpbFY/Y35PdYIDR36eQ==
+
+"@ast-grep/napi-darwin-x64@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-darwin-x64/-/napi-darwin-x64-0.39.5.tgz#e56f933475e61b66015129782edb58f81762706b"
+  integrity sha512-TZLIFoGbVUD9iCQmYTv2isLUBVRPu9kd+q1ifkdQ4iaSlit5UEqvvgluU0NHhWeAg1pW5EuN2COlSbvlcr/RKQ==
+
+"@ast-grep/napi-linux-arm64-gnu@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-arm64-gnu/-/napi-linux-arm64-gnu-0.39.5.tgz#2db6af2c8bdbcf7f12cd3a457a7004e7031f6d70"
+  integrity sha512-QPoVTfRzIyQRI7lNRMsuOTr8OfFLw8iLQSOHwAqa64Cb5AnjJIfLZEBIJhWj+z62ZWcFiX9sn2c8HlCp+58lAg==
+
+"@ast-grep/napi-linux-arm64-musl@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-arm64-musl/-/napi-linux-arm64-musl-0.39.5.tgz#d6fedb1317bb5a69df2599240f92bf5fdd1bb8b8"
+  integrity sha512-pk756OgZxienyktNJqiYHVF11zWR/zmOQRiFEzN70W+rWI6wQFRvdi4JPaezKScR524AKuSAeWXR7PUglBnoaA==
+
+"@ast-grep/napi-linux-x64-gnu@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-x64-gnu/-/napi-linux-x64-gnu-0.39.5.tgz#c795a3c8d70752f4063bf241a4eb685faf5bd6f7"
+  integrity sha512-UcQSD5A10isLk1TqvFzp4MfPZhAUc0Ehraf3ytsgaIjs9GUxjEc4uI6aKVesXd0Y1DDE/SjakgNfcAcizokjPw==
+
+"@ast-grep/napi-linux-x64-musl@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-linux-x64-musl/-/napi-linux-x64-musl-0.39.5.tgz#7df7f8fa9eb46caab4bb786e58035e36974ad62c"
+  integrity sha512-aJyiF57bA8Pa6H5hPNq5qz/hh6Q/NQ3f0cAe0oE09KW09lLGK3CWWInENq8QiK+nhO1aAaFvxGhUKUDwroA9ow==
+
+"@ast-grep/napi-win32-arm64-msvc@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-win32-arm64-msvc/-/napi-win32-arm64-msvc-0.39.5.tgz#9bafe76758d1b0078a2eca2ce4405379adb6943f"
+  integrity sha512-FfluwNw+oItFVMr7o26lnK9euFU6084JSBLFsbIhTdfZO2xiTRrxPXFm5A3jvr0grv669GBLJKfp9DNxcsoYsg==
+
+"@ast-grep/napi-win32-ia32-msvc@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-win32-ia32-msvc/-/napi-win32-ia32-msvc-0.39.5.tgz#eb04bb9a412986fb8e8963ee3c52c18b719600e1"
+  integrity sha512-pmx8Zfdv8qEgoepDB+XqV+nThnBioxvsDQT+q310RmeP4cRuSEHI13U3eb5Bgy/E0tGFzTSnQSKifZHuonp7YA==
+
+"@ast-grep/napi-win32-x64-msvc@0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi-win32-x64-msvc/-/napi-win32-x64-msvc-0.39.5.tgz#5cf74bd3098e21e5289022920b665466bae415a5"
+  integrity sha512-bffrn4aF7Tu7hN6qPfZ6PCcbfwRokamUst32ZyJIxBJRAuVua1+CDBXeBug6UHj96tSt0Oh6h2cvh+1mEqL1jg==
+
+"@ast-grep/napi@^0.39.5":
+  version "0.39.5"
+  resolved "https://registry.yarnpkg.com/@ast-grep/napi/-/napi-0.39.5.tgz#eebc48242988873eee7943a41ac9103430725870"
+  integrity sha512-/qEPYdY0+Mg4fdS06CY4Jptzbd6NDvdkKRBL1vTnpY8BO4t6j1q9sbNobgm74pr2xPv13Z4Lq2hVNzAYJNy9dw==
+  optionalDependencies:
+    "@ast-grep/napi-darwin-arm64" "0.39.5"
+    "@ast-grep/napi-darwin-x64" "0.39.5"
+    "@ast-grep/napi-linux-arm64-gnu" "0.39.5"
+    "@ast-grep/napi-linux-arm64-musl" "0.39.5"
+    "@ast-grep/napi-linux-x64-gnu" "0.39.5"
+    "@ast-grep/napi-linux-x64-musl" "0.39.5"
+    "@ast-grep/napi-win32-arm64-msvc" "0.39.5"
+    "@ast-grep/napi-win32-ia32-msvc" "0.39.5"
+    "@ast-grep/napi-win32-x64-msvc" "0.39.5"
+
 "@atlaskit/analytics-next-stable-react-context@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@atlaskit/analytics-next-stable-react-context/-/analytics-next-stable-react-context-1.0.1.tgz#93c4c7a1a35f4ab606d727af443f49f0842fd96f"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

There's a few gotchas when creating a new package in terms of making sure the tsconfig has all the right bits to ensure it builds properly and finds errors properly.

## Changes

* added linting for common issues - missing composite option, missing package.json if used in src, incorrect base reference
* added fixing when not running in `--frozen` mode

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: tools
