### PR TITLE
Tesseract resolver r19

### DIFF
--- a/.changeset/eleven-kiwis-push.md
+++ b/.changeset/eleven-kiwis-push.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/resolver-tesseract': patch
+---
+
+resolve to node version of react-dom/server

--- a/packages/resolvers/tesseract/src/TesseractResolver.ts
+++ b/packages/resolvers/tesseract/src/TesseractResolver.ts
@@ -22,6 +22,10 @@ interface TesseractResolverConfig {
   unsupportedExtensions?: Array<string>;
 }
 
+const isReactDomServer = (specifier: string) =>
+  specifier.includes('react-dom/server') ||
+  specifier.includes('react-dom-next/server');
+
 const IGNORE_MODULES_REGEX = /(mock|mocks|\.woff|\.woff2|\.mp3|\.ogg)$/;
 const IGNORE_PATH = join(__dirname, 'data', 'empty-module.js');
 
@@ -166,7 +170,7 @@ export default new Resolver({
 
     const snapvmEnv = new Proxy(dependency.env, {
       get(target, property) {
-        if (handleReactDomServer && specifier.includes('react-dom/server')) {
+        if (handleReactDomServer && isReactDomServer(specifier)) {
           if (property === 'isNode') {
             return () => true;
           }
@@ -193,8 +197,8 @@ export default new Resolver({
     });
 
     const packageConditions =
-      handleReactDomServer && specifier.includes('react-dom/server')
-        ? ['default']
+      handleReactDomServer && isReactDomServer(specifier)
+        ? ['node', 'default']
         : ['ssr', 'require'];
 
     const promise = useBrowser


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Modifies `@atlaspack/resolver-tesseract` to resolve to node version of `react-dom/server`.

## Checklist

- [ ] Existing or new tests cover this change
- [ ] There is a changeset for this change, or one is not required
- [ ] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
