### PR TITLE
MAGMA-4673 Update sync-dynamic-imports reject unresolved imports with error and wrap require() with Promise.resolve

### DIFF
--- a/.changeset/sync-dynamic-import-improvements.md
+++ b/.changeset/sync-dynamic-import-improvements.md
@@ -1,0 +1,7 @@
+---
+'@atlaspack/transformer-js': minor
+'@atlaspack/rust': minor
+'@atlaspack/feature-flags': minor
+---
+
+sync_dynamic_import: Remove `activate_reject_on_unresolved_imports` feature gate (now always enabled). Add `sync_require_paths` config with glob matching that wraps matched imports in `Promise.resolve(require(...))` instead of bare `require()`. Add `syncDynamicImportRejectWithError` feature flag that, when enabled, causes unresolved dynamic imports to reject with `new Error(message)` (with `.skipSsr = true`) instead of a plain string.

--- a/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
+++ b/crates/atlaspack_plugin_transformer_js/src/js_transformer.rs
@@ -39,7 +39,8 @@ define_feature_flags!(JsTransformerFlags, {
   exportsRebindingOptimisation,
   hmrImprovements,
   nestedPromiseImportFix,
-  newJsxConfig
+  newJsxConfig,
+  syncDynamicImportRejectWithError
 });
 
 #[derive(Clone, Hash)]
@@ -326,7 +327,7 @@ impl AtlaspackJsTransformerPlugin {
           let fallback = SyncDynamicImportConfig {
             entrypoint_filepath_suffix: "__NO_MATCH__".into(),
             actual_require_paths: vec![],
-            activate_reject_on_unresolved_imports: false,
+            sync_require_paths: vec![],
           };
 
           Some(fallback)
@@ -671,6 +672,7 @@ impl TransformerPlugin for AtlaspackJsTransformerPlugin {
       enable_dead_returns_removal,
       enable_unused_bindings_removal,
       sync_dynamic_import_config,
+      sync_dynamic_import_reject_with_error: self.feature_flags.syncDynamicImportRejectWithError(),
       enable_tokens_and_compiled_css_in_js_transform: self.tokens_config.is_some()
         || self.compiled_css_in_js_config.is_some(),
       tokens_config: self.tokens_config.clone(),

--- a/packages/core/feature-flags/src/index.ts
+++ b/packages/core/feature-flags/src/index.ts
@@ -144,6 +144,15 @@ export const DEFAULT_FEATURE_FLAGS = {
   inlineConstOptimisationFix: false,
 
   /**
+   * When enabled, unresolved dynamic imports in SSR code will reject with
+   * `new Error(message)` with a `.skipSsr` property instead of a plain string.
+   *
+   * @author Oliver Wessels <owessels@atlassian.com>
+   * @since 2025-02-17
+   */
+  syncDynamicImportRejectWithError: false,
+
+  /**
    * Improves/fixes HMR behaviour by:
    * - Fixing HMR behaviour with lazy bundle edges
    * - Moving the functionality of the react-refresh runtime into the react-refresh-wrap transformer

--- a/packages/transformers/js/core/src/lib.rs
+++ b/packages/transformers/js/core/src/lib.rs
@@ -195,6 +195,7 @@ pub struct Config {
   pub enable_dead_returns_removal: bool,
   pub enable_unused_bindings_removal: bool,
   pub sync_dynamic_import_config: Option<SyncDynamicImportConfig>,
+  pub sync_dynamic_import_reject_with_error: bool,
   pub enable_tokens_and_compiled_css_in_js_transform: bool,
   pub tokens_config: Option<TokensConfig>,
   pub compiled_css_in_js_config: Option<atlassian_swc_compiled_css::config::CompiledCssInJsConfig>,
@@ -576,6 +577,7 @@ pub fn transform(
                   &mut SyncDynamicImport::new(Path::new(&config.filename),
                     unresolved_mark,
                     &config.sync_dynamic_import_config,
+                    config.sync_dynamic_import_reject_with_error,
                   ));
                 }
 

--- a/packages/transformers/js/src/JSTransformer.ts
+++ b/packages/transformers/js/src/JSTransformer.ts
@@ -504,7 +504,7 @@ export default new Transformer({
       | {
           entrypoint_filepath_suffix: string;
           actual_require_paths: string[];
-          activate_reject_on_unresolved_imports?: boolean;
+          sync_require_paths?: string[];
         }
       | undefined;
 
@@ -519,10 +519,9 @@ export default new Transformer({
 
           invariant(typeof config?.entrypoint_filepath_suffix === 'string');
           invariant(Array.isArray(config.actual_require_paths));
-          invariant(
-            typeof (config.activate_reject_on_unresolved_imports ?? false) ===
-              'boolean',
-          );
+          if (config.sync_require_paths !== undefined) {
+            invariant(Array.isArray(config.sync_require_paths));
+          }
 
           configCache.set('SYNC_DYNAMIC_IMPORT_CONFIG', config);
         }
@@ -537,7 +536,7 @@ export default new Transformer({
         const fallback = {
           entrypoint_filepath_suffix: '__NO_MATCH__',
           actual_require_paths: [],
-          activate_reject_on_unresolved_imports: false,
+          sync_require_paths: [],
         };
 
         // Set cache to fallback so we don't keep trying to parse.
@@ -796,6 +795,8 @@ export default new Transformer({
       react_async_lift_by_default: Boolean(config.reactAsyncLiftByDefault),
       react_async_lift_report_level: String(config.reactAsyncLiftReportLevel),
       sync_dynamic_import_config: config.syncDynamicImportConfig,
+      sync_dynamic_import_reject_with_error:
+        options.featureFlags.syncDynamicImportRejectWithError,
       enable_tokens_and_compiled_css_in_js_transform: getFeatureFlag(
         'coreTokensAndCompiledCssInJsTransform',
       ),


### PR DESCRIPTION
## Motivation

* `actual_require_paths` creates a `require(...)` statement, which is not a promise. This is not correct because `import(...)` returns a promise. This adds a new config named `sync_require_paths` intended to replace that, which wraps with `Promise.resolve`.
* Cleaning up `activate_reject_on_unresolved_imports`, which was added to feature-gate enable.

## Changes

- **Removed `activate_reject_on_unresolved_imports`** config option — unresolved dynamic imports now always generate
rejecting promises
- **Added `sync_require_paths`** config option — behaves the same as `actual_require_paths` (substring matching) but
wraps matched imports in `Promise.resolve(require(...))` instead of bare `require()`. Takes priority over
`actual_require_paths`
- **Added `syncDynamicImportRejectWithError` feature flag** — when enabled, unresolved imports reject with `new
Error(message)` (with `.skipSsr = true`) instead of a plain string
- Updated Rust (`sync_dynamic_import.rs`, `js_transformer.rs`, `lib.rs`), TypeScript (`JSTransformer.ts`), and feature
flags (`index.ts`)