### PR TITLE
Detect resolve_import_binding calls outside Compiled CSS API bodies (AFB-2000)

### DIFF
--- a/crates/atlassian-swc-compiled-css/src/class-names/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/class-names/index.rs
@@ -324,6 +324,10 @@ where
     return false;
   }
 
+  // Mark `<ClassNames>` body processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
+
   let runtime_helper = get_runtime_class_name_library(meta);
   let children_expr = ensure_children_function(element, meta);
   let (css_identifiers, style_identifiers) = collect_css_and_style_aliases(children_expr);

--- a/crates/atlassian-swc-compiled-css/src/config.rs
+++ b/crates/atlassian-swc-compiled-css/src/config.rs
@@ -119,6 +119,15 @@ pub struct CompiledCssInJsConfig {
   /// Defaults to `None`.
   ///
   pub browserslist_env: Option<String>,
+  ///
+  /// When enabled, panic if `resolve_import_binding` is invoked outside of a
+  /// Compiled CSS API call body (`css(...)`, `styled.X(...)`, `cssMap({...})`,
+  /// `keyframes(...)`, or `<ClassNames>`). Used to detect transform-time
+  /// inlining that silently expands the file's transform-dependency footprint.
+  ///
+  /// Defaults to `false`.
+  ///
+  pub strict_css_block_guard: Option<bool>,
 }
 
 /// Full configuration for CompiledCssInJs transform.
@@ -239,6 +248,12 @@ pub struct CompiledCssInJsTransformConfig {
   /// Browserslist environment (e.g. "development" or "production") for package.json "browserslist".
   ///
   pub browserslist_env: Option<String>,
+  ///
+  /// When enabled, panic if a value is inlined from outside a CSS API call body.
+  ///
+  /// Defaults to `false`.
+  ///
+  pub strict_css_block_guard: bool,
 }
 
 impl Default for CompiledCssInJsTransformConfig {
@@ -263,6 +278,7 @@ impl Default for CompiledCssInJsTransformConfig {
       unsafe_use_safe_assets: false,
       unsafe_skip_pattern: None,
       browserslist_env: None,
+      strict_css_block_guard: false,
     }
   }
 }
@@ -300,6 +316,9 @@ impl From<CompiledCssInJsConfig> for CompiledCssInJsTransformConfig {
         .unwrap_or(defaults.unsafe_use_safe_assets),
       unsafe_skip_pattern: partial.unsafe_skip_pattern.or(defaults.unsafe_skip_pattern),
       browserslist_env: partial.browserslist_env.or(defaults.browserslist_env),
+      strict_css_block_guard: partial
+        .strict_css_block_guard
+        .unwrap_or(defaults.strict_css_block_guard),
     }
   }
 }

