### PR TITLE
Use edition from workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ members = [
   "packages/utils/dev-dep-resolver",
 ]
 
+[workspace.package]
+edition = "2024"
+
 [profile.dev]
 # Even in dev we want the fastest performance to decrease compile times when
 # testing or linking into products

--- a/crates/apvm/Cargo.toml
+++ b/crates/apvm/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "apvm"
 version = "0.0.1"
-edition = "2024"
+edition = { workspace = true }
 description = "Atlaspack Version Manager"
 
 [lints]

--- a/crates/atlaspack/Cargo.toml
+++ b/crates/atlaspack/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_config/Cargo.toml
+++ b/crates/atlaspack_config/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Monica Olejniczak <monica.j.olejniczak@gmail.com>",
   "Devon Govett <devongovett@gmail.com>",
 ]
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atlaspack_contextual_imports/Cargo.toml
+++ b/crates/atlaspack_contextual_imports/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_contextual_imports"
 version = "0.1.0"
 authors = ["Jake Lane <me@jakelane.me>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Atlaspack contextual imports transformation"
 
 [lints]

--- a/crates/atlaspack_contextual_imports_swc_plugin/Cargo.toml
+++ b/crates/atlaspack_contextual_imports_swc_plugin/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_contextual_imports_swc_plugin"
 version = "0.1.0"
 authors = ["Jake Lane <me@jakelane.me>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Atlaspack contextual imports plugin for SWC"
 
 [lints]

--- a/crates/atlaspack_core/Cargo.toml
+++ b/crates/atlaspack_core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack_core"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Core logic and types for the atlaspack bundler"
 
 [lints]

--- a/crates/atlaspack_filesystem/Cargo.toml
+++ b/crates/atlaspack_filesystem/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack_filesystem"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "FileSystem wrapper trait for use in Atlaspack codebase."
 
 [lints]

--- a/crates/atlaspack_monitoring/Cargo.toml
+++ b/crates/atlaspack_monitoring/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_monitoring"
 authors = ["Pedro Tacla Yamada <tacla.yamada@gmail.com>"]
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Provides tracing, error and crash reporting system for atlaspack"
 
 [lints]

--- a/crates/atlaspack_napi_helpers/Cargo.toml
+++ b/crates/atlaspack_napi_helpers/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Devon Govett <devongovett@gmail.com>"]
 name = "atlaspack_napi_helpers"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atlaspack_package_manager/Cargo.toml
+++ b/crates/atlaspack_package_manager/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
 name = "atlaspack_package_manager"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
+++ b/crates/atlaspack_plugin_optimizer_inline_requires/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_optimizer_inline_requires"
 authors = ["Pedro Tacla Yamada <tacla.yamada@gmail.com>"]
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atlaspack_plugin_resolver/Cargo.toml
+++ b/crates/atlaspack_plugin_resolver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack_plugin_resolver"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Resolver Plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_rpc/Cargo.toml
+++ b/crates/atlaspack_plugin_rpc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack_plugin_rpc"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_css/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_css/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_css"
 version = "0.1.0"
 authors = ["Matt Jones <mattjones701@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "CSS transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_html/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_html/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_html"
 version = "0.1.0"
 authors = ["Pedro Tacla Yamada <tacla.yamada@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "HTML transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_image/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_image/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_image"
 version = "0.1.0"
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Image transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_inline/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_inline/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_inline"
 version = "0.1.0"
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Inline transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_inline_string/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_inline_string/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_inline_string"
 version = "0.1.0"
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Inline string transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_js/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_js/Cargo.toml
@@ -5,7 +5,7 @@ authors = [
   "Pedro Tacla Yamada <tacla.yamada@gmail.com>",
   "Monica Olejniczak <monica.j.olejniczak@gmail.com>",
 ]
-edition = "2024"
+edition = { workspace = true }
 description = "JavaScript transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_json/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_json/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_json"
 version = "0.1.0"
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Json transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_raw/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_raw/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_raw"
 version = "0.1.0"
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Raw transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_plugin_transformer_yaml/Cargo.toml
+++ b/crates/atlaspack_plugin_transformer_yaml/Cargo.toml
@@ -2,7 +2,7 @@
 name = "atlaspack_plugin_transformer_yaml"
 version = "0.1.0"
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 description = "Yaml transformer plugin for the Atlaspack Bundler"
 
 [lints]

--- a/crates/atlaspack_shared_map/Cargo.toml
+++ b/crates/atlaspack_shared_map/Cargo.toml
@@ -3,7 +3,7 @@ name = "atlaspack_shared_map"
 description = "A hashmap to be used in caches where consistency between threads is not a concern."
 authors = ["Pedro Tacla Yamada <tacla.yamada@gmail.com>"]
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/atlaspack_sourcemap/Cargo.toml
+++ b/crates/atlaspack_sourcemap/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Monica Olejniczak <monica.j.olejniczak@gmail.com>"]
 name = "atlaspack_sourcemap"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "Sourcemaps for Atlaspack"
 
 [lints]

--- a/crates/atlaspack_swc_runner/Cargo.toml
+++ b/crates/atlaspack_swc_runner/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack_swc_runner"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 description = "SWC runner functions for Atlaspack"
 
 [lints]

--- a/crates/atlaspack_vcs/Cargo.toml
+++ b/crates/atlaspack_vcs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "atlaspack_vcs"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/caniuse_database/Cargo.toml
+++ b/crates/caniuse_database/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "caniuse_database"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/json-comments-rs/Cargo.toml
+++ b/crates/json-comments-rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "json_comments"
 version = "0.2.1"
 authors = ["Thayne McCombs <astrothayne@gmail.com>"]
-edition = "2024"
+edition = { workspace = true }
 license = "Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/tmccombs/json-comments-rs"

--- a/crates/lmdb-js-lite/Cargo.toml
+++ b/crates/lmdb-js-lite/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2024"
+edition = { workspace = true }
 name = "lmdb-js-lite"
 version = "0.1.5"
 repository = "https://github.com/atlassian-labs/atlaspack"

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Devon Govett <devongovett@gmail.com>"]
 name = "atlaspack-macros"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/node-bindings/Cargo.toml
+++ b/crates/node-bindings/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Devon Govett <devongovett@gmail.com>"]
 name = "atlaspack-node-bindings"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lints]
 workspace = true

--- a/packages/transformers/js/core/Cargo.toml
+++ b/packages/transformers/js/core/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Devon Govett <devongovett@gmail.com>"]
 name = "atlaspack-js-swc-core"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [lib]
 crate-type = ["rlib"]

--- a/packages/utils/dev-dep-resolver/Cargo.toml
+++ b/packages/utils/dev-dep-resolver/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Devon Govett <devongovett@gmail.com>"]
 name = "atlaspack-dev-dep-resolver"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [dependencies]
 atlaspack-resolver = { path = "../node-resolver-rs" }

--- a/packages/utils/node-resolver-rs/Cargo.toml
+++ b/packages/utils/node-resolver-rs/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Devon Govett <devongovett@gmail.com>"]
 name = "atlaspack-resolver"
 version = "0.1.0"
-edition = "2024"
+edition = { workspace = true }
 
 [[bench]]
 name = "node_resolver_bench"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-edition = "2024"
+edition = { workspace = true }
 tab_spaces = 2

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,2 @@
-edition = { workspace = true }
+edition = "2024"
 tab_spaces = 2


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Rust "edition" was specified in every crate separately, which could lead to mismatches. Ideally we'd use a consistent edition.

## Changes

Rust "edition" is specified in the root `Cargo.toml`, and inherited via `{ workspace = true }`. There were no other changes required.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
[no-changeset]: config only
