### PR TITLE
Add script to validate all feature flags are used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,14 @@ jobs:
       - uses: ./.github/actions/setup-node
       - run: yarn build:ts
 
+  lint_feature_flags:
+    name: 🏴‍☠️ Lint Feature Flags
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-node
+      - run: yarn lint:feature-flags
+
   lint_rust:
     name: 🦀 Lint Rust
     runs-on: ubuntu-24.04

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "check": "flow check",
     "update-ts-references": "node scripts/update-ts-references.mjs",
     "lint": "node ./scripts/lint-all.mjs",
+    "lint:feature-flags": "node ./scripts/find-unused-feature-flags.js",
     "prepublishOnly": "yarn pre-publish",
     "pre-publish": "yarn build && node ./scripts/rewrite-package-types.mjs",
     "changesets-publish": "yarn pre-publish && yarn changeset publish",

--- a/scripts/find-unused-feature-flags.js
+++ b/scripts/find-unused-feature-flags.js
@@ -1,0 +1,315 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * Find unused feature flags in the Atlaspack codebase
+ *
+ * This script:
+ * 1. Reads all feature flag names from DEFAULT_FEATURE_FLAGS in packages/core/feature-flags/src/index.ts
+ * 2. Uses fast-glob to find all TypeScript/JavaScript/Rust files in packages/ and crates/ (excluding lib/ directories)
+ * 3. Lazily filters files that contain feature flag patterns for efficiency
+ * 4. Uses AST parsing via @ast-grep/napi to find:
+ *    - TypeScript/JavaScript: getFeatureFlag() and getFeatureFlagValue() function calls
+ *    - TypeScript/JavaScript: *.featureFlags.<name> property access patterns
+ *    - TypeScript/JavaScript: *.featureFlags?.<name> optional chaining patterns
+ *    - Rust: *.feature_flags.bool_enabled("<name>") method calls
+ * 5. Returns a list of feature flags that are defined but never used (ignoring example flags)
+ *
+ * Dependencies: fast-glob, @ast-grep/napi
+ * Usage: node scripts/find-unused-feature-flags.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+const fg = require('fast-glob');
+const {parse, Lang} = require('@ast-grep/napi');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const FEATURE_FLAGS_FILE = path.join(
+  REPO_ROOT,
+  'packages/core/feature-flags/src/index.ts',
+);
+const PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
+const CRATES_DIR = path.join(REPO_ROOT, 'crates');
+
+/**
+ * Extract feature flag names from the DEFAULT_FEATURE_FLAGS object using AST parsing
+ */
+function extractFeatureFlagNames() {
+  try {
+    const content = fs.readFileSync(FEATURE_FLAGS_FILE, 'utf8');
+
+    // Parse the TypeScript file using @ast-grep/napi
+    const ast = parse(Lang.TypeScript, content);
+    const root = ast.root();
+
+    const flagNames = [];
+
+    // Find all pairs (property assignments) inside the DEFAULT_FEATURE_FLAGS variable declarator
+    const properties = root.findAll({
+      rule: {
+        kind: 'pair',
+        inside: {
+          kind: 'variable_declarator',
+          stopBy: 'end',
+          has: {
+            field: 'name',
+            regex: 'DEFAULT_FEATURE_FLAGS',
+          },
+        },
+      },
+    });
+
+    for (const property of properties) {
+      // Get the key field which contains the property name
+      const keyNode = property.field('key');
+      if (keyNode && keyNode.text()) {
+        let flagName = keyNode.text().trim();
+
+        // Remove quotes if it's a string literal property name
+        if (
+          (flagName.startsWith('"') && flagName.endsWith('"')) ||
+          (flagName.startsWith("'") && flagName.endsWith("'")) ||
+          (flagName.startsWith('`') && flagName.endsWith('`'))
+        ) {
+          flagName = flagName.slice(1, -1);
+        }
+
+        // Only add valid identifier names
+        if (flagName && /^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(flagName)) {
+          flagNames.push(flagName);
+        }
+      }
+    }
+
+    if (flagNames.length === 0) {
+      throw new Error(
+        'Could not find any feature flag properties in DEFAULT_FEATURE_FLAGS',
+      );
+    }
+
+    return flagNames;
+  } catch (error) {
+    console.error('Error extracting feature flag names:', error.message);
+    process.exit(1);
+  }
+}
+
+/**
+ * Search for feature flag usage in packages/ and crates/ directories using fast-glob and AST parsing
+ */
+function findGetFeatureFlagUsage() {
+  const usedFlags = new Set();
+
+  try {
+    // Use fast-glob to find all TypeScript/JavaScript files in packages and Rust files in crates
+    const tsJsPattern = `${PACKAGES_DIR}/**/src/**/*.{ts,tsx,js,jsx}`;
+    const rustPattern = `${CRATES_DIR}/**/*.rs`;
+    const ignorePatterns = ['**/lib/**', '**/node_modules/**', '**/target/**'];
+
+    console.log('   📁 Finding TypeScript/JavaScript and Rust files...');
+
+    const tsJsFiles = fg.sync(tsJsPattern, {
+      ignore: ignorePatterns,
+      absolute: true,
+      onlyFiles: true,
+    });
+
+    const rustFiles = fg.sync(rustPattern, {
+      ignore: ignorePatterns,
+      absolute: true,
+      onlyFiles: true,
+    });
+
+    const allFiles = [...tsJsFiles, ...rustFiles];
+
+    console.log(
+      `   📄 Found ${allFiles.length} source files (${tsJsFiles.length} TS/JS, ${rustFiles.length} Rust), filtering for feature flag usage...`,
+    );
+
+    // Filter files that contain feature flag patterns and parse them
+    let candidateFiles = [];
+    for (const filePath of allFiles) {
+      try {
+        const content = fs.readFileSync(filePath, 'utf8');
+        // Check for TypeScript/JavaScript patterns or Rust patterns
+        if (
+          content.includes('getFeatureFlag') ||
+          content.includes('getFeatureFlagValue') ||
+          content.includes('featureFlags') ||
+          content.includes('feature_flags')
+        ) {
+          candidateFiles.push(filePath);
+        }
+      } catch (error) {
+        // Skip files that can't be read
+        console.warn(`   ⚠️  Could not read file: ${filePath}: ${error}`);
+      }
+    }
+
+    console.log(
+      `   🔍 Found ${candidateFiles.length} files containing feature flag patterns`,
+    );
+
+    // Now parse each candidate file using AST
+    for (const filePath of candidateFiles) {
+      const fileFlags = parseFileForFlags(filePath);
+      fileFlags.forEach((flag) => usedFlags.add(flag));
+    }
+
+    return Array.from(usedFlags);
+  } catch (error) {
+    console.error('Error searching for getFeatureFlag usage:', error.message);
+    return [];
+  }
+}
+
+/**
+ * Parse a file using ast-grep to find feature flag usage patterns in TypeScript/JavaScript/Rust
+ */
+function parseFileForFlags(filePath) {
+  const usedFlags = new Set();
+
+  try {
+    const content = fs.readFileSync(filePath, 'utf8');
+
+    // Quick string check first - only parse if feature flag patterns are mentioned
+    if (
+      !content.includes('getFeatureFlag') &&
+      !content.includes('getFeatureFlagValue') &&
+      !content.includes('featureFlags') &&
+      !content.includes('feature_flags')
+    ) {
+      return Array.from(usedFlags);
+    }
+
+    // Skip the feature flags definition file itself
+    if (filePath.includes('feature-flags/src/index.ts')) {
+      return Array.from(usedFlags);
+    }
+
+    // Determine language based on file extension
+    let language;
+
+    if (filePath.endsWith('.rs')) {
+      language = Lang.Rust;
+    } else if (/\.tsx?$/.test(filePath)) {
+      language = Lang.TypeScript;
+    } else {
+      language = Lang.JavaScript;
+    }
+
+    // @ast-grep/napi currently fails to parse Rust files properly, so this is a bit of a hack
+    if (language === Lang.Rust) {
+      // Handle Rust patterns: *.feature_flags.bool_enabled("<flag>")
+      const rustPattern = /bool_enabled\("([^"]+)"\)/g;
+      let match;
+      while ((match = rustPattern.exec(content)) !== null) {
+        const flagName = match[1];
+        if (flagName) {
+          usedFlags.add(flagName);
+        }
+      }
+    } else {
+      // Handle TypeScript/JavaScript patterns
+      // Parse the file
+      const ast = parse(language, content);
+      const root = ast.root();
+
+      // Find all getFeatureFlag calls with string arguments
+      const flagAccessCalls = root.findAll({
+        rule: {
+          any: [
+            {pattern: 'getFeatureFlag($FLAG)'},
+            {pattern: 'getFeatureFlagValue($FLAG)'},
+            {pattern: '$OBJ.featureFlags.$FLAG'},
+            {pattern: '$OBJ.featureFlags?.$FLAG'},
+          ],
+        },
+      });
+
+      for (const call of flagAccessCalls) {
+        const flagMatch = call.getMatch('FLAG');
+        if (flagMatch && flagMatch.text()) {
+          let flagName = flagMatch.text().trim();
+          // Check if it's a string literal
+          if (
+            (flagName.startsWith('"') && flagName.endsWith('"')) ||
+            (flagName.startsWith("'") && flagName.endsWith("'")) ||
+            (flagName.startsWith('`') && flagName.endsWith('`'))
+          ) {
+            // Remove quotes from string literal
+            flagName = flagName.slice(1, -1);
+          }
+          if (flagName) {
+            usedFlags.add(flagName);
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.warn(`Error parsing file ${filePath}:`, error.message);
+  }
+
+  return Array.from(usedFlags);
+}
+
+/**
+ * Main function to find unused feature flags
+ */
+function main() {
+  console.log('🏁 Finding unused feature flags...\n');
+
+  console.log('📖 Extracting feature flag names from DEFAULT_FEATURE_FLAGS...');
+  const allFlags = extractFeatureFlagNames();
+  console.log(`   Found ${allFlags.length} feature flags`);
+
+  console.log(
+    '\n🔍 Searching for feature flag usage patterns in packages/ and crates/...',
+  );
+  const usedFlags = findGetFeatureFlagUsage();
+  console.log(
+    `   Found ${usedFlags.length} flags referenced across all usage patterns`,
+  );
+
+  console.log('\n📋 Used flags:');
+  if (usedFlags.length > 0) {
+    usedFlags.sort().forEach((flag) => console.log(`   ✅ ${flag}`));
+  } else {
+    console.log('   None found');
+  }
+
+  console.log('\n🚫 Unused flags:');
+  const unusedFlags = allFlags.filter(
+    (flag) => !usedFlags.includes(flag) && !flag.startsWith('example'),
+  );
+
+  if (unusedFlags.length > 0) {
+    unusedFlags.sort().forEach((flag) => console.log(`   ❌ ${flag}`));
+    console.log(
+      `\n📊 Summary: ${unusedFlags.length} of ${allFlags.length} feature flags are unused (${Math.round((unusedFlags.length / allFlags.length) * 100)}%) (excluding example flags)`,
+    );
+  } else {
+    console.log(
+      '   None! All feature flags are being used (excluding example flags).',
+    );
+    console.log(`\n📊 Summary: All non-example feature flags are in use.`);
+  }
+
+  // Return the unused flags for programmatic use
+  return unusedFlags;
+}
+
+// Run the script if called directly
+if (require.main === module) {
+  try {
+    const unusedFlags = main();
+    if (unusedFlags.length > 0) {
+      process.exitCode = 1;
+    }
+  } catch (error) {
+    console.error('Error running script:', error);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = {main, extractFeatureFlagNames, findGetFeatureFlagUsage};

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -6,6 +6,7 @@
     "@ast-grep/napi": "^0.39.5",
     "@swc/plugin-transform-imports": "^8.0.4",
     "flowgen": "^1.21.0",
+    "fast-glob": "^3.3.3",
     "glob": "^7.1.6",
     "json5": "^2.2.3",
     "zx": "^8.1.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11507,7 +11507,7 @@ fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
   integrity sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==
 
-fast-glob@3, fast-glob@^3.2.5, fast-glob@^3.3.2:
+fast-glob@3, fast-glob@^3.2.5, fast-glob@^3.3.2, fast-glob@^3.3.3:
   version "3.3.3"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.3.tgz#d06d585ce8dba90a16b0505c543c3ccfb3aeb818"
   integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

I accidentally released a change that had a feature flag in the feature flags list, but that feature flag wasn't actually used anywhere in the code.

We should have a lint for this, this will also help to ensure we cleanup feature flags properly.

## Changes

Added a script that validates every feature flag is "used" (i.e. accessed via options or `getFeatureFlag`) somewhere in the Rust or TS code.

Added a new CI check that runs this lint and fails if there are unused flags.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: scripts only
