### PR TITLE
Fix registry URL appending

### DIFF
--- a/.changeset/swift-eels-divide.md
+++ b/.changeset/swift-eels-divide.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/lsp': patch
+---
+
+Fix public registry format

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -199,7 +199,7 @@ jobs:
           output-modes: npm
       - name: Set publish registry
         run: |
-          echo "@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/" >> "${{ github.workspace }}/.npmrc-public"
+          printf "\n@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/\n" >> "${{ github.workspace }}/.npmrc-public"
       - name: Debug npm publish config
         run: |
           echo "=== npm config list ==="


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Current solution appends registry URL with line spaces, making the config erroneous. 

## Changes

Append registry URL with line spaces

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