--- a/crates/atlassian-swc-compiled-css/src/css-map/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/css-map/index.rs
@@ -32,6 +32,9 @@ pub fn visit_css_map_path_with_builder<'a, F>(
 where
   F: FnMut(&Expr, &Metadata) -> CssOutput,
 {
+  // Mark `cssMap({...})` body processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
   match usage {
     CssMapUsage::TaggedTemplate(tagged_tpl) => {
       report_css_map_error_with_hints(meta, tagged_tpl.span, ErrorMessages::NoTaggedTemplate);

--- a/crates/atlassian-swc-compiled-css/src/css-prop/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/css-prop/index.rs
@@ -89,6 +89,10 @@ where
     return;
   };
 
+  // Mark `css={...}` JSX prop processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
+
   if std::env::var("COMPILED_CLI_TRACE").is_ok() {
     use swc_core::ecma::ast::JSXElementName;
     let name = match &element.opening.name {

--- a/crates/atlassian-swc-compiled-css/src/styled/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/styled/index.rs
@@ -267,6 +267,10 @@ where
     return result;
   };
 
+  // Mark `styled.X({...})` / `` styled.X`...` `` body as inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
+
   if let Expr::TaggedTpl(tagged) = node {
     if has_invalid_expression(tagged) {
       panic_invalid_expression(tagged.span, meta);

--- a/crates/atlassian-swc-compiled-css/src/types.rs
+++ b/crates/atlassian-swc-compiled-css/src/types.rs
@@ -159,6 +159,13 @@ pub struct PluginOptions {
   /// Browserslist environment (e.g. "development" or "production") for config with
   /// "browserslist": { "development": [...], "production": [...] }.
   pub browserslist_env: Option<String>,
+  /// Panic if `resolve_import_binding` is called outside the body of a Compiled
+  /// CSS API call (`css(...)`, `styled.X(...)`, `` css`...` ``, `` styled.X`...` ``,
+  /// `cssMap({...})`, `keyframes(...)` or `<ClassNames>`). Crossing an import
+  /// boundary outside a CSS API call would silently expand the file's
+  /// transitive transform-dependency footprint, so this guard catches any
+  /// regression in the entry-point wiring.
+  pub strict_css_block_guard: Option<bool>,
 }
 
 impl Default for PluginOptions {
@@ -183,6 +190,7 @@ impl Default for PluginOptions {
       flatten_multiple_selectors: None,
       extract: None,
       browserslist_env: None,
+      strict_css_block_guard: None,
     }
   }
 }
@@ -209,6 +217,7 @@ impl From<&crate::config::CompiledCssInJsConfig> for PluginOptions {
       flatten_multiple_selectors: config.flatten_multiple_selectors,
       extract: config.extract,
       browserslist_env: config.browserslist_env.clone(),
+      strict_css_block_guard: config.strict_css_block_guard,
     }
   }
 }
@@ -652,6 +661,11 @@ pub struct Metadata {
   pub parent_scope: SharedScope,
   pub own_scope: Option<SharedScope>,
   pub parent_expr: Option<Box<Expr>>,
+  /// True when the current resolution chain is happening inside the body of a
+  /// Compiled CSS API call. Set by entry-point wiring (`enter_css_block`) and
+  /// preserved across all `with_*` helpers and binding lookups. Used by the
+  /// strict `resolve_import_binding` guard.
+  pub in_css_block: bool,
 }
 
 impl Metadata {
@@ -668,6 +682,17 @@ impl Metadata {
       parent_scope,
       own_scope: None,
       parent_expr: None,
+      in_css_block: false,
+    }
+  }
+
+  /// Mark this metadata as being inside a Compiled CSS API call body. All
+  /// downstream `resolve_import_binding` calls reached from this metadata are
+  /// considered legitimate transform-time inlinings.
+  pub fn enter_css_block(&self) -> Self {
+    Self {
+      in_css_block: true,
+      ..self.clone()
     }
   }
 

--- a/crates/atlassian-swc-compiled-css/src/utils/css-builders.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/css-builders.rs
@@ -811,6 +811,25 @@ where
     }
   }
 
