### PR TITLE
Hardcode registry in npmrc

### DIFF
--- a/.changeset/green-worms-check.md
+++ b/.changeset/green-worms-check.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/test-utils': patch
+---
+
+Set registry in .npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,6 @@ jobs:
         uses: atlassian-labs/artifact-publish-token@v1.0.1
         with:
           output-modes: npm
-      - name: Set registry to Artifactory
-        run: |
-          echo "@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/" >> ${{ github.workspace }}/.npmrc-public
       - uses: changesets/action@v1
         with:
           publish: yarn changesets-publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.yarnpkg.com
+@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Current method of setting publish registry doesn't work with changesets.

## Changes

Hardcode publish registry in `.npmrc` instead.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
