### PR TITLE
Remove publishing debug logs

### DIFF
--- a/.changeset/few-moose-invite.md
+++ b/.changeset/few-moose-invite.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/test-utils': patch
+---
+
+Remove debugging for publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,18 +200,6 @@ jobs:
       - name: Set publish registry
         run: |
           printf "\n@atlaspack:registry=https://packages.atlassian.com/api/npm/npm-public/\n" >> "${{ github.workspace }}/.npmrc-public"
-      - name: Debug npm publish config
-        run: |
-          echo "=== npm config list ==="
-          npm config list
-          echo "=== npm config list --json ==="
-          npm config list --json
-          echo "=== effective registry for @atlaspack scope ==="
-          npm config get "@atlaspack:registry"
-          echo "=== .npmrc-public contents ==="
-          cat "${{ github.workspace }}/.npmrc-public"
-        env:
-          NPM_CONFIG_USERCONFIG: ${{ github.workspace }}/.npmrc-public
       - uses: changesets/action@v1
         with:
           publish: yarn changesets-publish


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

Logs were previously added to `release.yml` to debug if correct publish registry details were added. Publishing is to Artifactory is working now, so logs no longer needed.

## Changes

Remove debugging step.

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
