### PR TITLE
Update Picomatch to fix vulnerability

### DIFF
--- a/.changeset/popular-camels-laugh.md
+++ b/.changeset/popular-camels-laugh.md
@@ -1,0 +1,10 @@
+---
+'@atlaspack/integration-tests': minor
+'@atlaspack/test-utils': minor
+'@atlaspack/utils': minor
+'@atlaspack/inspector': minor
+'@atlaspack/inspector-frontend': minor
+'@atlaspack/watcher-watchman-js': minor
+---
+
+Update picomatch to resolve vulnerability

--- a/package.json
+++ b/package.json
@@ -20,6 +20,10 @@
   ],
   "resolutions": {
     "@swc/core": "1.15.11",
+    "anymatch/picomatch": "^2.3.2",
+    "jest-util/picomatch": "^2.3.2",
+    "micromatch/picomatch": "^2.3.2",
+    "readdirp/picomatch": "^2.3.2",
     "react": "18.2.0",
     "react-dom": "18.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -18931,15 +18931,15 @@ picocolors@^1.1.0:
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
   integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
-  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3, picomatch@^2.3.1, picomatch@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.2.tgz#5a942915e26b372dc0f0e6753149a16e6b1c5601"
+  integrity sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==
 
 picomatch@^4.0.2, picomatch@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.3.tgz#796c76136d1eead715db1e7bad785dedd695a042"
-  integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pify@5.0.0:
   version "5.0.0"


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

A security vulnerability was discovered in `picomatch` versions below `v2.3.2` and `v4.0.4`.

## Changes

- Add manual resolution of relevant dependencies to safe v2.3.2 of Picomatch.
- Update non-manual-resolve Picomatch to v4.0.4.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
