### PR TITLE
strict_css_block_guard and imported_binding_hop options

### DIFF
--- a/.changeset/rare-impalas-enjoy.md
+++ b/.changeset/rare-impalas-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@atlaspack/rust': minor
+---
+
+Add strict_css_block_guard and imported_binding_hop options to Compiled rust implementation

--- a/crates/atlassian-swc-compiled-css/src/class-names/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/class-names/index.rs
@@ -324,6 +324,10 @@ where
     return false;
   }
 
+  // Mark `<ClassNames>` body processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
+
   let runtime_helper = get_runtime_class_name_library(meta);
   let children_expr = ensure_children_function(element, meta);
   let (css_identifiers, style_identifiers) = collect_css_and_style_aliases(children_expr);

--- a/crates/atlassian-swc-compiled-css/src/config.rs
+++ b/crates/atlassian-swc-compiled-css/src/config.rs
@@ -1,3 +1,17 @@
+/// Action to take when a multi-file import hop is detected in Compiled CSS resolution.
+///
+/// Exposed to TypeScript as `"ban" | "log"` via NAPI's `string_enum`.
+#[cfg_attr(feature = "napi", napi_derive::napi(string_enum = "lowercase"))]
+#[cfg_attr(not(feature = "napi"), derive(Clone, Copy))]
+#[derive(Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ImportedBindingHop {
+  /// Panic immediately when a multi-file hop is detected.
+  Ban,
+  /// Emit a warning to stderr instead of panicking.
+  Log,
+}
+
 /// Partial configuration for CompiledCssInJs transform.
 /// All fields are optional and will use defaults if not specified.
 #[cfg_attr(feature = "napi", napi_derive::napi(object))]
@@ -119,6 +133,23 @@ pub struct CompiledCssInJsConfig {
   /// Defaults to `None`.
   ///
   pub browserslist_env: Option<String>,
+  ///
+  /// When enabled, panic if `resolve_import_binding` is invoked outside of a
+  /// Compiled CSS API call body (`css(...)`, `styled.X(...)`, `cssMap({...})`,
+  /// `keyframes(...)`, or `<ClassNames>`). Used to detect transform-time
+  /// inlining that silently expands the file's transform-dependency footprint.
+  ///
+  /// Defaults to `false`.
+  ///
+  pub strict_css_block_guard: Option<bool>,
+  ///
+  /// Multi-file import hop detection mode (`"ban"` = panic, `"log"` = warn,
+  /// unset = disabled).
+  ///
+  /// An imported binding that is itself re-exported from a third module
+  /// requires at least two cross-module resolutions, silently expanding the
+  /// transform-dependency chain.
+  pub imported_binding_hop: Option<ImportedBindingHop>,
 }
 
 /// Full configuration for CompiledCssInJs transform.
@@ -239,6 +270,15 @@ pub struct CompiledCssInJsTransformConfig {
   /// Browserslist environment (e.g. "development" or "production") for package.json "browserslist".
   ///
   pub browserslist_env: Option<String>,
+  ///
+  /// When enabled, panic if a value is inlined from outside a CSS API call body.
+  ///
+  /// Defaults to `false`.
+  ///
+  pub strict_css_block_guard: bool,
+  /// Multi-file import hop detection mode
+  /// Defaults to `None`
+  pub imported_binding_hop: Option<ImportedBindingHop>,
 }
 
 impl Default for CompiledCssInJsTransformConfig {
@@ -263,6 +303,8 @@ impl Default for CompiledCssInJsTransformConfig {
       unsafe_use_safe_assets: false,
       unsafe_skip_pattern: None,
       browserslist_env: None,
+      strict_css_block_guard: false,
+      imported_binding_hop: None,
     }
   }
 }
@@ -300,6 +342,12 @@ impl From<CompiledCssInJsConfig> for CompiledCssInJsTransformConfig {
         .unwrap_or(defaults.unsafe_use_safe_assets),
       unsafe_skip_pattern: partial.unsafe_skip_pattern.or(defaults.unsafe_skip_pattern),
       browserslist_env: partial.browserslist_env.or(defaults.browserslist_env),
+      strict_css_block_guard: partial
+        .strict_css_block_guard
+        .unwrap_or(defaults.strict_css_block_guard),
+      imported_binding_hop: partial
+        .imported_binding_hop
+        .or(defaults.imported_binding_hop),
     }
   }
 }

