### PR TITLE
Add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: Continuous Integration
 
 on:
+  workflow_dispatch:
   merge_group:
   pull_request:
   push:


### PR DESCRIPTION
## Motivation

Bit annoying having to open a PR just to get CI to run.

## Changes

Added the `workflow_dispatch` trigger to the CI flow, so that it can be run manually without a PR if desired.

## Checklist

- [x] There is a changeset for this change, or one is not required

[no-changeset]: CI changes only