### PR TITLE
Cleanup customEnvInTargets feature flag

### DIFF
--- a/.changeset/seven-pens-beg.md
+++ b/.changeset/seven-pens-beg.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/feature-flags': patch
+---
+
+Cleanup customEnvInTargets feature flag

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -249,14 +249,6 @@ export const DEFAULT_FEATURE_FLAGS = {
   exportsRebindingOptimisation: false,
 
   /**
-   * When enabled, allows custom per-target "env" properties to be used in transformers.
-   *
-   * @author Marcin Szczepanski <mszczepanski@atlassian.com>
-   * @since 2025-09-04
-   */
-  customEnvInTargets: process.env.ATLASPACK_BUILD_ENV === 'test',
-
-  /**
    * When enabled, ensures the `unstableSingleFileOutput` environment property is preserved during CSS transformation
    *
    * @author Marcin Szczepanski <mszczepanski@atlassian.com>

--- a/packages/core/integration-tests/test/targets.ts
+++ b/packages/core/integration-tests/test/targets.ts
@@ -25,7 +25,7 @@ describe('targets', () => {
               ]
             }
           }
-          
+
         common.js:
           export const common = 'my env is: MY_ENV';
 
@@ -72,7 +72,6 @@ describe('targets', () => {
         },
         featureFlags: {
           allowExplicitTargetEntries: true,
-          customEnvInTargets: true,
         },
       },
     );


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

The `customEnvInTargets` feature flag is unused / rolled out so can be cleaned up.

## Changes

Clean up the `customEnvInTargets` feature flag

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
