### PR TITLE
Namespace native cache stats, add transformer bailout breakdown

### DIFF
--- a/.changeset/flat-ears-whisper.md
+++ b/.changeset/flat-ears-whisper.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/types-internal': minor
+'@atlaspack/core': minor
+'@atlaspack/rust': minor
+---
+
+Refactor native cache stats to namespace by cache user. Add transformer bailouts to transformer pipeline cache stats. Add additional log for transformer pipeline cache stats immediately after asset graph construction for better debugging experience.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,7 +666,9 @@ dependencies = [
  "atlaspack_dev_dep_resolver",
  "atlaspack_filesystem",
  "mockall",
+ "pretty_assertions",
  "serde",
+ "serde_json",
  "tracing",
 ]
 

--- a/crates/atlaspack/src/cache_stats.rs
+++ b/crates/atlaspack/src/cache_stats.rs
@@ -1,0 +1,51 @@
+//! Cache statistics types for reporting native cache metrics.
+//!
+//! These types are used to return cache statistics from the Rust layer to JavaScript,
+//! namespaced by cache user to support multiple caching systems.
+
+use std::collections::HashMap;
+
+use atlaspack_memoization_cache::StatsSnapshot;
+use serde::Serialize;
+
+/// Stats for transformer pipeline cache, including transformer-specific bailout breakdown.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TransformerPipelineCacheStats {
+  pub hits: u64,
+  pub misses: u64,
+  pub uncacheables: u64,
+  pub bailouts: u64,
+  pub errors: u64,
+  pub validations: u64,
+  pub bailouts_by_transformer: HashMap<String, u64>,
+}
+
+impl TransformerPipelineCacheStats {
+  pub fn from_snapshot(
+    stats: &StatsSnapshot,
+    bailouts_by_transformer: HashMap<String, u64>,
+  ) -> Self {
+    Self {
+      hits: stats.hits,
+      misses: stats.misses,
+      uncacheables: stats.uncacheables,
+      bailouts: stats.bailouts,
+      errors: stats.errors,
+      validations: stats.validations,
+      bailouts_by_transformer,
+    }
+  }
+
+  pub fn log(&self) {
+    tracing::info!("Transformer pipeline cache stats: {:#?}", self);
+  }
+}
+
+/// Top-level cache stats container, namespaced by cache user.
+/// This allows different caching systems to report their stats independently.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NativeCacheStats {
+  pub transformer_pipelines: Option<TransformerPipelineCacheStats>,
+}

--- a/crates/atlaspack/src/lib.rs
+++ b/crates/atlaspack/src/lib.rs
@@ -1,10 +1,12 @@
 pub use atlaspack::*;
 pub use atlaspack_filesystem as file_system;
 pub use atlaspack_plugin_rpc as rpc;
+pub use cache_stats::*;
 pub use error::*;
 pub use watch::*;
 
 pub mod atlaspack;
+pub mod cache_stats;
 pub(crate) mod request_tracker;
 
 mod error;

