### PR TITLE
Revert "Hardcode registry in npmrc"

### DIFF
--- a/.changeset/green-worms-check.md
+++ b/.changeset/green-worms-check.md
@@ -1,5 +1,0 @@
----
-'@atlaspack/test-utils': patch
----
-
-Set registry in .npmrc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,6 +197,9 @@ jobs:
         uses: atlassian-labs/artifact-publish-token@v1.0.1
         with:
           output-modes: npm
+      - name: Set registry to Artifactory
+        run: |
+          echo "@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/" >> ${{ github.workspace }}/.npmrc-public
       - uses: changesets/action@v1
         with:
           publish: yarn changesets-publish

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 registry=https://registry.yarnpkg.com
-@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/


### PR DESCRIPTION
Reverts atlassian-labs/atlaspack#1091

Breaks canary releases