### PR TITLE
Output log directory if tracing mode is active

### DIFF
--- a/.changeset/metal-insects-rest.md
+++ b/.changeset/metal-insects-rest.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': patch
+---
+
+print the log directory if any tracing mode is active

--- a/crates/atlaspack_monitoring/src/tracer.rs
+++ b/crates/atlaspack_monitoring/src/tracer.rs
@@ -92,6 +92,12 @@ impl Tracer {
       .to_string();
     let prefix = "atlaspack-tracing".to_string();
     let max_files = 4;
+
+    // Print the log directory if any tracing mode is active
+    if !options.is_empty() {
+      println!("Atlaspack tracing logs → {directory}/");
+    }
+
     let file_appender = tracing_appender::rolling::Builder::new()
       .rotation(tracing_appender::rolling::Rotation::HOURLY)
       .max_log_files(max_files as usize)


### PR DESCRIPTION
Debugging quality of life.

Example output:
```sh
# start atlaspack with ATLASPACK_TRACING_MODE enabled
RUST_LOG="error,atlaspack=info" ATLASPACK_TRACING_MODE=stdout ATLASPACK_V3=false yarn start
```
```sh
Atlaspack tracing logs → /var/folders/5j/lrrnkpld5nnfrwbs29sg4th40000gn/T/atlaspack_trace/
```

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder
