### PR TITLE
[AFBH-1740] : Normalize public URL handling in dev server

### DIFF
--- a/.changeset/normalize-publicurl-trailing-slash.md
+++ b/.changeset/normalize-publicurl-trailing-slash.md
@@ -1,0 +1,17 @@
+---
+'@atlaspack/cli': patch
+'@atlaspack/feature-flags': patch
+'@atlaspack/integration-tests': patch
+---
+
+Add feature flag to normalize publicUrl trailing slash in dev server
+
+This change adds a new feature flag `normalizePublicUrlTrailingSlash` that, when enabled, automatically adds a trailing slash to `publicUrl` values in the dev server. This prevents issues where URLs without trailing slashes (e.g., `http://localhost:8080` or `/assets`) could result in malformed asset URLs like `localhost:8080assets.json` instead of `localhost:8080/assets.json`.
+
+The feature flag is disabled by default to maintain backward compatibility. Enable it with:
+
+```js
+featureFlags: {
+  normalizePublicUrlTrailingSlash: true;
+}
+```

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -363,6 +363,16 @@ export const DEFAULT_FEATURE_FLAGS = {
    * @since 2025-12-15
    */
   v3Caching: false,
+
+  /**
+   * Normalize publicUrl to always have a trailing slash in dev server.
+   * This prevents issues where URLs without trailing slashes could result in
+   * malformed asset URLs (e.g., "localhost:8080assets.json" instead of "localhost:8080/assets.json")
+   *
+   * @author Sravan Kumar <sravankumar@atlassian.com>
+   * @since 2026-01-08
+   */
+  normalizePublicUrlTrailingSlash: process.env.ATLASPACK_BUILD_ENV === 'test',
 };
 
 export type FeatureFlags = typeof DEFAULT_FEATURE_FLAGS;

--- a/packages/core/integration-tests/test/server.ts
+++ b/packages/core/integration-tests/test/server.ts
@@ -391,6 +391,62 @@ describe('server', function () {
     );
   });
 
+  it('should normalize public url without trailing slash', async function () {
+    let port = await getPort();
+    let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
+      defaultTargetOptions: {
+        distDir,
+      },
+      config,
+      featureFlags: {
+        normalizePublicUrlTrailingSlash: true,
+      },
+      serveOptions: {
+        https: false,
+        port: port,
+        host: 'localhost',
+        publicUrl: '/assets',
+      },
+    });
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let data = await get('/assets/index.js', port);
+    assert.equal(
+      data,
+      await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8'),
+    );
+  });
+
+  it('should normalize full URL public url without trailing slash', async function () {
+    let port = await getPort();
+    let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {
+      defaultTargetOptions: {
+        distDir,
+      },
+      config,
+      featureFlags: {
+        normalizePublicUrlTrailingSlash: true,
+      },
+      serveOptions: {
+        https: false,
+        port: port,
+        host: 'localhost',
+        publicUrl: `http://localhost:${port}`,
+      },
+    });
+
+    subscription = await b.watch();
+    await getNextBuild(b);
+
+    let data = await get('/index.js', port);
+    assert.equal(
+      data,
+      await outputFS.readFile(path.join(distDir, 'index.js'), 'utf8'),
+    );
+  });
+
   it('should work with query parameters that contain a dot', async function () {
     let port = await getPort();
     let b = bundler(path.join(__dirname, '/integration/commonjs/index.js'), {


### PR DESCRIPTION

## Motivation

The dev server currently allows `publicUrl` values without trailing slashes (e.g., `http://localhost:8080` or `/assets`), which can result in malformed asset URLs like `localhost:8080assets.json` instead of `localhost:8080/assets.json`. This leads to broken asset loading in the development environment.

## Changes

- Added URL normalization that affects both dev server routing and bundled asset URLs 
- Added a new feature flag `normalizePublicUrlTrailingSlash` that automatically appends a trailing slash to `publicUrl` values in the dev server when enabled
- The feature flag is enabled by default in test environment but disabled in production to maintain backward compatibility
- Added integration tests to verify the normalization works correctly for both relative paths (e.g., `/assets`) and full URLs (e.g., `http://localhost:8080`)
- Updated both `packages/core/cli/src/normalizeOptions.ts` and `packages/core/feature-flags/src/index.ts`

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required

---
Changeset :
---



This change adds a new feature flag `normalizePublicUrlTrailingSlash` that, when enabled, automatically adds a trailing slash to `publicUrl` values in the dev server. This prevents issues where URLs without trailing slashes (e.g., `http://localhost:8080` or `/assets`) could result in malformed asset URLs like `localhost:8080assets.json` instead of `localhost:8080/assets.json`.

The feature flag is disabled by default to maintain backward compatibility. Enable it with:

```js
featureFlags: {
  normalizePublicUrlTrailingSlash: true;
}
```