### PR TITLE
Dynamically set registry to .npmrc-public

### DIFF
--- a/.changeset/early-icons-hammer.md
+++ b/.changeset/early-icons-hammer.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/test-utils': patch
+---
+
+Set publish registry to .npmrc-public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,14 +192,14 @@ jobs:
           pattern: packages-*
           path: packages
           merge-multiple: true
-      - name: Configure publishing for Artifactory
-        run: |
-          npm config set "@atlaspack:registry" "https://packages.atlassian.com/api/npm/npm-public/"
       - name: Get Artifact Publish Token
         id: publish-token
         uses: atlassian-labs/artifact-publish-token@v1.0.1
         with:
           output-modes: npm
+      - name: Set registry to Artifactory
+        run: |
+          echo "@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/" >> ${{ github.workspace }}/.npmrc-public
       - uses: changesets/action@v1
         with:
           publish: yarn changesets-publish


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Current solution of using `npm set` to set registry gets ignored as `NPM_CONFIG_USERCONFIG` gets set to .npmrc-public.

## Changes

Write registry URL to .npmrc-public when changeset job is executed.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