+  // Imported cssMap declarations are banned by Compiled; every cssMap reference
+  // must be a local `const X = cssMap({...})`. Skip import bindings (and any
+  // unresolvable identifier) to avoid unnecessary cross-module parsing and
+  // spurious strict CSS-block guard violations (AFB-2000).
+  let is_local_variable = {
+    let own_hit = meta
+      .own_scope()
+      .and_then(|scope| scope.borrow().get(name.as_str()).cloned());
+    let scoped = own_hit.or_else(|| meta.parent_scope().borrow().get(name.as_str()).cloned());
+    matches!(
+      scoped.as_ref().map(|b| &b.source),
+      Some(BindingSource::Module),
+    )
+  };
+  if !is_local_variable {
+    meta.state_mut().ignore_member_expressions.insert(name);
+    return false;
+  }
+
   let resolved = resolve_binding(name.as_str(), meta.clone(), evaluate_expression);
 
   if let Some(PartialBindingWithMeta {
@@ -2075,6 +2094,9 @@ pub fn extract_keyframes_with_builder<F>(
 where
   F: FnMut(&Expr, &Metadata) -> CssOutput,
 {
+  // Mark `keyframes(...)` body processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
   // COMPAT: Babel computes the keyframe name by hashing `generate(expression).code`.
   // Our SWC port originally stringified the expression using swc_ecma_codegen which can
   // differ subtly (whitespace/formatting) from Babel, leading to different hashes.
@@ -3215,9 +3237,15 @@ fn build_css_internal(node: &Expr, meta: &Metadata) -> CssOutput {
     let mut normalized_node = binding_node;
     normalize_props_usage(&mut normalized_node);
 
-    let result = build_css_internal(&normalized_node, &binding.meta);
+    // Propagate the CSS-block context: binding.meta is captured at module-scope
+    // time (in_css_block=false), but we reached here via build_css, so any
+    // further import resolution is legitimate transform-time inlining.
+    let mut binding_meta = binding.meta.clone();
+    binding_meta.in_css_block |= meta.in_css_block;
+
+    let result = build_css_internal(&normalized_node, &binding_meta);
     assert_no_imported_css_variables(&Expr::Ident(identifier.clone()), meta, &binding, &result);
-    callback_if_file_included(meta, &binding.meta);
+    callback_if_file_included(meta, &binding_meta);
     return result;
   }
 
@@ -3333,6 +3361,10 @@ static INVALID_DYNAMIC_INDIRECT_SELECTOR_REGEX: Lazy<Regex> = Lazy::new(|| {
 });
 
 pub fn build_css(node: &Expr, meta: &Metadata) -> CssOutput {
+  // Defence-in-depth: anything reaching build_css is inside a Compiled CSS API
+  // call body, so all downstream resolve_import_binding calls are legitimate.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
   let output = build_css_internal(node, meta);
 
   let has_invalid_selector = output.css.iter().any(|item| {

--- a/crates/atlassian-swc-compiled-css/src/utils/resolve-binding.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/resolve-binding.rs
@@ -51,7 +51,10 @@ fn expression_references_import(
         }
 
         if let Some(node) = &binding.node {
-          return expression_references_import(node, &binding.meta, visited, evaluate_expression);
+          // Propagate CSS-block context across the binding boundary.
+          let mut next_meta = binding.meta.clone();
+          next_meta.in_css_block |= meta.in_css_block;
+          return expression_references_import(node, &next_meta, visited, evaluate_expression);
         }
       }
 
@@ -718,13 +721,18 @@ fn resolve_variable_binding(
   binding: PartialBindingWithMeta,
   path: &[String],
   default: &Option<Expr>,
+  caller_meta: &Metadata,
   evaluate_expression: EvaluateExpression,
 ) -> Option<PartialBindingWithMeta> {
   let Some(base) = binding.node.as_ref() else {
     return Some(binding);
   };
 
-  let mut pair = evaluate_expression(base, binding.meta.clone());
+  // Inherit caller's CSS-block context: binding.meta is captured at module-scope
+  // time; the variable may legitimately be resolved inside a CSS API call body.
+  let mut eval_meta = binding.meta.clone();
+  eval_meta.in_css_block |= caller_meta.in_css_block;
+  let mut pair = evaluate_expression(base, eval_meta);
   if std::env::var("STACK_DEBUG_BINDING").is_ok() || std::env::var("STACK_DEBUG_SHARED").is_ok() {
     eprintln!(
       "[resolve_binding] variable base expr_type={} path={:?}",
@@ -781,7 +789,12 @@ fn resolve_variable_binding(
     )
   ) {
     let mut visited = IndexSet::new();
-    if expression_references_import(base, &binding.meta, &mut visited, evaluate_expression) {
+    // Diagnostic-only walk to decide whether to clear `resolved.constant`.
+    // Must inherit caller's CSS-block context so the strict guard doesn't fire
+    // for legitimate inlining (e.g. `styled.div({ h: \`calc(${TOKEN}px)\` })`).
+    let mut diagnostic_meta = binding.meta.clone();
+    diagnostic_meta.in_css_block |= caller_meta.in_css_block;
+    if expression_references_import(base, &diagnostic_meta, &mut visited, evaluate_expression) {
       // Mirror Babel: treat import-derived string/template bindings as dynamic so they are not
       // eagerly inlined, but still preserve the node for consumers (e.g., styled tagged
       // templates) that need the original template literal to build CSS.
@@ -810,17 +823,42 @@ fn resolve_import_binding(
     return Some(binding);
   }
 
+  // CSS-block guard: import-boundary inlining is only valid inside a Compiled
+  // API call body (css/styled/cssMap/keyframes/<ClassNames>). A caller outside
+  // such a body silently expands the file's transform-dependency footprint.
+  if !meta.in_css_block && meta.state().opts.strict_css_block_guard.unwrap_or(false) {
+    panic!(
+      "Compiled SWC plugin: resolve_import_binding for source '{}' (kind={:?}) called \
+       outside a CSS block (file={:?}). Crossing import boundaries for value inlining \
+       must originate from a css(), styled.X(), keyframes(), cssMap() or <ClassNames> body.",
+      source,
+      kind,
+      meta.state().file().filename,
+    );
+  }
+
   let cached = load_or_parse_module(&meta, source)?;
 
+  let in_css_block = meta.in_css_block;
   let resolved = match kind {
     ImportBindingKind::Namespace => Some(binding),
     ImportBindingKind::Default => {
       let result = get_default_export(&cached.program)?;
-      Some(build_import_binding(binding, result, cached.state))
+      Some(build_import_binding(
+        binding,
+        result,
+        cached.state,
+        in_css_block,
+      ))
     }
     ImportBindingKind::Named(name) => {
       let result = get_named_export(&cached.program, name)?;
-      Some(build_import_binding(binding, result, cached.state))
+      Some(build_import_binding(
+        binding,
+        result,
+        cached.state,
+        in_css_block,
+      ))
     }
   }?;
 
@@ -831,8 +869,12 @@ fn build_import_binding(
   mut binding: PartialBindingWithMeta,
   traversed: TraverserResult<Expr>,
   state: Rc<RefCell<TransformState>>,
+  in_css_block: bool,
 ) -> PartialBindingWithMeta {
-  let metadata = Metadata::new(state).with_parent_span(Some(traversed.span));
+  let mut metadata = Metadata::new(state).with_parent_span(Some(traversed.span));
+  // Propagate the CSS-block context across the module boundary so the strict
+  // guard does not fire when the imported value is itself an alias / re-export.
+  metadata.in_css_block = in_css_block;
   binding.node = Some(traversed.node);
   binding.meta = metadata;
   binding
@@ -916,7 +958,7 @@ pub fn resolve_binding(
 
   match path_kind {
     Some(BindingPathKind::Variable { path, default }) => {
-      resolve_variable_binding(binding, &path, &default, evaluate_expression)
+      resolve_variable_binding(binding, &path, &default, &meta, evaluate_expression)
     }
     Some(BindingPathKind::Import { source, kind }) => {
       let imported = resolve_import_binding(binding, &source, &kind, meta);
@@ -1136,6 +1178,155 @@ mod tests {
     };
 
     assert_eq!(str_lit.value, "blue");
+  }
+
+  #[test]
+  fn strict_guard_disabled_by_default_allows_import_resolution() {
+    let dir = tempdir().expect("temp directory");
+    let entry_path = dir.path().join("entry.tsx");
+    fs::write(&entry_path, "").expect("write entry");
+
+    let module_path = dir.path().join("colors.ts");
+    fs::write(&module_path, "export const blue = 'blue';").expect("write module");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.path().to_path_buf()),
+        root: Some(dir.path().to_path_buf()),
+        loc_filename: None,
+      },
+    );
+
+    // Default: strict_css_block_guard is None / false.
+    let state = Rc::new(RefCell::new(TransformState::new(
+      file,
+      PluginOptions::default(),
+    )));
+    let meta = Metadata::new(state.clone());
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./colors".into(),
+        ImportBindingKind::Named("blue".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("blue", binding);
+
+    // Note: meta is NOT in a css block, but guard is disabled, so this must succeed.
+    let result =
+      resolve_binding("blue", meta, identity_evaluate as EvaluateExpression).expect("binding");
+
+    let Expr::Lit(Lit::Str(str_lit)) = result.node.expect("resolved literal") else {
+      panic!("expected string literal");
+    };
+
+    assert_eq!(str_lit.value, "blue");
+  }
+
+  #[test]
+  fn strict_guard_allows_import_resolution_inside_css_block() {
+    let dir = tempdir().expect("temp directory");
+    let entry_path = dir.path().join("entry.tsx");
+    fs::write(&entry_path, "").expect("write entry");
+
+    let module_path = dir.path().join("colors.ts");
+    fs::write(&module_path, "export const blue = 'blue';").expect("write module");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.path().to_path_buf()),
+        root: Some(dir.path().to_path_buf()),
+        loc_filename: None,
+      },
+    );
+
+    let mut options = PluginOptions::default();
+    options.strict_css_block_guard = Some(true);
+
+    let state = Rc::new(RefCell::new(TransformState::new(file, options)));
+    let meta = Metadata::new(state.clone()).enter_css_block();
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./colors".into(),
+        ImportBindingKind::Named("blue".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("blue", binding);
+
+    // Guard enabled, but we are inside a CSS block, so this must succeed.
+    let result =
+      resolve_binding("blue", meta, identity_evaluate as EvaluateExpression).expect("binding");
+
+    let Expr::Lit(Lit::Str(str_lit)) = result.node.expect("resolved literal") else {
+      panic!("expected string literal");
+    };
+
+    assert_eq!(str_lit.value, "blue");
+  }
+
+  #[test]
+  #[should_panic(expected = "outside a CSS block")]
+  fn strict_guard_panics_when_import_resolved_outside_css_block() {
+    let dir = tempdir().expect("temp directory");
+    let entry_path = dir.path().join("entry.tsx");
+    fs::write(&entry_path, "").expect("write entry");
+
+    let module_path = dir.path().join("colors.ts");
+    fs::write(&module_path, "export const blue = 'blue';").expect("write module");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.path().to_path_buf()),
+        root: Some(dir.path().to_path_buf()),
+        loc_filename: None,
+      },
+    );
+
+    let mut options = PluginOptions::default();
+    options.strict_css_block_guard = Some(true);
+
+    let state = Rc::new(RefCell::new(TransformState::new(file, options)));
+    // No `enter_css_block()` — this represents an unintended call site.
+    let meta = Metadata::new(state.clone());
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./colors".into(),
+        ImportBindingKind::Named("blue".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("blue", binding);
+
+    // Guard enabled, not in CSS block — must panic.
+    let _ = resolve_binding("blue", meta, identity_evaluate as EvaluateExpression);
   }
 
   #[test]

--- a/crates/atlassian-swc-compiled-css/src/utils/traverse-expression/traverse-identifier.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/traverse-expression/traverse-identifier.rs
@@ -17,7 +17,11 @@ pub fn traverse_identifier(
   {
     if binding.constant {
       if let Some(node) = binding.node.as_ref() {
-        let result = (evaluate_expression)(node, binding.meta.clone());
+        // Propagate CSS-block context so import resolution inside the binding's
+        // initializer (e.g. `\`url(${assetUrl})\``) is treated as legitimate.
+        let mut binding_meta = binding.meta.clone();
+        binding_meta.in_css_block |= meta.in_css_block;
+        let result = (evaluate_expression)(node, binding_meta);
         return create_result_pair(result.value, result.meta);
       }
     }

--- a/crates/node-bindings/src/plugin_compiled_css_in_js.rs
+++ b/crates/node-bindings/src/plugin_compiled_css_in_js.rs
@@ -62,6 +62,11 @@ pub struct CompiledCssInJsConfigPlugin {
   pub unsafe_skip_pattern: Option<String>,
   /// Browserslist environment (e.g. "development" or "production") for package.json "browserslist".
   pub browserslist_env: Option<String>,
+  /// When enabled, panic if `resolve_import_binding` is invoked outside a
+  /// Compiled CSS API call body (`css(...)`, `styled.X(...)`, `cssMap({...})`,
+  /// `keyframes(...)`, or `<ClassNames>`). Used to detect transform-time
+  /// inlining that silently expands the file's transform-dependency footprint.
+  pub strict_css_block_guard: Option<bool>,
 }
 
 #[napi(object)]
@@ -288,6 +293,7 @@ fn process_compiled_css_in_js(
         .browserslist_env
         .clone()
         .or_else(|| input.browserslist_env.clone()),
+      strict_css_block_guard: input.config.strict_css_block_guard,
     },
   );
 
@@ -612,6 +618,7 @@ fn config_to_plugin_options(
     flatten_multiple_selectors: Some(config.flatten_multiple_selectors),
     extract: Some(config.extract),
     browserslist_env: config.browserslist_env.clone(),
+    strict_css_block_guard: Some(config.strict_css_block_guard),
   }
 }
 


### PR DESCRIPTION
## Summary

Add a strict CSS-block guard that panics (when opt-in via `strict_css_block_guard: true`) if `resolve_import_binding` is called outside a Compiled CSS API call body — detecting any code path that silently crosses import boundaries for value inlining outside of `css()`/`styled.X()`/`cssMap()`/`keyframes()`/`<ClassNames>`.

## What was added

### In-CSS-block tracking
- New `in_css_block: bool` field on `Metadata`, preserved across all `with_*` helpers.
- `Metadata::enter_css_block()` marks the context as inside a CSS API body.
- Every Compiled API entry point (css-prop, css-map, styled, class-names, keyframes, and `build_css` as defence-in-depth) calls `enter_css_block()`.

### Strict guard in resolve_import_binding
- Panics with a descriptive message when `in_css_block=false` and `strict_css_block_guard=true`.
- `strict_css_block_guard` is plumbed through `PluginOptions`, `CompiledCssInJsConfig`, `CompiledCssInJsTransformConfig`, and the NAPI `CompiledCssInJsConfigPlugin` struct.

### Context propagation fixes (found by running against Confluence)

| Location | Fix |
|---|---|
| `generate_cache_for_css_map_with_builder` | Skip import bindings entirely — imported `cssMap` is banned, avoids false-positives for e.g. enum identifiers inside `xcss={cx(local.x, Enum.X !== Y && local.y)}` |
| `build_css_internal` identifier branch | Propagate `in_css_block` from caller meta into `binding.meta` before recursive `build_css_internal` |
| `traverse_identifier` | Propagate `in_css_block` when evaluating a binding's initializer node |
| `resolve_variable_binding` | Propagate `in_css_block` into both the evaluation pass and the diagnostic `expression_references_import` walk |
| `expression_references_import` | Propagate `in_css_block` in recursive binding-boundary traversal |

## Tests
Three unit tests added in `utils/resolve-binding.rs`:
- Guard disabled (default): import resolution succeeds outside CSS block.
- Guard enabled + inside CSS block: import resolution succeeds.
- Guard enabled + outside CSS block: panics with "outside a CSS block".

## Validation
Ran `--build-all confluence` (7093 bundles) against the AFM monorepo with `strict_css_block_guard: true` enabled:
- Before: multiple panics (`ResultsStates`, `FULL_PAGE_EDITOR_TOOLBAR_HEIGHT`, `cursorImg`, `GRADIENT_BACKGROUND_SUBTLEST_START`, ...)
- After: **panicked=0**; 7088 ok, 5 unrelated node-builtin resolution failures.

Relates to AFB-2000.