--- a/crates/atlassian-swc-compiled-css/src/css-map/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/css-map/index.rs
@@ -32,6 +32,9 @@ pub fn visit_css_map_path_with_builder<'a, F>(
 where
   F: FnMut(&Expr, &Metadata) -> CssOutput,
 {
+  // Mark `cssMap({...})` body processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
   match usage {
     CssMapUsage::TaggedTemplate(tagged_tpl) => {
       report_css_map_error_with_hints(meta, tagged_tpl.span, ErrorMessages::NoTaggedTemplate);

--- a/crates/atlassian-swc-compiled-css/src/css-prop/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/css-prop/index.rs
@@ -492,4 +492,151 @@ mod tests {
 
     assert!(css_attr, "css attribute should remain when disabled");
   }
+
+  fn create_strict_metadata(
+    entry_path: &std::path::Path,
+    dir: &std::path::Path,
+  ) -> (
+    Metadata,
+    Rc<RefCell<crate::types::TransformState>>,
+    Lrc<SourceMap>,
+  ) {
+    use crate::types::{TransformFile, TransformFileOptions, TransformState};
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm.clone(),
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.to_path_buf()),
+        root: Some(dir.to_path_buf()),
+        loc_filename: None,
+      },
+    );
+    let mut opts = PluginOptions::default();
+    opts.strict_css_block_guard = Some(true);
+    let state = Rc::new(RefCell::new(TransformState::new(file, opts)));
+    // Register `css` as the Compiled CSS import alias.
+    state
+      .borrow_mut()
+      .imported_compiled_imports
+      .css
+      .replace("css".into());
+    let meta = Metadata::new(state.clone());
+    (meta, state, cm)
+  }
+
+  /// Parse a JSX expression using a pre-existing `SourceMap` so spans are
+  /// compatible with a `Metadata` that was built from the same `SourceMap`.
+  fn parse_jsx_with_cm(code: &str, cm: Lrc<SourceMap>) -> Expr {
+    use swc_core::common::FileName;
+    let fm = cm.new_source_file(FileName::Custom("expr.jsx".into()).into(), code.to_string());
+    let lexer = swc_core::ecma::parser::lexer::Lexer::new(
+      swc_core::ecma::parser::Syntax::Es(swc_core::ecma::parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+      }),
+      Default::default(),
+      swc_core::ecma::parser::StringInput::from(&*fm),
+      None,
+    );
+    let mut parser = swc_core::ecma::parser::Parser::new_from(lexer);
+    *parser.parse_expr().expect("parse JSX expression")
+  }
+
+  fn setup_import_binding(dir: &std::path::Path) -> (Metadata, Lrc<SourceMap>) {
+    use crate::utils_types::{
+      BindingPath, BindingSource, ImportBindingKind, PartialBindingWithMeta,
+    };
+    use swc_core::common::DUMMY_SP;
+
+    let entry_path = dir.join("entry.tsx");
+    std::fs::write(&entry_path, "").unwrap();
+    std::fs::write(dir.join("binding.ts"), "export const red = 'red';").unwrap();
+
+    let (meta, _state, cm) = create_strict_metadata(&entry_path, dir);
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./binding".into(),
+        ImportBindingKind::Named("red".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("red", binding);
+    (meta, cm)
+  }
+
+  #[test]
+  #[should_panic(expected = "outside a CSS block")]
+  fn panics_if_imported_without_css_wrap() {
+    // `css={{ color: importedValue }}` — raw object, no css() wrapper. Must panic.
+    use crate::utils_css_builders::build_css;
+    use swc_core::ecma::ast::{IdentName, KeyValueProp, ObjectLit, Prop, PropName, PropOrSpread};
+    use tempfile::tempdir;
+
+    let dir = tempdir().expect("temp dir");
+    let (meta, cm) = setup_import_binding(dir.path());
+
+    let red_ident = parse_jsx_with_cm("red", cm);
+    let object = Expr::Object(ObjectLit {
+      span: swc_core::common::DUMMY_SP,
+      props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+        key: PropName::Ident(IdentName {
+          span: swc_core::common::DUMMY_SP,
+          sym: "color".into(),
+        }),
+        value: Box::new(red_ident),
+      })))],
+    });
+
+    crate::test_utils::with_globals(|| {
+      build_css(&object, &meta);
+    });
+  }
+
+  #[test]
+  fn works_if_imported_with_css_wrap() {
+    // `css({ color: importedValue })` — wrapped in css() Compiled API. Must NOT panic.
+    use crate::utils_css_builders::build_css;
+    use swc_core::ecma::ast::{
+      CallExpr, Callee, ExprOrSpread, IdentName, KeyValueProp, ObjectLit, Prop, PropName,
+      PropOrSpread,
+    };
+    use tempfile::tempdir;
+
+    let dir = tempdir().expect("temp dir");
+    let (meta, cm) = setup_import_binding(dir.path());
+
+    let red_ident = parse_jsx_with_cm("red", cm.clone());
+    let inner_object = Expr::Object(ObjectLit {
+      span: swc_core::common::DUMMY_SP,
+      props: vec![PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+        key: PropName::Ident(IdentName {
+          span: swc_core::common::DUMMY_SP,
+          sym: "color".into(),
+        }),
+        value: Box::new(red_ident),
+      })))],
+    });
+    let css_ident = parse_jsx_with_cm("css", cm);
+    let call = Expr::Call(CallExpr {
+      span: swc_core::common::DUMMY_SP,
+      ctxt: swc_core::common::SyntaxContext::empty(),
+      callee: Callee::Expr(Box::new(css_ident)),
+      args: vec![ExprOrSpread {
+        spread: None,
+        expr: Box::new(inner_object),
+      }],
+      type_args: None,
+    });
+
+    crate::test_utils::with_globals(|| {
+      build_css(&call, &meta);
+    });
+  }
 }

--- a/crates/atlassian-swc-compiled-css/src/postcss/postcss_pipeline.rs
+++ b/crates/atlassian-swc-compiled-css/src/postcss/postcss_pipeline.rs
@@ -3188,7 +3188,6 @@ fn wrap_bare_declarations_plugin(options: TransformCssOptions) -> pc::BuiltPlugi
 mod tests {
   use super::collapse_repeated_class_descendants;
   use crate::postcss::transform::{TransformCssOptions, transform_css};
-  use crate::utils_hash::hash;
   use pretty_assertions::assert_eq;
 
   #[test]

--- a/crates/atlassian-swc-compiled-css/src/styled/index.rs
+++ b/crates/atlassian-swc-compiled-css/src/styled/index.rs
@@ -267,6 +267,10 @@ where
     return result;
   };
 
+  // Mark `styled.X({...})` / `` styled.X`...` `` body as inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
+
   if let Expr::TaggedTpl(tagged) = node {
     if has_invalid_expression(tagged) {
       panic_invalid_expression(tagged.span, meta);

--- a/crates/atlassian-swc-compiled-css/src/types.rs
+++ b/crates/atlassian-swc-compiled-css/src/types.rs
@@ -159,6 +159,9 @@ pub struct PluginOptions {
   /// Browserslist environment (e.g. "development" or "production") for config with
   /// "browserslist": { "development": [...], "production": [...] }.
   pub browserslist_env: Option<String>,
+  pub strict_css_block_guard: Option<bool>,
+  /// Multi-file import hop detection mode (`Ban` = panic, `Log` = warn, `None` = disabled).
+  pub imported_binding_hop: Option<crate::config::ImportedBindingHop>,
 }
 
 impl Default for PluginOptions {
@@ -183,6 +186,8 @@ impl Default for PluginOptions {
       flatten_multiple_selectors: None,
       extract: None,
       browserslist_env: None,
+      strict_css_block_guard: None,
+      imported_binding_hop: None,
     }
   }
 }
@@ -209,6 +214,8 @@ impl From<&crate::config::CompiledCssInJsConfig> for PluginOptions {
       flatten_multiple_selectors: config.flatten_multiple_selectors,
       extract: config.extract,
       browserslist_env: config.browserslist_env.clone(),
+      strict_css_block_guard: config.strict_css_block_guard,
+      imported_binding_hop: config.imported_binding_hop,
     }
   }
 }
@@ -652,6 +659,16 @@ pub struct Metadata {
   pub parent_scope: SharedScope,
   pub own_scope: Option<SharedScope>,
   pub parent_expr: Option<Box<Expr>>,
+  /// True when the current resolution chain is happening inside the body of a
+  /// Compiled CSS API call. Set by entry-point wiring (`enter_css_block`) and
+  /// preserved across all `with_*` helpers and binding lookups. Used by the
+  /// strict `resolve_import_binding` guard.
+  pub in_css_block: bool,
+  /// True when we are already inside a `resolve_import_binding` call. Used to
+  /// detect multi-file hops: an imported value that is itself re-imported from
+  /// another module requires a second cross-file resolution, which expands the
+  /// transform-dependency chain beyond what is permitted.
+  pub resolving_import: bool,
 }
 
 impl Metadata {
@@ -668,6 +685,28 @@ impl Metadata {
       parent_scope,
       own_scope: None,
       parent_expr: None,
+      in_css_block: false,
+      resolving_import: false,
+    }
+  }
+
+  /// Mark this metadata as being inside a Compiled CSS API call body. All
+  /// downstream `resolve_import_binding` calls reached from this metadata are
+  /// considered legitimate transform-time inlinings.
+  pub fn enter_css_block(&self) -> Self {
+    Self {
+      in_css_block: true,
+      ..self.clone()
+    }
+  }
+
+  /// Mark this metadata as being inside an active `resolve_import_binding`
+  /// call. Any further call to `resolve_import_binding` while this flag is
+  /// set constitutes a multi-file hop.
+  pub fn enter_import_resolution(&self) -> Self {
+    Self {
+      resolving_import: true,
+      ..self.clone()
     }
   }
 

--- a/crates/atlassian-swc-compiled-css/src/utils/css-builders.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/css-builders.rs
@@ -5349,7 +5349,7 @@ mod tests {
     // and don't participate in runtime class-name toggling. Wrapping them in Logical
     // would cause transform_css to receive raw @keyframes CSS as a declaration,
     // producing empty sheets and a runtime error.
-    let meta = create_metadata();
+    let _meta = create_metadata();
 
     // Simulate the output of processing css({ '@keyframes': {...}, svg: {...} })
     // which produces a Sheet + Unconditional pair

--- a/crates/atlassian-swc-compiled-css/src/utils/css-builders.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/css-builders.rs
@@ -811,6 +811,23 @@ where
     }
   }
 
+  // Imported cssMap declarations are banned by Compiled; every cssMap reference
+  // must be a local `const X = cssMap({...})`.
+  let is_local_variable = {
+    let own_hit = meta
+      .own_scope()
+      .and_then(|scope| scope.borrow().get(name.as_str()).cloned());
+    let scoped = own_hit.or_else(|| meta.parent_scope().borrow().get(name.as_str()).cloned());
+    matches!(
+      scoped.as_ref().map(|b| &b.source),
+      Some(BindingSource::Module),
+    )
+  };
+  if !is_local_variable {
+    meta.state_mut().ignore_member_expressions.insert(name);
+    return false;
+  }
+
   let resolved = resolve_binding(name.as_str(), meta.clone(), evaluate_expression);
 
   if let Some(PartialBindingWithMeta {
@@ -2075,6 +2092,9 @@ pub fn extract_keyframes_with_builder<F>(
 where
   F: FnMut(&Expr, &Metadata) -> CssOutput,
 {
+  // Mark `keyframes(...)` body processing as being inside a CSS block.
+  let meta_owned = meta.enter_css_block();
+  let meta = &meta_owned;
   // COMPAT: Babel computes the keyframe name by hashing `generate(expression).code`.
   // Our SWC port originally stringified the expression using swc_ecma_codegen which can
   // differ subtly (whitespace/formatting) from Babel, leading to different hashes.
@@ -3215,9 +3235,13 @@ fn build_css_internal(node: &Expr, meta: &Metadata) -> CssOutput {
     let mut normalized_node = binding_node;
     normalize_props_usage(&mut normalized_node);
 
-    let result = build_css_internal(&normalized_node, &binding.meta);
+    // Inherit caller's CSS-block context (binding.meta is module-scope).
+    let mut binding_meta = binding.meta.clone();
+    binding_meta.in_css_block |= meta.in_css_block;
+
+    let result = build_css_internal(&normalized_node, &binding_meta);
     assert_no_imported_css_variables(&Expr::Ident(identifier.clone()), meta, &binding, &result);
-    callback_if_file_included(meta, &binding.meta);
+    callback_if_file_included(meta, &binding_meta);
     return result;
   }
 
@@ -3293,7 +3317,10 @@ fn build_css_internal(node: &Expr, meta: &Metadata) -> CssOutput {
     if is_compiled_css_call_expression(node, &state) {
       drop(state);
       if let Some(first) = call.args.first() {
-        return build_css_internal(&first.expr, meta);
+        // css({...}) is a Compiled API call body — enter the CSS block context
+        // so any import resolution inside the arguments is treated as legitimate.
+        let css_block_meta = meta.enter_css_block();
+        return build_css_internal(&first.expr, &css_block_meta);
       }
       return CssOutput::new();
     }

--- a/crates/atlassian-swc-compiled-css/src/utils/resolve-binding.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/resolve-binding.rs
@@ -51,7 +51,10 @@ fn expression_references_import(
         }
 
         if let Some(node) = &binding.node {
-          return expression_references_import(node, &binding.meta, visited, evaluate_expression);
+          // Propagate CSS-block context across the binding boundary.
+          let mut next_meta = binding.meta.clone();
+          next_meta.in_css_block |= meta.in_css_block;
+          return expression_references_import(node, &next_meta, visited, evaluate_expression);
         }
       }
 
@@ -718,13 +721,17 @@ fn resolve_variable_binding(
   binding: PartialBindingWithMeta,
   path: &[String],
   default: &Option<Expr>,
+  caller_meta: &Metadata,
   evaluate_expression: EvaluateExpression,
 ) -> Option<PartialBindingWithMeta> {
   let Some(base) = binding.node.as_ref() else {
     return Some(binding);
   };
 
-  let mut pair = evaluate_expression(base, binding.meta.clone());
+  // Inherit caller's CSS-block context (binding.meta is module-scope).
+  let mut eval_meta = binding.meta.clone();
+  eval_meta.in_css_block |= caller_meta.in_css_block;
+  let mut pair = evaluate_expression(base, eval_meta);
   if std::env::var("STACK_DEBUG_BINDING").is_ok() || std::env::var("STACK_DEBUG_SHARED").is_ok() {
     eprintln!(
       "[resolve_binding] variable base expr_type={} path={:?}",
@@ -781,7 +788,11 @@ fn resolve_variable_binding(
     )
   ) {
     let mut visited = IndexSet::new();
-    if expression_references_import(base, &binding.meta, &mut visited, evaluate_expression) {
+    // Diagnostic walk for `resolved.constant`; inherits caller's CSS-block
+    // context so the strict guard doesn't fire on legitimate inlining.
+    let mut diagnostic_meta = binding.meta.clone();
+    diagnostic_meta.in_css_block |= caller_meta.in_css_block;
+    if expression_references_import(base, &diagnostic_meta, &mut visited, evaluate_expression) {
       // Mirror Babel: treat import-derived string/template bindings as dynamic so they are not
       // eagerly inlined, but still preserve the node for consumers (e.g., styled tagged
       // templates) that need the original template literal to build CSS.
@@ -810,17 +821,74 @@ fn resolve_import_binding(
     return Some(binding);
   }
 
+  // CSS-block guard: import-boundary inlining is only valid inside a Compiled
+  // API call body (css/styled/cssMap/keyframes/<ClassNames>). A caller outside
+  // such a body silently expands the file's transform-dependency footprint.
+  if !meta.in_css_block && meta.state().opts.strict_css_block_guard.unwrap_or(false) {
+    panic!(
+      "Compiled SWC plugin: resolve_import_binding for source '{}' (kind={:?}) called \
+       outside a CSS block (file={:?}). Crossing import boundaries for value inlining \
+       must originate from a css(), styled.X(), keyframes(), cssMap() or <ClassNames> body.",
+      source,
+      kind,
+      meta.state().file().filename,
+    );
+  }
+
+  // Multi-file hop guard: if we are already resolving an import, this is a
+  // second cross-module resolution (e.g. a re-export). Imported values used in
+  // Compiled CSS API calls must be defined in the imported module, not
+  // re-exported from a third file.
+  if meta.resolving_import {
+    let file = meta.state().file().filename.clone();
+    match meta.state().opts.imported_binding_hop {
+      Some(crate::config::ImportedBindingHop::Ban) => {
+        panic!(
+          "Compiled SWC plugin: resolve_import_binding for source '{}' (kind={:?}) called \
+           while already resolving an import (file={:?}). Multi-file hops are banned — \
+           imported values must be defined in the directly-imported module, not re-exported \
+           from a third file.",
+          source, kind, file,
+        );
+      }
+      Some(crate::config::ImportedBindingHop::Log) => {
+        eprintln!(
+          "Compiled SWC plugin [WARN]: multi-file import hop detected — source='{}' \
+           kind={:?} file={:?}",
+          source, kind, file,
+        );
+      }
+      None => {}
+    }
+  }
+
+  // Mark subsequent resolutions as being inside an import-resolution chain.
+  let meta = meta.enter_import_resolution();
+
   let cached = load_or_parse_module(&meta, source)?;
 
+  let in_css_block = meta.in_css_block;
   let resolved = match kind {
     ImportBindingKind::Namespace => Some(binding),
     ImportBindingKind::Default => {
       let result = get_default_export(&cached.program)?;
-      Some(build_import_binding(binding, result, cached.state))
+      Some(build_import_binding(
+        binding,
+        result,
+        cached.state,
+        in_css_block,
+        meta.resolving_import,
+      ))
     }
     ImportBindingKind::Named(name) => {
       let result = get_named_export(&cached.program, name)?;
-      Some(build_import_binding(binding, result, cached.state))
+      Some(build_import_binding(
+        binding,
+        result,
+        cached.state,
+        in_css_block,
+        meta.resolving_import,
+      ))
     }
   }?;
 
@@ -831,8 +899,14 @@ fn build_import_binding(
   mut binding: PartialBindingWithMeta,
   traversed: TraverserResult<Expr>,
   state: Rc<RefCell<TransformState>>,
+  in_css_block: bool,
+  resolving_import: bool,
 ) -> PartialBindingWithMeta {
-  let metadata = Metadata::new(state).with_parent_span(Some(traversed.span));
+  let mut metadata = Metadata::new(state).with_parent_span(Some(traversed.span));
+  // Propagate context flags across the module boundary so downstream guards
+  // have accurate state when the imported value is further resolved.
+  metadata.in_css_block = in_css_block;
+  metadata.resolving_import = resolving_import;
   binding.node = Some(traversed.node);
   binding.meta = metadata;
   binding
@@ -916,7 +990,7 @@ pub fn resolve_binding(
 
   match path_kind {
     Some(BindingPathKind::Variable { path, default }) => {
-      resolve_variable_binding(binding, &path, &default, evaluate_expression)
+      resolve_variable_binding(binding, &path, &default, &meta, evaluate_expression)
     }
     Some(BindingPathKind::Import { source, kind }) => {
       let imported = resolve_import_binding(binding, &source, &kind, meta);
@@ -1136,6 +1210,240 @@ mod tests {
     };
 
     assert_eq!(str_lit.value, "blue");
+  }
+
+  #[test]
+  fn strict_guard_disabled_by_default_allows_import_resolution() {
+    let dir = tempdir().expect("temp directory");
+    let entry_path = dir.path().join("entry.tsx");
+    fs::write(&entry_path, "").expect("write entry");
+
+    let module_path = dir.path().join("colors.ts");
+    fs::write(&module_path, "export const blue = 'blue';").expect("write module");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.path().to_path_buf()),
+        root: Some(dir.path().to_path_buf()),
+        loc_filename: None,
+      },
+    );
+
+    let state = Rc::new(RefCell::new(TransformState::new(
+      file,
+      PluginOptions::default(),
+    )));
+    let meta = Metadata::new(state.clone());
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./colors".into(),
+        ImportBindingKind::Named("blue".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("blue", binding);
+
+    let result =
+      resolve_binding("blue", meta, identity_evaluate as EvaluateExpression).expect("binding");
+
+    let Expr::Lit(Lit::Str(str_lit)) = result.node.expect("resolved literal") else {
+      panic!("expected string literal");
+    };
+
+    assert_eq!(str_lit.value, "blue");
+  }
+
+  #[test]
+  fn strict_guard_allows_import_resolution_inside_css_block() {
+    let dir = tempdir().expect("temp directory");
+    let entry_path = dir.path().join("entry.tsx");
+    fs::write(&entry_path, "").expect("write entry");
+
+    let module_path = dir.path().join("colors.ts");
+    fs::write(&module_path, "export const blue = 'blue';").expect("write module");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.path().to_path_buf()),
+        root: Some(dir.path().to_path_buf()),
+        loc_filename: None,
+      },
+    );
+
+    let mut options = PluginOptions::default();
+    options.strict_css_block_guard = Some(true);
+
+    let state = Rc::new(RefCell::new(TransformState::new(file, options)));
+    let meta = Metadata::new(state.clone()).enter_css_block();
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./colors".into(),
+        ImportBindingKind::Named("blue".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("blue", binding);
+
+    let result =
+      resolve_binding("blue", meta, identity_evaluate as EvaluateExpression).expect("binding");
+
+    let Expr::Lit(Lit::Str(str_lit)) = result.node.expect("resolved literal") else {
+      panic!("expected string literal");
+    };
+
+    assert_eq!(str_lit.value, "blue");
+  }
+
+  #[test]
+  #[should_panic(expected = "outside a CSS block")]
+  fn strict_guard_panics_when_import_resolved_outside_css_block() {
+    let dir = tempdir().expect("temp directory");
+    let entry_path = dir.path().join("entry.tsx");
+    fs::write(&entry_path, "").expect("write entry");
+
+    let module_path = dir.path().join("colors.ts");
+    fs::write(&module_path, "export const blue = 'blue';").expect("write module");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.path().to_path_buf()),
+        root: Some(dir.path().to_path_buf()),
+        loc_filename: None,
+      },
+    );
+
+    let mut options = PluginOptions::default();
+    options.strict_css_block_guard = Some(true);
+
+    let state = Rc::new(RefCell::new(TransformState::new(file, options)));
+    // No `enter_css_block()` — this represents an unintended call site.
+    let meta = Metadata::new(state.clone());
+
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./colors".into(),
+        ImportBindingKind::Named("blue".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("blue", binding);
+
+    let _ = resolve_binding("blue", meta, identity_evaluate as EvaluateExpression);
+  }
+
+  fn create_hop_metadata(
+    dir: &std::path::Path,
+    hop_mode: Option<crate::config::ImportedBindingHop>,
+  ) -> (Metadata, Rc<RefCell<crate::types::TransformState>>) {
+    let entry_path = dir.join("entry.tsx");
+    std::fs::write(&entry_path, "").expect("write entry");
+    // Intermediate module that re-exports from a third file.
+    let intermediate_path = dir.join("intermediate.ts");
+    std::fs::write(&intermediate_path, "export { RED } from './source';")
+      .expect("write intermediate");
+    // Source module with the actual value.
+    let source_path = dir.join("source.ts");
+    std::fs::write(&source_path, "export const RED = 'red';").expect("write source");
+
+    let cm: Lrc<SourceMap> = Default::default();
+    let file = TransformFile::transform_compiled_with_options(
+      cm,
+      Vec::new(),
+      TransformFileOptions {
+        filename: Some(entry_path.to_string_lossy().into_owned()),
+        cwd: Some(dir.to_path_buf()),
+        root: Some(dir.to_path_buf()),
+        loc_filename: None,
+      },
+    );
+    let mut opts = PluginOptions::default();
+    opts.imported_binding_hop = hop_mode;
+    // Ensure we're inside a CSS block so the css-block guard doesn't interfere.
+    let state = Rc::new(RefCell::new(TransformState::new(file, opts)));
+    let mut meta = Metadata::new(state.clone()).enter_css_block();
+
+    // Simulate `import { RED } from './intermediate'` in the entry module.
+    let binding = PartialBindingWithMeta::new(
+      None,
+      Some(BindingPath::import(
+        Some(DUMMY_SP),
+        "./intermediate".into(),
+        ImportBindingKind::Named("RED".into()),
+      )),
+      true,
+      meta.clone(),
+      BindingSource::Import,
+    );
+    meta.insert_parent_binding("RED", binding);
+    (meta, state)
+  }
+
+  /// Resolve `RED` through intermediate.ts (a re-export) and then evaluate
+  /// the returned ident to trigger the second hop into source.ts.
+  fn resolve_and_evaluate_red(meta: Metadata) -> Option<PartialBindingWithMeta> {
+    let result = resolve_binding(
+      "RED",
+      meta,
+      utils_evaluate_expression::evaluate_expression as EvaluateExpression,
+    )?;
+    let node = result.node.as_ref()?;
+    // Evaluating the returned ident triggers resolve_binding("RED") in
+    // intermediate.ts's scope, which calls resolve_import_binding for ./source.
+    // This is the second hop that the guard must catch when ban=true.
+    let _ = utils_evaluate_expression::evaluate_expression(node, result.meta.clone());
+    Some(result)
+  }
+
+  #[test]
+  fn hop_guard_disabled_by_default_allows_reexport() {
+    let dir = tempdir().expect("temp dir");
+    let (meta, _state) = create_hop_metadata(dir.path(), None);
+    assert!(resolve_and_evaluate_red(meta).is_some());
+  }
+
+  #[test]
+  #[should_panic(expected = "Multi-file hops are banned")]
+  fn ban_hop_guard_panics_on_reexport() {
+    let dir = tempdir().expect("temp dir");
+    let (meta, _state) =
+      create_hop_metadata(dir.path(), Some(crate::config::ImportedBindingHop::Ban));
+    // Evaluating triggers the second hop: intermediate.ts -> source.ts.
+    let _ = resolve_and_evaluate_red(meta);
+  }
+
+  #[test]
+  fn log_hop_guard_does_not_panic_on_reexport() {
+    let dir = tempdir().expect("temp dir");
+    let (meta, _state) =
+      create_hop_metadata(dir.path(), Some(crate::config::ImportedBindingHop::Log));
+    // log only: must warn to stderr but NOT panic.
+    assert!(resolve_and_evaluate_red(meta).is_some());
   }
 
   #[test]

--- a/crates/atlassian-swc-compiled-css/src/utils/resolve-binding.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/resolve-binding.rs
@@ -1386,7 +1386,7 @@ mod tests {
     opts.imported_binding_hop = hop_mode;
     // Ensure we're inside a CSS block so the css-block guard doesn't interfere.
     let state = Rc::new(RefCell::new(TransformState::new(file, opts)));
-    let mut meta = Metadata::new(state.clone()).enter_css_block();
+    let meta = Metadata::new(state.clone()).enter_css_block();
 
     // Simulate `import { RED } from './intermediate'` in the entry module.
     let binding = PartialBindingWithMeta::new(

--- a/crates/atlassian-swc-compiled-css/src/utils/traverse-expression/traverse-identifier.rs
+++ b/crates/atlassian-swc-compiled-css/src/utils/traverse-expression/traverse-identifier.rs
@@ -17,7 +17,11 @@ pub fn traverse_identifier(
   {
     if binding.constant {
       if let Some(node) = binding.node.as_ref() {
-        let result = (evaluate_expression)(node, binding.meta.clone());
+        // Propagate CSS-block context so import resolution inside the binding's
+        // initializer (e.g. `\`url(${assetUrl})\``) is treated as legitimate.
+        let mut binding_meta = binding.meta.clone();
+        binding_meta.in_css_block |= meta.in_css_block;
+        let result = (evaluate_expression)(node, binding_meta);
         return create_result_pair(result.value, result.meta);
       }
     }

--- a/crates/node-bindings/src/plugin_compiled_css_in_js.rs
+++ b/crates/node-bindings/src/plugin_compiled_css_in_js.rs
@@ -655,6 +655,8 @@ mod tests {
         ssr: Some(true),
         sort_shorthand: Some(true),
         browserslist_env: None,
+        strict_css_block_guard: None,
+        imported_binding_hop: None,
       },
     }
   }

--- a/crates/node-bindings/src/plugin_compiled_css_in_js.rs
+++ b/crates/node-bindings/src/plugin_compiled_css_in_js.rs
@@ -62,6 +62,9 @@ pub struct CompiledCssInJsConfigPlugin {
   pub unsafe_skip_pattern: Option<String>,
   /// Browserslist environment (e.g. "development" or "production") for package.json "browserslist".
   pub browserslist_env: Option<String>,
+  pub strict_css_block_guard: Option<bool>,
+  /// Multi-file import hop detection: `"ban"` = panic, `"log"` = warn.
+  pub imported_binding_hop: Option<atlassian_swc_compiled_css::config::ImportedBindingHop>,
 }
 
 #[napi(object)]
@@ -288,6 +291,8 @@ fn process_compiled_css_in_js(
         .browserslist_env
         .clone()
         .or_else(|| input.browserslist_env.clone()),
+      strict_css_block_guard: input.config.strict_css_block_guard,
+      imported_binding_hop: input.config.imported_binding_hop,
     },
   );
 
@@ -612,6 +617,8 @@ fn config_to_plugin_options(
     flatten_multiple_selectors: Some(config.flatten_multiple_selectors),
     extract: Some(config.extract),
     browserslist_env: config.browserslist_env.clone(),
+    strict_css_block_guard: Some(config.strict_css_block_guard),
+    imported_binding_hop: config.imported_binding_hop,
   }
 }
 

--- a/packages/core/rust/index.js
+++ b/packages/core/rust/index.js
@@ -342,6 +342,7 @@ const {
   hashBuffer,
   hashCode,
   hashString,
+  ImportedBindingHop,
   initializeMonitoring,
   initTracingSubscriber,
   isSafeFromJs,
@@ -392,6 +393,7 @@ module.exports.Hash = Hash
 module.exports.hashBuffer = hashBuffer
 module.exports.hashCode = hashCode
 module.exports.hashString = hashString
+module.exports.ImportedBindingHop = ImportedBindingHop
 module.exports.initializeMonitoring = initializeMonitoring
 module.exports.initTracingSubscriber = initTracingSubscriber
 module.exports.isSafeFromJs = isSafeFromJs


### PR DESCRIPTION
<!-- Provide a summary of your changes in the title field above -->

## Motivation

We want to introduce some more strict checks into compiled. This will ban certain non-performant patterns and allow us to fully remove patterns safely.

## Changes

- strict_css_block_guard: requires all css blocks to be wrapped by a compiled helper (like `css` or `cssMap`)
- imported_binding_hop: bans more than 1 hop when using bindings from an import. This helps performance significantly by reducing the amount of assets we need to consider "changed"

## Checklist

- [x] Existing or new tests cover this change
- [x] There is a changeset for this change, or one is not required
- [x] Added documentation for any new features to the `docs/` folder

<!-- If this change does not require a changeset, uncomment the tag and explain why -->
<!-- [no-changeset]: -->