--- a/crates/atlaspack/src/request_tracker/request.rs
+++ b/crates/atlaspack/src/request_tracker/request.rs
@@ -32,6 +32,13 @@ pub enum DynCacheHandler {
 }
 
 impl DynCacheHandler {
+  pub fn get_stats_snapshot(&self) -> atlaspack_memoization_cache::StatsSnapshot {
+    match self {
+      DynCacheHandler::Lmdb(cache) => cache.get_stats_snapshot(),
+      DynCacheHandler::InMemory(cache) => cache.get_stats_snapshot(),
+    }
+  }
+
   pub fn complete_session(&self) -> anyhow::Result<atlaspack_memoization_cache::StatsSnapshot> {
     match self {
       DynCacheHandler::Lmdb(cache) => cache.complete_session(),

--- a/crates/atlaspack_core/src/plugin/transformer_plugin.rs
+++ b/crates/atlaspack_core/src/plugin/transformer_plugin.rs
@@ -27,6 +27,9 @@ pub struct TransformResult {
   /// if these paths change.
   pub invalidate_on_file_change: Vec<PathBuf>,
   pub cache_bailout: bool,
+  /// The name of the transformer that caused a cacheable pipeline bailout, if any.
+  /// Used for tracking bailout statistics for cacheable transformers.
+  pub bailout_transformer: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/atlaspack_memoization_cache/src/lib.rs
+++ b/crates/atlaspack_memoization_cache/src/lib.rs
@@ -133,6 +133,10 @@ pub struct CacheHandler<T: CacheReaderWriter> {
 
 #[async_trait]
 pub trait CacheHandlerTrait {
+  /// Get a snapshot of the current cache statistics without clearing them.
+  /// Useful for intermediate logging during a build.
+  fn get_stats_snapshot(&self) -> StatsSnapshot;
+
   fn complete_session(&self) -> anyhow::Result<StatsSnapshot>;
 
   async fn run<Input, RunFn, Res, FutureResult, Error>(
@@ -265,9 +269,12 @@ impl<T: CacheReaderWriter> CacheHandler<T> {
 
 #[async_trait]
 impl<T: CacheReaderWriter> CacheHandlerTrait for CacheHandler<T> {
+  fn get_stats_snapshot(&self) -> StatsSnapshot {
+    self.stats.get_snapshot()
+  }
+
   fn complete_session(&self) -> anyhow::Result<StatsSnapshot> {
     let snapshot = self.stats.get_snapshot();
-    tracing::info!("Cache stats {:#?}", snapshot);
 
     self.stats.clear();
     self.reader_writer.complete_session()?;

--- a/crates/atlaspack_package_manager/Cargo.toml
+++ b/crates/atlaspack_package_manager/Cargo.toml
@@ -15,4 +15,8 @@ atlaspack_dev_dep_resolver = { path = "../atlaspack_dev_dep_resolver" }
 atlaspack-resolver = { path = "../../packages/utils/node-resolver-rs" }
 atlaspack_filesystem = { path = "../atlaspack_filesystem" }
 serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/crates/atlaspack_package_manager/src/node_package_manager.rs
+++ b/crates/atlaspack_package_manager/src/node_package_manager.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{borrow::Cow, hash::Hasher, path::PathBuf};
 
 use anyhow::anyhow;
@@ -44,15 +45,14 @@ impl PackageManager for NodePackageManager<'_> {
   ) -> anyhow::Result<DevDep> {
     let crate::Resolution { resolved } = self.resolve(package_name, resolve_from)?;
 
-    match atlaspack_dev_dep_resolver::build_esm_graph(
+    // Build ESM graph for the main transformer package
+    let all_invalidations = match atlaspack_dev_dep_resolver::build_esm_graph(
       &resolved,
       &self.project_root,
       &self.resolver.cache,
       &self.dev_dep_cache,
     ) {
       Err(err) => {
-        // For now we'll ignore dev dev resolution errors and just treat it as
-        // uncachable
         tracing::warn!(
           "Error while building dev dependency graph for '{}': {:?}",
           package_name,
@@ -63,22 +63,131 @@ impl PackageManager for NodePackageManager<'_> {
           hash: None,
         });
       }
-      Ok(result) => {
-        Ok(DevDep {
-          file_path: resolved,
-          // For we're just mapping to an option and ignoring errors
-          // If we want more advanced reporting on cachability we can change this
-          // later
-          hash: self
-            .hash_invalidations(&result, ignore_startup_invalidations)
-            .ok(),
-        })
+      Ok(result) => result,
+    };
+
+    // Read additional dev deps from the consumer's package.json.
+    // These are packages that the transformer dynamically loads at runtime
+    // (e.g., a custom resolver) which the static ESM graph walk cannot discover.
+    let additional_deps = self.read_additional_dev_deps(package_name, resolve_from);
+
+    for dep in &additional_deps {
+      match self.resolve(dep, resolve_from) {
+        Ok(crate::Resolution { resolved: dep_path }) => {
+          match atlaspack_dev_dep_resolver::build_esm_graph(
+            &dep_path,
+            &self.project_root,
+            &self.resolver.cache,
+            &self.dev_dep_cache,
+          ) {
+            Ok(dep_invalidations) => {
+              tracing::debug!(
+                "Built ESM graph for additional dev dep '{}' (resolved to {:?})",
+                dep,
+                dep_path
+              );
+              all_invalidations.extend(&dep_invalidations);
+            }
+            Err(err) => {
+              tracing::warn!(
+                "Error building ESM graph for additional dev dep '{}': {:?}",
+                dep,
+                err
+              );
+            }
+          }
+        }
+        Err(err) => {
+          tracing::warn!(
+            "Could not resolve additional dev dep '{}' from {:?}: {:?}",
+            dep,
+            resolve_from,
+            err
+          );
+        }
       }
     }
+
+    Ok(DevDep {
+      file_path: resolved,
+      hash: self
+        .hash_invalidations(&all_invalidations, ignore_startup_invalidations)
+        .ok(),
+    })
   }
 }
 
 impl NodePackageManager<'_> {
+  /// Reads `additionalDevDeps` from the consumer's package.json for a given plugin.
+  ///
+  /// The consumer (e.g. Confluence) can declare additional packages that a transformer
+  /// dynamically loads at runtime. These are specified in package.json under the
+  /// `"atlaspack"` top-level key, namespaced by plugin package name:
+  ///
+  /// ```json
+  /// {
+  ///   "atlaspack": {
+  ///     "@atlaspack/transformer-compiled": {
+  ///       "additionalDevDeps": ["@devtools/compiled-resolver"]
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// We use the `"atlaspack"` namespace to avoid collisions with Atlaspack's own
+  /// `getConfigFrom` API, which reads plugin config from `package.json` using the
+  /// plugin's package name as a top-level key.
+  ///
+  /// The `resolve_from` path points to the `.parcelrc` file. We look for `package.json`
+  /// in the same directory (the project root).
+  fn read_additional_dev_deps(&self, package_name: &str, resolve_from: &Path) -> Vec<String> {
+    let package_json_path = match resolve_from.parent() {
+      Some(dir) => dir.join("package.json"),
+      None => return Vec::new(),
+    };
+
+    let contents = match self.resolver.cache.fs.read_to_string(&package_json_path) {
+      Ok(contents) => contents,
+      Err(_) => return Vec::new(),
+    };
+
+    let json: serde_json::Value = match serde_json::from_str(&contents) {
+      Ok(json) => json,
+      Err(err) => {
+        tracing::warn!(
+          "Failed to parse {:?} for additionalDevDeps: {:?}",
+          package_json_path,
+          err
+        );
+        return Vec::new();
+      }
+    };
+
+    let additional_deps = json
+      .get("atlaspack")
+      .and_then(|atlaspack_config| atlaspack_config.get(package_name))
+      .and_then(|plugin_config| plugin_config.get("additionalDevDeps"))
+      .and_then(|deps| deps.as_array())
+      .map(|deps| {
+        deps
+          .iter()
+          .filter_map(|dep| dep.as_str().map(String::from))
+          .collect::<Vec<_>>()
+      })
+      .unwrap_or_default();
+
+    if !additional_deps.is_empty() {
+      tracing::info!(
+        "Found additionalDevDeps for '{}' in {:?}: {:?}",
+        package_name,
+        package_json_path,
+        additional_deps
+      );
+    }
+
+    additional_deps
+  }
+
   #[tracing::instrument(level = "debug", skip_all)]
   fn hash_invalidations(
     &self,
@@ -129,5 +238,179 @@ impl NodePackageManager<'_> {
     }
 
     Ok(hasher.finish())
+  }
+}
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use atlaspack_filesystem::in_memory_file_system::InMemoryFileSystem;
+  use pretty_assertions::assert_eq;
+  use std::sync::Arc;
+
+  fn create_package_manager<'a>(
+    fs: &Arc<InMemoryFileSystem>,
+    project_root: &str,
+  ) -> NodePackageManager<'a> {
+    NodePackageManager::new(PathBuf::from(project_root), fs.clone() as FileSystemRef)
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_returns_deps_when_present() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    fs.write_file(
+      &PathBuf::from("/project/package.json"),
+      serde_json::json!({
+        "name": "my-app",
+        "atlaspack": {
+          "@atlaspack/transformer-compiled": {
+            "additionalDevDeps": ["@devtools/compiled-resolver", "@custom/other-dep"]
+          }
+        }
+      })
+      .to_string(),
+    );
+
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let deps = pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(
+      deps,
+      vec![
+        "@devtools/compiled-resolver".to_string(),
+        "@custom/other-dep".to_string(),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_returns_empty_when_no_config() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    fs.write_file(
+      &PathBuf::from("/project/package.json"),
+      serde_json::json!({
+        "name": "my-app",
+        "dependencies": {}
+      })
+      .to_string(),
+    );
+
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let deps = pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(deps, Vec::<String>::new());
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_returns_empty_when_no_package_json() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let deps = pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(deps, Vec::<String>::new());
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_returns_empty_when_no_additional_dev_deps_key() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    fs.write_file(
+      &PathBuf::from("/project/package.json"),
+      serde_json::json!({
+        "name": "my-app",
+        "atlaspack": {
+          "@atlaspack/transformer-compiled": {
+            "someOtherConfig": true
+          }
+        }
+      })
+      .to_string(),
+    );
+
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let deps = pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(deps, Vec::<String>::new());
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_ignores_non_string_entries() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    fs.write_file(
+      &PathBuf::from("/project/package.json"),
+      serde_json::json!({
+        "atlaspack": {
+          "@atlaspack/transformer-compiled": {
+            "additionalDevDeps": ["@devtools/compiled-resolver", 42, null, "@custom/valid"]
+          }
+        }
+      })
+      .to_string(),
+    );
+
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let deps = pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(
+      deps,
+      vec![
+        "@devtools/compiled-resolver".to_string(),
+        "@custom/valid".to_string(),
+      ]
+    );
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_different_plugin_name() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    fs.write_file(
+      &PathBuf::from("/project/package.json"),
+      serde_json::json!({
+        "atlaspack": {
+          "@atlaspack/transformer-compiled": {
+            "additionalDevDeps": ["@devtools/compiled-resolver"]
+          },
+          "@atlaspack/transformer-css": {
+            "additionalDevDeps": ["@custom/css-plugin"]
+          }
+        }
+      })
+      .to_string(),
+    );
+
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let compiled_deps =
+      pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(
+      compiled_deps,
+      vec!["@devtools/compiled-resolver".to_string()]
+    );
+
+    let css_deps = pm.read_additional_dev_deps("@atlaspack/transformer-css", resolve_from);
+    assert_eq!(css_deps, vec!["@custom/css-plugin".to_string()]);
+
+    let unknown_deps = pm.read_additional_dev_deps("@atlaspack/transformer-unknown", resolve_from);
+    assert_eq!(unknown_deps, Vec::<String>::new());
+  }
+
+  #[test]
+  fn test_read_additional_dev_deps_handles_malformed_json_gracefully() {
+    let fs = Arc::new(InMemoryFileSystem::default());
+    fs.write_file(
+      &PathBuf::from("/project/package.json"),
+      "{ invalid json".to_string(),
+    );
+
+    let pm = create_package_manager(&fs, "/project");
+    let resolve_from = Path::new("/project/.parcelrc");
+
+    let deps = pm.read_additional_dev_deps("@atlaspack/transformer-compiled", resolve_from);
+    assert_eq!(deps, Vec::<String>::new());
   }
 }

--- a/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer/mod.rs
+++ b/crates/atlaspack_plugin_rpc/src/nodejs/plugins/nodejs_rpc_transformer/mod.rs
@@ -382,16 +382,21 @@ impl TransformerPlugin for NodejsRpcTransformerPlugin {
 
     // Only track bailouts for transformers that are marked as cacheable.
     let bailout_transformer = if cache_bailout && matches!(self.cache_key, CacheStatus::Hash(_)) {
-      tracing::debug!(
-        "Transformer({}) bailout for asset '{}'\n{}",
-        self.plugin_node.package_name,
-        transformed_asset.file_path.display(),
-        cache_bailouts
-          .iter()
-          .map(|b| format!("- {}", b))
-          .collect::<Vec<String>>()
-          .join("\n")
-      );
+      match self.plugin_node.package_name.as_str() {
+        "@atlassian/parcel-transformer-babel-conditional" => {}
+        _ => {
+          tracing::debug!(
+            "Transformer({}) bailout for asset '{}'\n{}",
+            self.plugin_node.package_name,
+            transformed_asset.file_path.display(),
+            cache_bailouts
+              .iter()
+              .map(|b| format!("- {}", b))
+              .collect::<Vec<String>>()
+              .join("\n")
+          );
+        }
+      }
       Some(self.plugin_node.package_name.clone())
     } else {
       None

--- a/crates/atlaspack_plugin_rpc/src/testing.rs
+++ b/crates/atlaspack_plugin_rpc/src/testing.rs
@@ -75,6 +75,7 @@ pub mod testing {
         discovered_assets: vec![],
         invalidate_on_file_change: vec![],
         cache_bailout: false,
+        bailout_transformer: None,
       })
     }
   }

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -770,6 +770,7 @@ mod tests {
         dependencies: vec![],
         invalidate_on_file_change: vec![],
         cache_bailout: false,
+        bailout_transformer: None,
       }
     );
 
@@ -2137,6 +2138,7 @@ mod tests {
         dependencies: vec![],
         invalidate_on_file_change: vec![],
         cache_bailout: false,
+        bailout_transformer: None,
       }
     );
 
@@ -2243,6 +2245,7 @@ mod tests {
         dependencies: expected_dependencies,
         invalidate_on_file_change: vec![],
         cache_bailout: false,
+        bailout_transformer: None,
       }
     );
 

--- a/packages/core/core/src/atlaspack-v3/worker/worker.ts
+++ b/packages/core/core/src/atlaspack-v3/worker/worker.ts
@@ -294,8 +294,12 @@ export class AtlaspackWorker {
       cacheBailouts.push(`Env access: ${variable}`);
     }
 
-    for (let {method, path} of sideEffects.fsUsage) {
-      cacheBailouts.push(`FS usage: ${method}(${path})`);
+    for (let {method, path, stack} of sideEffects.fsUsage) {
+      if (stack && path?.endsWith('package.json')) {
+        cacheBailouts.push(`FS usage: ${method}(${path})\n${stack}`);
+      } else {
+        cacheBailouts.push(`FS usage: ${method}(${path})`);
+      }
     }
 
     assert(

--- a/packages/core/integration-tests/test/native-cache.ts
+++ b/packages/core/integration-tests/test/native-cache.ts
@@ -44,16 +44,16 @@ describe.v3('Native cache', function () {
     });
 
     let buildOne = await instance.run();
-    assert.equal(buildOne.nativeCacheStats.hits, 0);
-    assert.equal(buildOne.nativeCacheStats.misses, 2);
+    assert.equal(buildOne.nativeCacheStats.transformerPipelines?.hits, 0);
+    assert.equal(buildOne.nativeCacheStats.transformerPipelines?.misses, 2);
 
     let output = await run(buildOne.bundleGraph);
     assert.equal(output.default, 'should not fail');
 
     let buildTwo = await instance.run();
     // Two hits: one for index.js, one for the esmodule-helpers.js
-    assert.equal(buildTwo.nativeCacheStats.hits, 2);
-    assert.equal(buildTwo.nativeCacheStats.misses, 0);
+    assert.equal(buildTwo.nativeCacheStats.transformerPipelines?.hits, 2);
+    assert.equal(buildTwo.nativeCacheStats.transformerPipelines?.misses, 0);
 
     output = await run(buildTwo.bundleGraph);
     assert.equal(output.default, 'should not fail');
@@ -103,7 +103,10 @@ describe.v3('Native cache', function () {
     });
 
     let buildOne = await instance.run();
-    assert.equal(buildOne.nativeCacheStats.uncacheables, 2);
+    assert.equal(
+      buildOne.nativeCacheStats.transformerPipelines?.uncacheables,
+      2,
+    );
 
     let output = await run(buildOne.bundleGraph);
     assert.equal(output.default, 'should not cache');
@@ -153,7 +156,19 @@ describe.v3('Native cache', function () {
     });
 
     let buildOne = await instance.run();
-    assert.equal(buildOne.nativeCacheStats.bailouts, 2);
+    assert.equal(buildOne.nativeCacheStats.transformerPipelines?.bailouts, 2);
+
+    // Verify bailouts are tracked by transformer name
+    const bailoutsByTransformer =
+      buildOne.nativeCacheStats.transformerPipelines?.bailoutsByTransformer;
+    assert.ok(bailoutsByTransformer, 'bailoutsByTransformer should be defined');
+    const transformerBailouts =
+      bailoutsByTransformer['./transformer-plugin-2.ts'];
+    assert.equal(
+      transformerBailouts,
+      2,
+      'transformer-plugin-2.ts should have 2 bailouts',
+    );
 
     let output = await run(buildOne.bundleGraph);
     assert.equal(output.default, 'should not true');
@@ -206,7 +221,19 @@ describe.v3('Native cache', function () {
     });
 
     let buildOne = await instance.run();
-    assert.equal(buildOne.nativeCacheStats.bailouts, 2);
+    assert.equal(buildOne.nativeCacheStats.transformerPipelines?.bailouts, 2);
+
+    // Verify bailouts are tracked by transformer name
+    const bailoutsByTransformer =
+      buildOne.nativeCacheStats.transformerPipelines?.bailoutsByTransformer;
+    assert.ok(bailoutsByTransformer, 'bailoutsByTransformer should be defined');
+    const transformerBailouts =
+      bailoutsByTransformer['./transformer-plugin-3.ts'];
+    assert.equal(
+      transformerBailouts,
+      2,
+      'transformer-plugin-3.ts should have 2 bailouts',
+    );
 
     let output = await run(buildOne.bundleGraph);
     assert.equal(output.default, 'should not cache');
@@ -256,7 +283,7 @@ describe.v3('Native cache', function () {
     });
 
     let buildOne = await instance.run();
-    assert.equal(buildOne.nativeCacheStats.misses, 2);
+    assert.equal(buildOne.nativeCacheStats.transformerPipelines?.misses, 2);
 
     let output = await run(buildOne.bundleGraph);
     assert.equal(output.default, 'should not true');
@@ -311,14 +338,20 @@ describe.v3('Native cache', function () {
     let buildOne = await instance.run();
 
     // Transformer explicitly disabled caching via disableCache: true
-    assert.equal(buildOne.nativeCacheStats.uncacheables, 2);
+    assert.equal(
+      buildOne.nativeCacheStats.transformerPipelines?.uncacheables,
+      2,
+    );
 
     let output = await run(buildOne.bundleGraph);
     assert.equal(output.default, 'should not cache');
 
     // Second build should also be uncacheable (no cache hits)
     let buildTwo = await instance.run();
-    assert.equal(buildTwo.nativeCacheStats.uncacheables, 2);
-    assert.equal(buildTwo.nativeCacheStats.hits, 0);
+    assert.equal(
+      buildTwo.nativeCacheStats.transformerPipelines?.uncacheables,
+      2,
+    );
+    assert.equal(buildTwo.nativeCacheStats.transformerPipelines?.hits, 0);
   });
 });

--- a/packages/core/types-internal/src/index.ts
+++ b/packages/core/types-internal/src/index.ts
@@ -2195,13 +2195,28 @@ export type BuildProgressEvent =
   | OptimizingProgressEvent
   | PackagingAndOptimizingProgressEvent;
 
-export type NativeCacheStats = {
+/**
+ * Stats for transformer pipeline cache, including transformer-specific bailout breakdown.
+ */
+export type TransformerPipelineCacheStats = {
   hits: number;
   misses: number;
   uncacheables: number;
   bailouts: number;
   errors: number;
   validations: number;
+  /** Map of transformer package name to number of bailouts */
+  bailoutsByTransformer: Record<string, number>;
+};
+
+/**
+ * Top-level cache stats container, namespaced by cache user.
+ * This allows different caching systems to report their stats independently.
+ */
+export type NativeCacheStats = {
+  /** Stats for transformer pipeline caching */
+  transformerPipelines?: TransformerPipelineCacheStats;
+  // Future: resolver?: ResolverCacheStats;
 };
 
 /**

--- a/packages/transformers/compiled/package.json
+++ b/packages/transformers/compiled/package.json
@@ -31,6 +31,7 @@
     "@compiled/babel-plugin": "^0.36.0",
     "@compiled/babel-plugin-strip-runtime": "^0.36.0",
     "@compiled/utils": "^0.13.1",
+    "browserslist": "^4.22.1",
     "enhanced-resolve": "^5.18.1"
   },
   "devDependencies": {

--- a/packages/transformers/compiled/src/CompiledTransformer.ts
+++ b/packages/transformers/compiled/src/CompiledTransformer.ts
@@ -229,6 +229,12 @@ export default new Transformer<Config>({
       // Load the resolver now (during setup) to populate the cache
       // This ensures FS operations happen during setup, not during transform
       loadResolver(contents.resolver, options.projectRoot);
+      // After loading, we strip the resolver string from contents so that it never appears in
+      // compiledConfig. This prevents the Compiled babel plugin from seeing a string resolver
+      // and doing require.resolve() during transform -- even if the resolver override in the
+      // plugin options is omitted.
+      // The resolverCacheKey preserves the string for cache key computation.
+      delete contents.resolver;
     }
 
     return {

--- a/packages/transformers/compiled/src/types.ts
+++ b/packages/transformers/compiled/src/types.ts
@@ -80,4 +80,15 @@ export interface CompiledTransformerOpts extends BabelPluginOpts {
    * This will throw an error if used alongside extraction or `extract: true`.
    */
   classHashPrefix?: string;
+
+  /**
+   * Browserslist configuration for Babel's target resolution.
+   * If not specified, the transformer will try to read it from the nearest package.json.
+   *
+   * This can be a string array of browser queries, or an object mapping environment names
+   * to query arrays (e.g., { production: ["..."], development: ["..."] }).
+   *
+   * Example: ["last 2 Chrome versions", "last 2 Firefox versions"]
+   */
+  browserslist?: string[] | {[env: string]: string[]};
 }


### PR DESCRIPTION
## Motivation

Extensibility - the native cache stats need to be structured to support multiple caching systems as we add more native caching in the future. Also providing visibility into which specific transformers are causing cache bailouts allows us to detect caching issues early via analytics events.

## Changes


- Restructured `nativeCacheStats` to namespace stats by cache user:

```json
  {
    "nativeCacheStats": {
      "transformerPipelines": {
        "hits": 51972,
        "bailoutsByTransformer": { ... }
      }
    }
  }
  ```

- Added `bailoutsByTransformer` field to track bailout counts per transformer
- Improved debugging: cache stats are now logged immediately after asset graph construction
- Created dedicated `cache_stats.rs` module for cache stats types
- Updated native cache integration tests to refactored cache stats object and verify bailout tracking

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder
