### PR TITLE
Fix custom environment properties sometimes being ignored

### DIFF
--- a/.changeset/ninety-frogs-live.md
+++ b/.changeset/ninety-frogs-live.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/core': minor
+---
+
+Fix custom environment properties sometimes being ignored

--- a/packages/core/core/src/requests/TargetRequest.ts
+++ b/packages/core/core/src/requests/TargetRequest.ts
@@ -1151,6 +1151,7 @@ export class TargetResolver {
             shouldScopeHoist:
               shouldScopeHoist && descriptor.scopeHoist !== false,
             sourceMap: normalizeSourceMap(this.options, descriptor.sourceMap),
+            customEnv: descriptor.env,
           }),
           loc: toInternalSourceLocation(this.options.projectRoot, loc),
         });

--- a/packages/core/core/test/TargetRequest.test.ts
+++ b/packages/core/core/test/TargetRequest.test.ts
@@ -382,6 +382,9 @@ describe('TargetResolver', () => {
             loc: undefined,
             sourceType: 'module',
             unstableSingleFileOutput: false,
+            customEnv: {
+              useFlag: 'false',
+            },
           }),
           loc: {
             filePath: relative(
@@ -416,6 +419,9 @@ describe('TargetResolver', () => {
             loc: undefined,
             sourceType: 'module',
             unstableSingleFileOutput: false,
+            customEnv: {
+              useFlag: 'true',
+            },
           }),
           loc: {
             filePath: relative(
@@ -501,6 +507,9 @@ describe('TargetResolver', () => {
             loc: undefined,
             sourceType: 'module',
             unstableSingleFileOutput: false,
+            customEnv: {
+              useFlag: 'false',
+            },
           }),
           loc: {
             filePath: relative(
@@ -535,6 +544,9 @@ describe('TargetResolver', () => {
             loc: undefined,
             sourceType: 'module',
             unstableSingleFileOutput: false,
+            customEnv: {
+              useFlag: 'true',
+            },
           }),
           loc: {
             filePath: relative(

--- a/packages/core/core/test/fixtures/custom-targets/package.json
+++ b/packages/core/core/test/fixtures/custom-targets/package.json
@@ -9,11 +9,17 @@
     "browserModern": {
       "engines": {
         "browsers": ["last 1 version"]
+      },
+      "env": {
+        "useFlag": "false"
       }
     },
     "browserLegacy": {
       "engines": {
         "browsers": ["ie11"]
+      },
+      "env": {
+        "useFlag": "true"
       }
     }
   }


### PR DESCRIPTION
## Motivation

While investigating avenues for configuring WIP native transformers I noticed that custom environment properties were not being used by the bundler and found that the second place assignment could be done seems to have just been overlooked.

## Changes

* Add missing `customEnv` assignment from descriptor in `resolvePackageTargets`
* Add to existing tests to verify addition

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder
